### PR TITLE
Hotfix: enable promotion codes on Stripe Checkout

### DIFF
--- a/src/app/api/checkout/products/create/route.ts
+++ b/src/app/api/checkout/products/create/route.ts
@@ -252,6 +252,12 @@ export async function POST(request: Request) {
     // parent's app locale. Falls back to 'auto' (browser Accept-Language) for
     // locales Stripe doesn't support — e.g. Klingon.
     locale: stripeCheckoutLocale(profile.locale),
+    // Show the "Add promotion code" field. Codes themselves are created and
+    // managed in the Stripe dashboard (per mode — test and live separately);
+    // nothing in our DB models them. With Adaptive Pricing, percent-off
+    // coupons convert cleanly; amount_off coupons are currency-bound, so
+    // prefer percent-off when creating codes.
+    allow_promotion_codes: true,
     expires_at: expiresAt,
     metadata,
     success_url: successUrl,

--- a/tests/integration/api/checkout-products-create.test.ts
+++ b/tests/integration/api/checkout-products-create.test.ts
@@ -432,6 +432,9 @@ describe("POST /api/checkout/products/create", () => {
     expect(params.customer).toBe(STRIPE_CUSTOMER_ID);
     // Adaptive Pricing presents the customer's local currency; we settle EUR.
     expect(params.adaptive_pricing).toEqual({ enabled: true });
+    // Checkout shows the "Add promotion code" field (codes live in the Stripe
+    // dashboard).
+    expect(params.allow_promotion_codes).toBe(true);
     // One-time payments offer to save the card for future purchases.
     expect(params.saved_payment_method_options).toEqual({
       payment_method_save: "enabled",
@@ -562,6 +565,8 @@ describe("POST /api/checkout/products/create", () => {
     });
     // No app locale on the profile → Stripe chrome falls back to 'auto'.
     expect(params.locale).toBe("auto");
+    // Promotion-code entry is enabled on the subscription path too.
+    expect(params.allow_promotion_codes).toBe(true);
   });
 
   it("localizes the Stripe chrome and description to the parent's locale", async () => {


### PR DESCRIPTION
## Summary

Hotfix: enable the "Add promotion code" field on Stripe Checkout. Stripe hides it unless the session opts in via `allow_promotion_codes`; the flag is set on the shared session params, so both single-payment (camps/events) and subscription (clubs) checkouts get it.

Cherry-picked from `dev` (d18bf8a). **Do not reset `dev` after merging** — this intentionally creates a twin commit that the next full `pr-dev-to-main` release run will detect and filter out via its divergent path.

## Test plan

- [ ] CI green (lint, type-check, unit/integration tests — both checkout session tests now assert the flag)
- [ ] On prod after deploy: open a paid product checkout and confirm the "Add promotion code" link appears
- [ ] Create a percent-off promotion code in the **live-mode** Stripe dashboard and confirm it applies (no live codes exist yet — until then the field rejects all input as invalid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
