### PR TITLE
Add Supabase CLI setup to deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
       - name: Push migrations to Supabase
         run: |
           supabase link --project-ref ${{ secrets.SUPABASE_PROD_PROJECT_REF }}


### PR DESCRIPTION
Fix: deploy job missing CLI after npm supabase removal