### PR TITLE
Fix supabase link in CI by passing password via -p flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Push migrations and config to Supabase
         run: |
-          npx supabase link --project-ref ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
+          npx supabase link --project-ref ${{ secrets.SUPABASE_PROD_PROJECT_REF }} -p "$SUPABASE_DB_PASSWORD"
           npx supabase db push
           npx supabase config push
         env:


### PR DESCRIPTION
## Summary
- Fix `supabase link` failing in CI due to missing keyring service (`org.freedesktop.secrets`)
- Pass DB password directly via `-p` flag instead of relying on env var + keyring

## Test plan
- [ ] Deploy job succeeds on merge to main (migrations + config push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)