### PR TITLE
Hotfix: enable Stripe Tax (VAT) on new product signups

### DIFF
--- a/src/app/api/checkout/products/create/route.ts
+++ b/src/app/api/checkout/products/create/route.ts
@@ -258,6 +258,15 @@ export async function POST(request: Request) {
     // coupons convert cleanly; amount_off coupons are currency-bound, so
     // prefer percent-off when creating codes.
     allow_promotion_codes: true,
+    // Enable Stripe Tax so new signups get VAT itemized like the migrated
+    // Chargebee subs do. `customer_update: { address: "auto" }` is required by
+    // Stripe whenever a `customer` is pre-set on the session with automatic_tax
+    // on; it also makes Checkout collect the billing address and persist it back
+    // onto the Customer (getOrCreateStripeCustomer creates customers with email
+    // + name only, no address), which Stripe Tax needs to locate the customer.
+    // Session-level automatic_tax covers both "subscription" and "payment" modes.
+    automatic_tax: { enabled: true },
+    customer_update: { address: "auto" },
     expires_at: expiresAt,
     metadata,
     success_url: successUrl,

--- a/src/lib/stripe/participation-prices.ts
+++ b/src/lib/stripe/participation-prices.ts
@@ -83,6 +83,13 @@ export async function getOrCreateSubscriptionPrice(
     product: stripeProductId,
     currency,
     unit_amount: unitAmount,
+    // Our prices are the full amount the customer pays with VAT *inside* them
+    // (same as Chargebee). With Stripe Tax on, a price with unspecified
+    // tax_behavior resolves to exclusive and would add VAT on top — so mark it
+    // inclusive. tax_behavior is immutable once a price is created, so this only
+    // governs prices created from here on; existing prices rely on the account
+    // default tax behavior (set to Inclusive in the Stripe Dashboard).
+    tax_behavior: "inclusive",
     recurring: { interval: "month", interval_count: 1 },
     metadata: {
       productId,


### PR DESCRIPTION
## Summary

New paid signups created on the website had **no VAT** on their Stripe invoices (€0 tax), while migrated Chargebee subs correctly show 25.5% VAT. Root cause: the Checkout Session we create never enabled Stripe Tax, so nothing turned `automatic_tax` on for new signups.

This ships ahead of the next full release because every new paid signup is currently being invoiced without VAT — a billing/compliance issue that shouldn't wait.

Cherry-picked from `dev`: `6ead1de`.

### Changes
- Enable `automatic_tax` on the Checkout Session, with `customer_update: { address: "auto" }` (required when a customer is pre-set on the session with automatic_tax on; also backfills the billing address Stripe Tax needs, since `getOrCreateStripeCustomer` creates customers with email + name only).
- Set `tax_behavior: "inclusive"` on newly created subscription prices so VAT is carved out of the existing price (€59 stays €59 with ~€11.99 VAT inside) rather than added on top.

> **Note:** Existing prices rely on the **account default tax behavior** being set to *Inclusive* in the Stripe Dashboard (test mode already done; **live mode must be set before/with this deploy** or existing-price signups resolve to exclusive and over-bill). The `tax_behavior` in code only governs prices created after deploy.

## Test plan
- [x] CI green (lint, type-check, unit/integration, db). The dev commit's CI is green; this branch re-runs the same suite.
- [x] 27/27 integration tests for the checkout route pass locally on this branch.
- [ ] After deploy: a real prod signup shows VAT on the Stripe Checkout page.
- [ ] Resulting subscription's upcoming invoice shows the price unchanged (e.g. €59 total) with 25.5% VAT itemized *inside* it, and `subscription.automatic_tax.enabled === true`.

## Merge instructions
- **Merge as a merge commit** (not squash) so the cherry-picked commit lands on `main` with its subject verbatim — this lets the next release's twin filter pair it with the dev original.
- **Do NOT reset `dev`** after merging. The twin commit left on `main` is expected; the next `/pr-dev-to-main` self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
