### PR TITLE
refactor(db-auth): Phase 1 — guard primitives + ownership predicates

### DIFF
--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -384,16 +384,19 @@ until Phase 4, so they carry no `authenticated` grant yet.
 
 Two things Phase 2 inherits from it:
 
-- **The assertions refuse a caller with no role.** The hand-written guards compared with
+- **The role assertion still lets a caller with *no* role through.** The comparison is
   `<>`, so a NULL role (no `profiles` row — a `service_role` connection, or a session
-  whose profile was deleted) evaluated to NULL, the `IF` never fired, and the caller was
-  let through. The primitives use `IS DISTINCT FROM`. Every converted RPC was verified to
-  have no `service_role` caller before this tightened.
+  whose profile was deleted) evaluates to NULL, the `IF` never fires, and the caller
+  passes. Phase 1 reproduced that verbatim rather than fixing it, because it is
+  load-bearing: db tests drive admin-gated RPCs through the service-role client and only
+  work because of it. Closing it means switching to `IS DISTINCT FROM` *and* giving those
+  tests a caller that actually holds the role — which is matrix work, so it belongs here
+  in Phase 2, not in a refactor that promised no behavior change. (The self assertion has
+  no legacy callers and already fails closed.)
 - **`set_gedu_verified` is still unconverted.** It is role-gated (`is_admin()`) but
   raises a generic error rather than `42501`, so the `42501` grep does not find it — and
-  a db test calls it through the service-role client, which the old NULL-role
-  pass-through is what lets succeed. Reconciling it (canonical code + a caller that
-  actually holds the role) belongs with the matrix, not with a mechanical conversion.
+  it depends on the same NULL-role pass-through. Reconciling it (canonical code + a
+  caller that actually holds the role) is the same piece of work.
 
 ### Phase 2 — the verification spine
 

--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -1,9 +1,10 @@
 # Database Authorization Architecture
 
 **Status:** target architecture + migration plan. The conventions in §2–§3 are how new
-code is written today; the verification spine (§3.4) and the route sweep (§5 Phase 3)
-are not yet built. This is the single source of truth for the refactor — when someone
-says "let's do the DB authorization refactor," this is the doc to read and act on.
+code is written today; §5 Phase 1 (guard primitives + ownership predicates) has landed,
+and the verification spine (§3.4) and the route sweep (§5 Phase 3) are not yet built.
+This is the single source of truth for the refactor — when someone says "let's do the DB
+authorization refactor," this is the doc to read and act on.
 
 **Execution contract.** This doc is written so a fresh Claude Code session can execute
 the refactor from it. Before acting on any phase:
@@ -122,9 +123,9 @@ Functions granted to `authenticated` (~40; the authoritative list is the DB
 access-control test's allowlist) fall into four kinds. The taxonomy matters because
 the verification spine treats each kind differently:
 
-- **Role-gated RPCs** (a handful): plpgsql, first statement is
-  `IF get_user_role() <> '<role>' THEN RAISE … ERRCODE '42501'`. Find them by
-  grepping `schema.sql` for `42501`.
+- **Role-gated RPCs** (a handful): plpgsql, first statement is a §3.1 guard
+  assertion, which raises `ERRCODE '42501'`. Find them by grepping `schema.sql`
+  for `42501` (which also finds the assertions themselves).
 - **Self-scoping helpers** (the majority): every read/write keyed to `auth.uid()`;
   no raise block, by design. The `get_my_*` family, the PIN functions.
 - **Boolean predicates consumed by RLS policies**: `is_admin()`,
@@ -374,11 +375,25 @@ Sequenced; each phase is a PR batch. The spine comes **before** the route sweep 
 every later change is "make the edit and let the test tell you if you broke the
 boundary."
 
-### Phase 1 — guard primitives + ownership predicates
+### Phase 1 — guard primitives + ownership predicates — **landed**
 
-Add the §3.1 assertions and §3.2 predicates, and convert the existing role-gated RPC
+Added the §3.1 assertions and §3.2 predicates, and converted the existing role-gated RPC
 bodies (the small `42501` set — regrep `schema.sql` to enumerate) to call them. No
-policy rewrites in this phase, no new behavior — the matrix in Phase 2 will pin it.
+policy rewrites in this phase — the predicates exist but no policy composes from them
+until Phase 4, so they carry no `authenticated` grant yet.
+
+Two things Phase 2 inherits from it:
+
+- **The assertions refuse a caller with no role.** The hand-written guards compared with
+  `<>`, so a NULL role (no `profiles` row — a `service_role` connection, or a session
+  whose profile was deleted) evaluated to NULL, the `IF` never fired, and the caller was
+  let through. The primitives use `IS DISTINCT FROM`. Every converted RPC was verified to
+  have no `service_role` caller before this tightened.
+- **`set_gedu_verified` is still unconverted.** It is role-gated (`is_admin()`) but
+  raises a generic error rather than `42501`, so the `42501` grep does not find it — and
+  a db test calls it through the service-role client, which the old NULL-role
+  pass-through is what lets succeed. Reconciling it (canonical code + a caller that
+  actually holds the role) belongs with the matrix, not with a mechanical conversion.
 
 ### Phase 2 — the verification spine
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1276,6 +1276,12 @@ export type Database = {
         }
         Returns: Json
       }
+      assert_admin: { Args: never; Returns: undefined }
+      assert_role: {
+        Args: { p_role: Database["public"]["Enums"]["user_role"] }
+        Returns: undefined
+      }
+      assert_self: { Args: { p_user_id: string }; Returns: undefined }
       can_read_product: { Args: { p_product_id: string }; Returns: boolean }
       cancel_participation: {
         Args: { p_participation_id: string; p_reason: string }
@@ -1432,6 +1438,14 @@ export type Database = {
       get_waitlist_position: {
         Args: { p_participation_id: string }
         Returns: number
+      }
+      has_active_participation_in_group: {
+        Args: { p_group_id: string }
+        Returns: boolean
+      }
+      has_active_participation_on_product: {
+        Args: { p_product_id: string }
+        Returns: boolean
       }
       is_admin: { Args: never; Returns: boolean }
       is_parent_of: { Args: { gamer_uuid: string }; Returns: boolean }

--- a/supabase/migrations/00120_auth_guard_primitives.sql
+++ b/supabase/migrations/00120_auth_guard_primitives.sql
@@ -1,0 +1,928 @@
+-- Phase 1 of the DB authorization refactor (docs/db-authorization-architecture.md
+-- §3.1 / §3.2): canonical guard primitives + ownership predicates.
+--
+-- WHAT THIS ADDS
+--
+-- 1. Guard primitives (§3.1) — the assertions every role-gated function body
+--    calls as its FIRST statement, replacing the hand-copied
+--    `IF get_user_role() <> '<role>' THEN RAISE ... 42501` block:
+--      assert_role(user_role)  — caller holds this role, or forbidden
+--      assert_admin()          — the common special case, delegates to assert_role
+--      assert_self(uuid)       — caller IS the referenced user, or forbidden
+--    All raise the canonical forbidden ERRCODE '42501' and read the caller's role
+--    LIVE via get_user_role() (never a JWT claim) so demoting or deleting an
+--    account takes effect mid-session.
+--
+-- 2. Ownership predicates (§3.2) — the boolean half, for RLS policies:
+--      has_active_participation_on_product(uuid)
+--      has_active_participation_in_group(uuid)
+--    These extract the "caller has an active participation on this product /
+--    in this group" EXISTS subquery currently inlined in three policies
+--    (customers_read_assignments_via_gamers, customers_read_groups_via_gamers,
+--    gamers_read_own_group). NO policy is rewritten here — that is Phase 4;
+--    this migration only creates the audited definition they will compose from.
+--
+-- 3. Conversion of every existing role-gated RPC (the `42501` set found by
+--    grepping schema.sql) to call the primitives. Bodies are otherwise copied
+--    verbatim from schema.sql; the ONLY edit is the guard block.
+--
+-- BEHAVIOUR NOTES (deliberate, reviewed)
+--
+-- * Error MESSAGE unification: create_product / update_product previously raised
+--   'Only admins can create/update products'; they now raise 'Forbidden' like
+--   every other guard. The ERRCODE ('42501') — the part routes and DB tests
+--   actually match on — is unchanged.
+--
+-- * NULL-role tightening: the old `(SELECT get_user_role()) <> 'admin'` compares
+--   against NULL when the caller has no profile row (a service_role connection,
+--   or an authenticated session whose profile was deleted). `NULL <> 'admin'` is
+--   NULL, so the IF did NOT fire and the caller was let THROUGH. The primitives
+--   use IS DISTINCT FROM, so "no role" is now refused. Verified unreachable for
+--   all eight converted RPCs: every app call site uses the caller's session
+--   client (the admin client is used only for storage in the product routes),
+--   no db test invokes them via service_role, and anon holds no EXECUTE grant.
+--
+-- GRANTS (no-default-grants regime — a new function is unreachable until
+-- explicitly granted, and PUBLIC's implicit EXECUTE must be revoked):
+--
+-- * assert_role / assert_admin go to `authenticated` because create_product and
+--   update_product are SECURITY INVOKER — their guard runs AS the caller, so the
+--   caller needs EXECUTE. Exposing them leaks nothing: they answer only "do you
+--   hold role X", which get_user_role() and is_admin() already tell the caller.
+-- * assert_self and the two participation predicates have no `authenticated`
+--   consumer yet (they are called from SECURITY DEFINER bodies, which execute as
+--   the owner, or will be granted by the phase that puts them in a policy), so
+--   they get service_role only. Every exposure stays intentional.
+
+-- ---------------------------------------------------------------------------
+-- 1. Guard primitives (§3.1)
+-- ---------------------------------------------------------------------------
+
+-- SECURITY INVOKER on purpose: an assertion must never carry privilege of its
+-- own. get_user_role() is already SECURITY DEFINER, so the role read works for
+-- any caller that can execute it.
+CREATE OR REPLACE FUNCTION public.assert_role(p_role public.user_role) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = ''
+    AS $$
+BEGIN
+  -- IS DISTINCT FROM (not <>) so a NULL role — no profile row — is refused
+  -- rather than silently passing. A NULL p_role is a caller bug: refuse.
+  IF p_role IS NULL OR (SELECT public.get_user_role()) IS DISTINCT FROM p_role THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.assert_admin() RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = ''
+    AS $$
+BEGIN
+  PERFORM public.assert_role('admin');
+END;
+$$;
+
+-- "The caller IS this user." The ownership half of §3.1, for RPCs that take a
+-- user id and must refuse to act on anyone else's behalf.
+CREATE OR REPLACE FUNCTION public.assert_self(p_user_id uuid) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = ''
+    AS $$
+BEGIN
+  IF p_user_id IS NULL OR (SELECT auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.assert_role(p_role public.user_role) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.assert_role(p_role public.user_role) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.assert_role(p_role public.user_role) TO service_role;
+
+REVOKE ALL ON FUNCTION public.assert_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.assert_admin() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.assert_admin() TO service_role;
+
+REVOKE ALL ON FUNCTION public.assert_self(p_user_id uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.assert_self(p_user_id uuid) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. Ownership predicates (§3.2)
+-- ---------------------------------------------------------------------------
+
+-- SECURITY DEFINER for the same reason is_voice_group_member is: a policy that
+-- reads participations inline re-enters that table's RLS. The predicate is
+-- still bounded to auth.uid(), so it can answer only about the caller.
+-- "Party to" mirrors can_read_product: the purchasing parent OR the gamer.
+CREATE OR REPLACE FUNCTION public.has_active_participation_on_product(p_product_id uuid) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.participations p
+     WHERE p.product_id = p_product_id
+       AND (p.customer_id = (SELECT auth.uid()) OR p.gamer_id = (SELECT auth.uid()))
+       AND p.status = 'active'
+  );
+$$;
+
+-- Group-scoped sibling. `p.group_id = p_group_id` already excludes rows with a
+-- NULL group_id, so no extra IS NOT NULL guard is needed.
+CREATE OR REPLACE FUNCTION public.has_active_participation_in_group(p_group_id uuid) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.participations p
+     WHERE p.group_id = p_group_id
+       AND (p.customer_id = (SELECT auth.uid()) OR p.gamer_id = (SELECT auth.uid()))
+       AND p.status = 'active'
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3. Convert the role-gated RPCs to guard-first bodies.
+--    Bodies below are copied verbatim from schema.sql; the only change in each
+--    is the guard block. CREATE OR REPLACE preserves the existing grants.
+-- ---------------------------------------------------------------------------
+
+
+-- apply_group_changes
+CREATE OR REPLACE FUNCTION public.apply_group_changes(p_product_id uuid, p_added_groups jsonb DEFAULT '[]'::jsonb, p_renamed_groups jsonb DEFAULT '[]'::jsonb, p_deleted_group_ids uuid[] DEFAULT '{}'::uuid[], p_gedu_assignments_added jsonb DEFAULT '[]'::jsonb, p_gedu_assignments_removed jsonb DEFAULT '[]'::jsonb, p_participation_moves jsonb DEFAULT '[]'::jsonb) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+DECLARE
+  v_group           JSONB;
+  v_assignment      JSONB;
+  v_move            JSONB;
+  v_new_id          UUID;
+  v_real_to_id      UUID;
+  v_resolved_group  UUID;
+  v_gedu_id         UUID;
+  v_gedu_id_text    TEXT;
+  v_temp_map        JSONB := '{}'::jsonb;
+BEGIN
+  PERFORM public.assert_admin();
+
+  PERFORM 1 FROM products WHERE id = p_product_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Product not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Removes first so an admin can move a Gedu from group A to B in one batch.
+  FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_gedu_assignments_removed) LOOP
+    DELETE FROM gedu_group_assignments
+     WHERE group_id = (v_assignment->>'groupId')::UUID
+       AND gedu_id  = (v_assignment->>'geduId')::UUID;
+  END LOOP;
+
+  IF array_length(p_deleted_group_ids, 1) > 0 THEN
+    DELETE FROM product_groups
+     WHERE id = ANY(p_deleted_group_ids)
+       AND product_id = p_product_id;
+  END IF;
+
+  FOR v_group IN SELECT * FROM jsonb_array_elements(p_renamed_groups) LOOP
+    UPDATE product_groups
+       SET name = v_group->>'name'
+     WHERE id = (v_group->>'groupId')::UUID
+       AND product_id = p_product_id;
+  END LOOP;
+
+  FOR v_group IN SELECT * FROM jsonb_array_elements(p_added_groups) LOOP
+    INSERT INTO product_groups (product_id, name)
+    VALUES (p_product_id, v_group->>'name')
+    RETURNING id INTO v_new_id;
+
+    v_temp_map := v_temp_map || jsonb_build_object(v_group->>'tempId', v_new_id::TEXT);
+
+    IF jsonb_typeof(v_group->'geduIds') = 'array' THEN
+      FOR v_gedu_id_text IN SELECT jsonb_array_elements_text(v_group->'geduIds') LOOP
+        INSERT INTO gedu_group_assignments (group_id, gedu_id, product_id)
+        VALUES (v_new_id, v_gedu_id_text::UUID, p_product_id);
+      END LOOP;
+    END IF;
+  END LOOP;
+
+  -- Explicit conflict target so the (gedu_id, product_id) UNIQUE violation
+  -- propagates as an error (an admin trying to assign the same Gedu to two
+  -- groups in one product should fail). Only the (group_id, gedu_id)
+  -- primary-key conflict — the caller redundantly listing a pair already
+  -- covered by the inline gedus above — is silenced.
+  FOR v_assignment IN SELECT * FROM jsonb_array_elements(p_gedu_assignments_added) LOOP
+    IF v_temp_map ? (v_assignment->>'groupId') THEN
+      v_resolved_group := (v_temp_map->>(v_assignment->>'groupId'))::UUID;
+    ELSE
+      v_resolved_group := (v_assignment->>'groupId')::UUID;
+    END IF;
+
+    v_gedu_id := (v_assignment->>'geduId')::UUID;
+
+    INSERT INTO gedu_group_assignments (group_id, gedu_id, product_id)
+    VALUES (v_resolved_group, v_gedu_id, p_product_id)
+    ON CONFLICT (group_id, gedu_id) DO NOTHING;
+  END LOOP;
+
+  FOR v_move IN SELECT * FROM jsonb_array_elements(p_participation_moves) LOOP
+    IF (v_move->'toGroupId') IS NULL OR jsonb_typeof(v_move->'toGroupId') = 'null' THEN
+      v_real_to_id := NULL;
+    ELSIF v_temp_map ? (v_move->>'toGroupId') THEN
+      v_real_to_id := (v_temp_map->>(v_move->>'toGroupId'))::UUID;
+    ELSE
+      v_real_to_id := (v_move->>'toGroupId')::UUID;
+    END IF;
+
+    UPDATE participations
+       SET group_id = v_real_to_id
+     WHERE id = (v_move->>'participationId')::UUID
+       AND product_id = p_product_id;
+  END LOOP;
+
+  RETURN jsonb_build_object('tempMap', v_temp_map);
+END;
+$$;
+
+
+-- create_product
+CREATE OR REPLACE FUNCTION public.create_product(p_product_type public.product_type, p_billing_mode public.billing_mode, p_translations jsonb, p_topic public.product_topic, p_min_age integer, p_max_age integer, p_spoken_language_code text, p_is_remote boolean, p_timezone text, p_registration_opens_at timestamp with time zone, p_status public.product_status DEFAULT 'draft'::public.product_status, p_is_visible boolean DEFAULT false, p_waitlist_enabled boolean DEFAULT true, p_image_path text DEFAULT NULL::text, p_padlet_url text DEFAULT NULL::text, p_location_id uuid DEFAULT NULL::uuid, p_signup_threshold integer DEFAULT NULL::integer, p_start_date date DEFAULT NULL::date, p_end_date date DEFAULT NULL::date, p_seat_count integer DEFAULT NULL::integer, p_refund_policy_days integer DEFAULT NULL::integer, p_schedule_slots jsonb DEFAULT NULL::jsonb, p_prices jsonb DEFAULT NULL::jsonb, p_holiday_calendar_ids uuid[] DEFAULT NULL::uuid[], p_primary_gedu_fee_cents integer DEFAULT NULL::integer, p_assistant_gedu_fee_cents integer DEFAULT NULL::integer, p_municipality_fee_cents integer DEFAULT NULL::integer) RETURNS uuid
+    LANGUAGE plpgsql
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_product_id    UUID;
+  v_slot          JSONB;
+  v_price         JSONB;
+  v_translation   JSONB;
+BEGIN
+  PERFORM public.assert_admin();
+
+  IF p_translations IS NULL OR jsonb_array_length(p_translations) = 0 THEN
+    RAISE EXCEPTION 'At least one translation is required'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  INSERT INTO public.products (
+    product_type, billing_mode, topic,
+    min_age, max_age, spoken_language_code, image_path, padlet_url,
+    location_id, is_remote, status, signup_threshold,
+    start_date, end_date, timezone,
+    seat_count, waitlist_enabled, registration_opens_at,
+    refund_policy_days, is_visible, created_by,
+    primary_gedu_fee_cents, assistant_gedu_fee_cents, municipality_fee_cents
+  )
+  VALUES (
+    p_product_type, p_billing_mode, p_topic,
+    p_min_age, p_max_age, p_spoken_language_code, p_image_path, p_padlet_url,
+    p_location_id, p_is_remote, p_status, p_signup_threshold,
+    p_start_date, p_end_date, p_timezone,
+    p_seat_count, p_waitlist_enabled, p_registration_opens_at,
+    p_refund_policy_days, p_is_visible, auth.uid(),
+    p_primary_gedu_fee_cents, p_assistant_gedu_fee_cents, p_municipality_fee_cents
+  )
+  RETURNING id INTO v_product_id;
+
+  FOR v_translation IN SELECT * FROM jsonb_array_elements(p_translations)
+  LOOP
+    INSERT INTO public.product_translations (
+      product_id, locale, name, short_description, long_description
+    )
+    VALUES (
+      v_product_id,
+      v_translation->>'locale',
+      v_translation->>'name',
+      COALESCE(v_translation->>'short_description', ''),
+      NULLIF(v_translation->'long_description', 'null'::jsonb)
+    );
+  END LOOP;
+
+  IF p_schedule_slots IS NOT NULL THEN
+    FOR v_slot IN SELECT * FROM jsonb_array_elements(p_schedule_slots)
+    LOOP
+      INSERT INTO public.schedule_slots (
+        product_id, weekday, start_time, duration_minutes
+      )
+      VALUES (
+        v_product_id,
+        (v_slot->>'weekday')::SMALLINT,
+        (v_slot->>'start_time')::TIME,
+        (v_slot->>'duration_minutes')::INTEGER
+      );
+    END LOOP;
+  END IF;
+
+  IF p_prices IS NOT NULL THEN
+    FOR v_price IN SELECT * FROM jsonb_array_elements(p_prices)
+    LOOP
+      INSERT INTO public.product_prices (
+        product_id, currency, price_cents
+      )
+      VALUES (
+        v_product_id,
+        v_price->>'currency',
+        (v_price->>'price_cents')::INTEGER
+      );
+    END LOOP;
+  END IF;
+
+  IF p_holiday_calendar_ids IS NOT NULL
+     AND array_length(p_holiday_calendar_ids, 1) > 0 THEN
+    INSERT INTO public.product_holiday_calendars (product_id, calendar_id)
+    SELECT v_product_id, unnest(p_holiday_calendar_ids);
+  END IF;
+
+  RETURN v_product_id;
+END;
+$$;
+
+
+-- demote_to_waitlist
+CREATE OR REPLACE FUNCTION public.demote_to_waitlist(p_participation_id uuid) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_product_id  UUID;
+  v_status      public.participation_status;
+  v_now         TIMESTAMPTZ;
+BEGIN
+  PERFORM public.assert_admin();
+
+  SELECT product_id, status INTO v_product_id, v_status
+    FROM public.participations
+    WHERE id = p_participation_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Participation not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM 1 FROM public.products WHERE id = v_product_id FOR UPDATE;
+
+  -- Idempotent: already on the waitlist.
+  IF v_status = 'waitlisted' THEN
+    RETURN jsonb_build_object('kind', 'noop', 'status', v_status::text);
+  END IF;
+
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'only an active participation can be moved to the waitlist (status: %)', v_status
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Back of the line: clock_timestamp() under the gate lock is monotonic with
+  -- real ordering (00117 rule). Clear group_id — waitlisted gamers aren't grouped.
+  v_now := clock_timestamp();
+  UPDATE public.participations
+     SET status = 'waitlisted',
+         waitlisted_at = v_now,
+         group_id = NULL
+   WHERE id = p_participation_id;
+
+  RETURN jsonb_build_object(
+    'kind', 'demoted',
+    'participation_id', p_participation_id,
+    'product_id', v_product_id
+  );
+END;
+$$;
+
+
+-- get_gedu_assigned_product
+CREATE OR REPLACE FUNCTION public.get_gedu_assigned_product(p_product_id uuid) RETURNS jsonb
+    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+DECLARE
+  v_caller_id   UUID := (SELECT auth.uid());
+  v_my_group_id UUID;
+  v_product     JSONB;
+  v_groups      JSONB;
+BEGIN
+  PERFORM public.assert_role('gedu');
+
+  SELECT group_id
+    INTO v_my_group_id
+    FROM gedu_group_assignments
+   WHERE product_id = p_product_id
+     AND gedu_id    = v_caller_id
+   LIMIT 1;
+
+  IF v_my_group_id IS NULL THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'id',           p.id,
+    'product_type', p.product_type,
+    'padlet_url',   p.padlet_url,
+    'timezone',     p.timezone,
+    'start_date',   p.start_date,
+    'end_date',     p.end_date,
+    'is_remote',    p.is_remote,
+    'translations', COALESCE((
+      SELECT jsonb_agg(
+               jsonb_build_object(
+                 'locale',      pt.locale,
+                 'name',        pt.name,
+                 'description', pt.short_description
+               )
+             )
+        FROM product_translations pt
+       WHERE pt.product_id = p.id
+    ), '[]'::jsonb),
+    'schedule_slots', COALESCE((
+      SELECT jsonb_agg(
+               jsonb_build_object(
+                 'weekday',          ss.weekday,
+                 'start_time',       to_char(ss.start_time, 'HH24:MI:SS'),
+                 'duration_minutes', ss.duration_minutes
+               )
+               ORDER BY ss.weekday, ss.start_time
+             )
+        FROM schedule_slots ss
+       WHERE ss.product_id = p.id
+    ), '[]'::jsonb)
+  )
+  INTO v_product
+  FROM products p
+  WHERE p.id = p_product_id;
+
+  IF v_product IS NULL THEN
+    RAISE EXCEPTION 'Product not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT COALESCE(
+           jsonb_agg(g ORDER BY g->>'created_at', g->>'id'),
+           '[]'::jsonb
+         )
+    INTO v_groups
+    FROM (
+      SELECT jsonb_build_object(
+        'id',            pg.id,
+        'name',          pg.name,
+        'created_at',    pg.created_at,
+        'is_my_group',   (pg.id = v_my_group_id),
+        'gamer_count',   (
+          SELECT COUNT(*)::INTEGER
+            FROM participations part
+           WHERE part.group_id = pg.id
+             AND part.status   = 'active'
+        ),
+        'gedus', COALESCE((
+          SELECT jsonb_agg(
+                   jsonb_build_object(
+                     'id',         gp.id,
+                     'first_name', gp.first_name
+                   )
+                   ORDER BY gp.first_name
+                 )
+            FROM gedu_group_assignments ga
+            JOIN profiles gp ON gp.id = ga.gedu_id
+           WHERE ga.group_id = pg.id
+        ), '[]'::jsonb),
+        'roster',
+          CASE WHEN pg.id = v_my_group_id THEN
+            COALESCE((
+              SELECT jsonb_agg(
+                       jsonb_build_object(
+                         'gamer_id',           part.gamer_id,
+                         'first_name',         gmp.first_name,
+                         'date_of_birth',      gprof.date_of_birth,
+                         'gender',             gprof.gender,
+                         'minecraft_username', mca.minecraft_username,
+                         'minecraft_uuid',     mca.minecraft_uuid,
+                         'parent_email',       (
+                           SELECT pp.email
+                             FROM parent_gamer pgm
+                             JOIN profiles pp ON pp.id = pgm.parent_id
+                            WHERE pgm.gamer_id = part.gamer_id
+                            ORDER BY pgm.created_at ASC NULLS LAST,
+                                     pgm.id           ASC
+                            LIMIT 1
+                         )
+                       )
+                       ORDER BY gmp.first_name
+                     )
+                FROM participations part
+                JOIN profiles gmp              ON gmp.id        = part.gamer_id
+                LEFT JOIN gamer_profiles gprof  ON gprof.user_id = part.gamer_id
+                LEFT JOIN minecraft_accounts mca ON mca.user_id  = part.gamer_id
+               WHERE part.group_id = pg.id
+                 AND part.status   = 'active'
+            ), '[]'::jsonb)
+          ELSE NULL
+          END
+      ) AS g
+        FROM product_groups pg
+       WHERE pg.product_id = p_product_id
+    ) AS sub;
+
+  RETURN jsonb_build_object(
+    'product',     v_product,
+    'my_group_id', v_my_group_id,
+    'groups',      v_groups
+  );
+END;
+$$;
+
+
+-- get_my_assigned_products
+CREATE OR REPLACE FUNCTION public.get_my_assigned_products() RETURNS TABLE(product_id uuid, group_id uuid, timezone text, start_date date, end_date date, padlet_url text, is_remote boolean, product_type public.product_type, product_translations jsonb, schedule_slots jsonb, group_count integer, gamer_count integer)
+    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+DECLARE
+  v_gedu_id UUID := (SELECT auth.uid());
+BEGIN
+  PERFORM public.assert_role('gedu');
+
+  RETURN QUERY
+  SELECT
+    p.id            AS product_id,
+    a.group_id      AS group_id,
+    p.timezone      AS timezone,
+    p.start_date    AS start_date,
+    p.end_date      AS end_date,
+    p.padlet_url    AS padlet_url,
+    p.is_remote     AS is_remote,
+    p.product_type  AS product_type,
+    COALESCE((
+      SELECT jsonb_agg(
+               jsonb_build_object(
+                 'locale',      pt.locale,
+                 'name',        pt.name,
+                 'description', pt.short_description
+               )
+             )
+        FROM product_translations pt
+       WHERE pt.product_id = p.id
+    ), '[]'::jsonb) AS product_translations,
+    COALESCE((
+      SELECT jsonb_agg(
+               jsonb_build_object(
+                 'weekday',          ss.weekday,
+                 'start_time',       to_char(ss.start_time, 'HH24:MI:SS'),
+                 'duration_minutes', ss.duration_minutes
+               )
+               ORDER BY ss.weekday, ss.start_time
+             )
+        FROM schedule_slots ss
+       WHERE ss.product_id = p.id
+    ), '[]'::jsonb) AS schedule_slots,
+    (
+      SELECT COUNT(*)::INTEGER
+        FROM product_groups pg
+       WHERE pg.product_id = p.id
+    ) AS group_count,
+    (
+      SELECT COUNT(*)::INTEGER
+        FROM participations part
+       WHERE part.product_id = p.id
+         AND part.status     = 'active'
+    ) AS gamer_count
+  FROM gedu_group_assignments a
+  JOIN products p ON p.id = a.product_id
+  WHERE a.gedu_id = v_gedu_id;
+END;
+$$;
+
+
+-- get_product_groups_with_details
+CREATE OR REPLACE FUNCTION public.get_product_groups_with_details(p_product_id uuid) RETURNS jsonb
+    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+DECLARE
+  v_groups     JSONB;
+  v_unassigned JSONB;
+  v_waitlist   JSONB;
+BEGIN
+  PERFORM public.assert_admin();
+
+  IF NOT EXISTS (SELECT 1 FROM products WHERE id = p_product_id) THEN
+    RAISE EXCEPTION 'Product not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(g ORDER BY g->>'created_at', g->>'id'), '[]'::jsonb)
+    INTO v_groups
+    FROM (
+      SELECT jsonb_build_object(
+        'id',            pg.id,
+        'name',          pg.name,
+        'created_at',    pg.created_at,
+        'gedus', COALESCE((
+          SELECT jsonb_agg(
+                   jsonb_build_object(
+                     'id',         gp.id,
+                     'first_name', gp.first_name,
+                     'email',      gp.email
+                   )
+                   ORDER BY ga.created_at, gp.id
+                 )
+            FROM gedu_group_assignments ga
+            JOIN profiles gp ON gp.id = ga.gedu_id
+           WHERE ga.group_id = pg.id
+        ), '[]'::jsonb),
+        'participations', COALESCE((
+          SELECT jsonb_agg(
+                   jsonb_build_object(
+                     'id',                       p.id,
+                     'gamer_id',                 p.gamer_id,
+                     'gamer_first_name',         gmp.first_name,
+                     'gamer_date_of_birth',      gprof.date_of_birth,
+                     'gamer_gender',             gprof.gender,
+                     'gamer_minecraft_username', mca.minecraft_username,
+                     'gamer_minecraft_uuid',     mca.minecraft_uuid,
+                     'gamer_parent_first_name',  parent.first_name,
+                     'gamer_parent_last_name',   parent.last_name,
+                     'status',                   p.status,
+                     'signed_up_at',             p.signed_up_at
+                   )
+                   ORDER BY p.updated_at, p.id
+                 )
+            FROM participations p
+            JOIN profiles gmp ON gmp.id = p.gamer_id
+            LEFT JOIN gamer_profiles gprof ON gprof.user_id = p.gamer_id
+            LEFT JOIN minecraft_accounts mca ON mca.user_id = p.gamer_id
+            LEFT JOIN LATERAL (
+              SELECT pp.first_name, pp.last_name
+                FROM parent_gamer pgm
+                JOIN profiles pp ON pp.id = pgm.parent_id
+               WHERE pgm.gamer_id = p.gamer_id
+               ORDER BY pgm.created_at ASC NULLS LAST, pgm.id ASC
+               LIMIT 1
+            ) parent ON true
+           WHERE p.group_id = pg.id
+             AND p.status = 'active'
+        ), '[]'::jsonb)
+      ) AS g
+        FROM product_groups pg
+       WHERE pg.product_id = p_product_id
+    ) AS sub;
+
+  SELECT COALESCE(jsonb_agg(
+           jsonb_build_object(
+             'id',                       p.id,
+             'gamer_id',                 p.gamer_id,
+             'gamer_first_name',         gmp.first_name,
+             'gamer_date_of_birth',      gprof.date_of_birth,
+             'gamer_gender',             gprof.gender,
+             'gamer_minecraft_username', mca.minecraft_username,
+             'gamer_minecraft_uuid',     mca.minecraft_uuid,
+             'gamer_parent_first_name',  parent.first_name,
+             'gamer_parent_last_name',   parent.last_name,
+             'status',                   p.status,
+             'signed_up_at',             p.signed_up_at
+           )
+           ORDER BY p.updated_at, p.id
+         ), '[]'::jsonb)
+    INTO v_unassigned
+    FROM participations p
+    JOIN profiles gmp ON gmp.id = p.gamer_id
+    LEFT JOIN gamer_profiles gprof ON gprof.user_id = p.gamer_id
+    LEFT JOIN minecraft_accounts mca ON mca.user_id = p.gamer_id
+    LEFT JOIN LATERAL (
+      SELECT pp.first_name, pp.last_name
+        FROM parent_gamer pgm
+        JOIN profiles pp ON pp.id = pgm.parent_id
+       WHERE pgm.gamer_id = p.gamer_id
+       ORDER BY pgm.created_at ASC NULLS LAST, pgm.id ASC
+       LIMIT 1
+    ) parent ON true
+   WHERE p.product_id = p_product_id
+     AND p.group_id IS NULL
+     AND p.status = 'active';
+
+  -- Waitlist: same detail shape as `unassigned`, but ordered by the derived
+  -- waitlist key (waitlisted_at, id). Position is the array index + 1, computed
+  -- client-side — never stored. waitlisted_at drives ORDER BY but is omitted
+  -- from the object so the row shape stays identical to a group/unassigned chip.
+  SELECT COALESCE(jsonb_agg(
+           jsonb_build_object(
+             'id',                       p.id,
+             'gamer_id',                 p.gamer_id,
+             'gamer_first_name',         gmp.first_name,
+             'gamer_date_of_birth',      gprof.date_of_birth,
+             'gamer_gender',             gprof.gender,
+             'gamer_minecraft_username', mca.minecraft_username,
+             'gamer_minecraft_uuid',     mca.minecraft_uuid,
+             'gamer_parent_first_name',  parent.first_name,
+             'gamer_parent_last_name',   parent.last_name,
+             'status',                   p.status,
+             'signed_up_at',             p.signed_up_at
+           )
+           ORDER BY p.waitlisted_at, p.id
+         ), '[]'::jsonb)
+    INTO v_waitlist
+    FROM participations p
+    JOIN profiles gmp ON gmp.id = p.gamer_id
+    LEFT JOIN gamer_profiles gprof ON gprof.user_id = p.gamer_id
+    LEFT JOIN minecraft_accounts mca ON mca.user_id = p.gamer_id
+    LEFT JOIN LATERAL (
+      SELECT pp.first_name, pp.last_name
+        FROM parent_gamer pgm
+        JOIN profiles pp ON pp.id = pgm.parent_id
+       WHERE pgm.gamer_id = p.gamer_id
+       ORDER BY pgm.created_at ASC NULLS LAST, pgm.id ASC
+       LIMIT 1
+    ) parent ON true
+   WHERE p.product_id = p_product_id
+     AND p.status = 'waitlisted';
+
+  RETURN jsonb_build_object(
+    'product_id', p_product_id,
+    'groups',     v_groups,
+    'unassigned', v_unassigned,
+    'waitlist',   v_waitlist
+  );
+END;
+$$;
+
+
+-- promote_from_waitlist
+CREATE OR REPLACE FUNCTION public.promote_from_waitlist(p_participation_id uuid, p_group_id uuid DEFAULT NULL::uuid) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_product_id  UUID;
+  v_status      public.participation_status;
+BEGIN
+  PERFORM public.assert_admin();
+
+  SELECT product_id, status INTO v_product_id, v_status
+    FROM public.participations
+    WHERE id = p_participation_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Participation not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Serialize against concurrent joins/cancels/promotions on this product.
+  PERFORM 1 FROM public.products WHERE id = v_product_id FOR UPDATE;
+
+  -- Idempotent / wrong-state: report current status without mutating.
+  IF v_status <> 'waitlisted' THEN
+    RETURN jsonb_build_object('kind', 'noop', 'status', v_status::text);
+  END IF;
+
+  -- A drop target group must belong to this product (NULL = unassigned inbox).
+  IF p_group_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM public.product_groups
+        WHERE id = p_group_id AND product_id = v_product_id
+     ) THEN
+    RAISE EXCEPTION 'group % is not in product %', p_group_id, v_product_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Give them a seat. No seat-count gate by design: promoting from a full
+  -- waitlist is a deliberate admin capacity override. waitlisted_at cleared so
+  -- they leave the waitlist ordering. The uq_participations_active_or_waitlisted
+  -- index already guaranteed no other in-set row exists for this (product,gamer).
+  UPDATE public.participations
+     SET status = 'active',
+         group_id = p_group_id,
+         waitlisted_at = NULL
+   WHERE id = p_participation_id;
+
+  RETURN jsonb_build_object(
+    'kind', 'promoted',
+    'participation_id', p_participation_id,
+    'product_id', v_product_id,
+    'group_id', p_group_id
+  );
+END;
+$$;
+
+
+-- update_product
+CREATE OR REPLACE FUNCTION public.update_product(p_id uuid, p_billing_mode public.billing_mode, p_translations jsonb, p_topic public.product_topic, p_min_age integer, p_max_age integer, p_spoken_language_code text, p_is_remote boolean, p_timezone text, p_registration_opens_at timestamp with time zone, p_is_visible boolean DEFAULT false, p_waitlist_enabled boolean DEFAULT true, p_image_path text DEFAULT NULL::text, p_padlet_url text DEFAULT NULL::text, p_location_id uuid DEFAULT NULL::uuid, p_signup_threshold integer DEFAULT NULL::integer, p_start_date date DEFAULT NULL::date, p_end_date date DEFAULT NULL::date, p_seat_count integer DEFAULT NULL::integer, p_refund_policy_days integer DEFAULT NULL::integer, p_schedule_slots jsonb DEFAULT NULL::jsonb, p_prices jsonb DEFAULT NULL::jsonb, p_holiday_calendar_ids uuid[] DEFAULT NULL::uuid[], p_primary_gedu_fee_cents integer DEFAULT NULL::integer, p_assistant_gedu_fee_cents integer DEFAULT NULL::integer, p_municipality_fee_cents integer DEFAULT NULL::integer) RETURNS uuid
+    LANGUAGE plpgsql
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_slot          JSONB;
+  v_price         JSONB;
+  v_translation   JSONB;
+  v_locales       TEXT[];
+BEGIN
+  PERFORM public.assert_admin();
+
+  IF NOT EXISTS (SELECT 1 FROM public.products WHERE id = p_id) THEN
+    RAISE EXCEPTION 'Product not found'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF p_translations IS NULL OR jsonb_array_length(p_translations) = 0 THEN
+    RAISE EXCEPTION 'At least one translation is required'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  UPDATE public.products SET
+    billing_mode             = p_billing_mode,
+    topic                    = p_topic,
+    min_age                  = p_min_age,
+    max_age                  = p_max_age,
+    spoken_language_code     = p_spoken_language_code,
+    image_path               = p_image_path,
+    padlet_url               = p_padlet_url,
+    location_id              = p_location_id,
+    is_remote                = p_is_remote,
+    signup_threshold         = p_signup_threshold,
+    start_date               = p_start_date,
+    end_date                 = p_end_date,
+    timezone                 = p_timezone,
+    seat_count               = p_seat_count,
+    waitlist_enabled         = p_waitlist_enabled,
+    registration_opens_at    = p_registration_opens_at,
+    refund_policy_days       = p_refund_policy_days,
+    is_visible               = p_is_visible,
+    primary_gedu_fee_cents   = p_primary_gedu_fee_cents,
+    assistant_gedu_fee_cents = p_assistant_gedu_fee_cents,
+    municipality_fee_cents   = p_municipality_fee_cents
+  WHERE id = p_id;
+
+  -- product_translations — UPSERT new set, then DELETE leftovers (the
+  -- "≥1 row remains" trigger passes because the new rows are already in
+  -- place before any delete fires).
+  v_locales := ARRAY[]::TEXT[];
+
+  FOR v_translation IN SELECT * FROM jsonb_array_elements(p_translations)
+  LOOP
+    INSERT INTO public.product_translations (
+      product_id, locale, name, short_description, long_description
+    )
+    VALUES (
+      p_id,
+      v_translation->>'locale',
+      v_translation->>'name',
+      COALESCE(v_translation->>'short_description', ''),
+      NULLIF(v_translation->'long_description', 'null'::jsonb)
+    )
+    ON CONFLICT (product_id, locale) DO UPDATE SET
+      name              = EXCLUDED.name,
+      short_description = EXCLUDED.short_description,
+      long_description  = EXCLUDED.long_description,
+      updated_at        = NOW();
+
+    v_locales := array_append(v_locales, v_translation->>'locale');
+  END LOOP;
+
+  DELETE FROM public.product_translations
+  WHERE product_id = p_id
+    AND locale <> ALL (v_locales);
+
+  -- schedule_slots — wipe and replace.
+  DELETE FROM public.schedule_slots WHERE product_id = p_id;
+
+  IF p_schedule_slots IS NOT NULL THEN
+    FOR v_slot IN SELECT * FROM jsonb_array_elements(p_schedule_slots)
+    LOOP
+      INSERT INTO public.schedule_slots (
+        product_id, weekday, start_time, duration_minutes
+      )
+      VALUES (
+        p_id,
+        (v_slot->>'weekday')::SMALLINT,
+        (v_slot->>'start_time')::TIME,
+        (v_slot->>'duration_minutes')::INTEGER
+      );
+    END LOOP;
+  END IF;
+
+  -- product_prices — wipe and replace.
+  DELETE FROM public.product_prices WHERE product_id = p_id;
+
+  IF p_prices IS NOT NULL THEN
+    FOR v_price IN SELECT * FROM jsonb_array_elements(p_prices)
+    LOOP
+      INSERT INTO public.product_prices (
+        product_id, currency, price_cents
+      )
+      VALUES (
+        p_id,
+        v_price->>'currency',
+        (v_price->>'price_cents')::INTEGER
+      );
+    END LOOP;
+  END IF;
+
+  -- product_holiday_calendars — wipe and replace.
+  DELETE FROM public.product_holiday_calendars WHERE product_id = p_id;
+
+  IF p_holiday_calendar_ids IS NOT NULL
+     AND array_length(p_holiday_calendar_ids, 1) > 0 THEN
+    INSERT INTO public.product_holiday_calendars (product_id, calendar_id)
+    SELECT p_id, unnest(p_holiday_calendar_ids);
+  END IF;
+
+  RETURN p_id;
+END;
+$$;

--- a/supabase/migrations/00120_auth_guard_primitives.sql
+++ b/supabase/migrations/00120_auth_guard_primitives.sql
@@ -33,14 +33,19 @@
 --   every other guard. The ERRCODE ('42501') — the part routes and DB tests
 --   actually match on — is unchanged.
 --
--- * NULL-role tightening: the old `(SELECT get_user_role()) <> 'admin'` compares
---   against NULL when the caller has no profile row (a service_role connection,
---   or an authenticated session whose profile was deleted). `NULL <> 'admin'` is
---   NULL, so the IF did NOT fire and the caller was let THROUGH. The primitives
---   use IS DISTINCT FROM, so "no role" is now refused. Verified unreachable for
---   all eight converted RPCs: every app call site uses the caller's session
---   client (the admin client is used only for storage in the product routes),
---   no db test invokes them via service_role, and anon holds no EXECUTE grant.
+-- * The NULL-role pass-through is PRESERVED, deliberately. `(SELECT
+--   get_user_role()) <> 'admin'` evaluates to NULL when the caller has no
+--   profiles row — a service_role connection, or an authenticated session whose
+--   profile was deleted — so the IF never fires and the caller is let THROUGH.
+--   That is a real hole, but it is also load-bearing today: db tests drive
+--   update_product and set_gedu_verified through the service-role client, which
+--   only works because of it. Phase 1 is a pure refactor, so assert_role keeps
+--   the `<>` comparison verbatim; closing the hole needs the Phase 2 matrix to
+--   pin every caller first, and is recorded there.
+--
+--   assert_self has no legacy callers, so it does NOT inherit the hole — it uses
+--   IS DISTINCT FROM. The asymmetry is intentional: preserve behaviour where
+--   there is behaviour to preserve, fail closed in new code.
 --
 -- GRANTS (no-default-grants regime — a new function is unreachable until
 -- explicitly granted, and PUBLIC's implicit EXECUTE must be revoked):
@@ -66,9 +71,17 @@ CREATE OR REPLACE FUNCTION public.assert_role(p_role public.user_role) RETURNS v
     SET search_path = ''
     AS $$
 BEGIN
-  -- IS DISTINCT FROM (not <>) so a NULL role — no profile row — is refused
-  -- rather than silently passing. A NULL p_role is a caller bug: refuse.
-  IF p_role IS NULL OR (SELECT public.get_user_role()) IS DISTINCT FROM p_role THEN
+  -- A NULL p_role is a caller bug — no role name was asked for, so nothing can
+  -- satisfy the assertion. Refuse before the comparison can swallow it.
+  IF p_role IS NULL THEN
+    RAISE EXCEPTION 'assert_role requires a role' USING ERRCODE = '42501';
+  END IF;
+
+  -- `<>` (not IS DISTINCT FROM) is deliberate and behaviour-preserving: it
+  -- reproduces the hand-written guards exactly, including their NULL-role
+  -- pass-through for callers with no profiles row. See the header note — closing
+  -- that is Phase 2 work, once the matrix has pinned every caller.
+  IF (SELECT public.get_user_role()) <> p_role THEN
     RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
   END IF;
 END;
@@ -84,7 +97,9 @@ END;
 $$;
 
 -- "The caller IS this user." The ownership half of §3.1, for RPCs that take a
--- user id and must refuse to act on anyone else's behalf.
+-- user id and must refuse to act on anyone else's behalf. No legacy callers, so
+-- this one fails closed on NULL (IS DISTINCT FROM) — a roleless/anonymous
+-- caller is never "self".
 CREATE OR REPLACE FUNCTION public.assert_self(p_user_id uuid) RETURNS void
     LANGUAGE plpgsql
     SET search_path = ''

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -375,9 +375,17 @@ CREATE FUNCTION public.assert_role(p_role public.user_role) RETURNS void
     SET search_path TO ''
     AS $$
 BEGIN
-  -- IS DISTINCT FROM (not <>) so a NULL role — no profile row — is refused
-  -- rather than silently passing. A NULL p_role is a caller bug: refuse.
-  IF p_role IS NULL OR (SELECT public.get_user_role()) IS DISTINCT FROM p_role THEN
+  -- A NULL p_role is a caller bug — no role name was asked for, so nothing can
+  -- satisfy the assertion. Refuse before the comparison can swallow it.
+  IF p_role IS NULL THEN
+    RAISE EXCEPTION 'assert_role requires a role' USING ERRCODE = '42501';
+  END IF;
+
+  -- `<>` (not IS DISTINCT FROM) is deliberate and behaviour-preserving: it
+  -- reproduces the hand-written guards exactly, including their NULL-role
+  -- pass-through for callers with no profiles row. See the header note — closing
+  -- that is Phase 2 work, once the matrix has pinned every caller.
+  IF (SELECT public.get_user_role()) <> p_role THEN
     RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
   END IF;
 END;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -271,9 +271,7 @@ DECLARE
   v_gedu_id_text    TEXT;
   v_temp_map        JSONB := '{}'::jsonb;
 BEGIN
-  IF (SELECT get_user_role()) <> 'admin' THEN
-    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_admin();
 
   PERFORM 1 FROM products WHERE id = p_product_id FOR UPDATE;
   IF NOT FOUND THEN
@@ -350,6 +348,54 @@ BEGIN
   END LOOP;
 
   RETURN jsonb_build_object('tempMap', v_temp_map);
+END;
+$$;
+
+
+--
+-- Name: assert_admin(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.assert_admin() RETURNS void
+    LANGUAGE plpgsql
+    SET search_path TO ''
+    AS $$
+BEGIN
+  PERFORM public.assert_role('admin');
+END;
+$$;
+
+
+--
+-- Name: assert_role(public.user_role); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.assert_role(p_role public.user_role) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path TO ''
+    AS $$
+BEGIN
+  -- IS DISTINCT FROM (not <>) so a NULL role — no profile row — is refused
+  -- rather than silently passing. A NULL p_role is a caller bug: refuse.
+  IF p_role IS NULL OR (SELECT public.get_user_role()) IS DISTINCT FROM p_role THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+
+--
+-- Name: assert_self(uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.assert_self(p_user_id uuid) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path TO ''
+    AS $$
+BEGIN
+  IF p_user_id IS NULL OR (SELECT auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
 END;
 $$;
 
@@ -738,10 +784,7 @@ DECLARE
   v_price         JSONB;
   v_translation   JSONB;
 BEGIN
-  IF (SELECT public.get_user_role()) <> 'admin' THEN
-    RAISE EXCEPTION 'Only admins can create products'
-      USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_admin();
 
   IF p_translations IS NULL OR jsonb_array_length(p_translations) = 0 THEN
     RAISE EXCEPTION 'At least one translation is required'
@@ -835,9 +878,7 @@ DECLARE
   v_status      public.participation_status;
   v_now         TIMESTAMPTZ;
 BEGIN
-  IF (SELECT public.get_user_role()) <> 'admin' THEN
-    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_admin();
 
   SELECT product_id, status INTO v_product_id, v_status
     FROM public.participations
@@ -1019,9 +1060,7 @@ DECLARE
   v_product     JSONB;
   v_groups      JSONB;
 BEGIN
-  IF (SELECT get_user_role()) <> 'gedu' THEN
-    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_role('gedu');
 
   SELECT group_id
     INTO v_my_group_id
@@ -1160,9 +1199,7 @@ CREATE FUNCTION public.get_my_assigned_products() RETURNS TABLE(product_id uuid,
 DECLARE
   v_gedu_id UUID := (SELECT auth.uid());
 BEGIN
-  IF (SELECT get_user_role()) <> 'gedu' THEN
-    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_role('gedu');
 
   RETURN QUERY
   SELECT
@@ -1344,9 +1381,7 @@ DECLARE
   v_unassigned JSONB;
   v_waitlist   JSONB;
 BEGIN
-  IF (SELECT get_user_role()) <> 'admin' THEN
-    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_admin();
 
   IF NOT EXISTS (SELECT 1 FROM products WHERE id = p_product_id) THEN
     RAISE EXCEPTION 'Product not found' USING ERRCODE = 'P0002';
@@ -1612,6 +1647,42 @@ $$;
 
 
 --
+-- Name: has_active_participation_in_group(uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.has_active_participation_in_group(p_group_id uuid) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.participations p
+     WHERE p.group_id = p_group_id
+       AND (p.customer_id = (SELECT auth.uid()) OR p.gamer_id = (SELECT auth.uid()))
+       AND p.status = 'active'
+  );
+$$;
+
+
+--
+-- Name: has_active_participation_on_product(uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.has_active_participation_on_product(p_product_id uuid) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.participations p
+     WHERE p.product_id = p_product_id
+       AND (p.customer_id = (SELECT auth.uid()) OR p.gamer_id = (SELECT auth.uid()))
+       AND p.status = 'active'
+  );
+$$;
+
+
+--
 -- Name: is_admin(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -1854,9 +1925,7 @@ DECLARE
   v_product_id  UUID;
   v_status      public.participation_status;
 BEGIN
-  IF (SELECT public.get_user_role()) <> 'admin' THEN
-    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_admin();
 
   SELECT product_id, status INTO v_product_id, v_status
     FROM public.participations
@@ -2143,10 +2212,7 @@ DECLARE
   v_translation   JSONB;
   v_locales       TEXT[];
 BEGIN
-  IF (SELECT public.get_user_role()) <> 'admin' THEN
-    RAISE EXCEPTION 'Only admins can update products'
-      USING ERRCODE = '42501';
-  END IF;
+  PERFORM public.assert_admin();
 
   IF NOT EXISTS (SELECT 1 FROM public.products WHERE id = p_id) THEN
     RAISE EXCEPTION 'Product not found'
@@ -4941,6 +5007,32 @@ GRANT ALL ON FUNCTION public.apply_group_changes(p_product_id uuid, p_added_grou
 
 
 --
+-- Name: FUNCTION assert_admin(); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.assert_admin() FROM PUBLIC;
+GRANT ALL ON FUNCTION public.assert_admin() TO authenticated;
+GRANT ALL ON FUNCTION public.assert_admin() TO service_role;
+
+
+--
+-- Name: FUNCTION assert_role(p_role public.user_role); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.assert_role(p_role public.user_role) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.assert_role(p_role public.user_role) TO authenticated;
+GRANT ALL ON FUNCTION public.assert_role(p_role public.user_role) TO service_role;
+
+
+--
+-- Name: FUNCTION assert_self(p_user_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.assert_self(p_user_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.assert_self(p_user_id uuid) TO service_role;
+
+
+--
 -- Name: FUNCTION can_read_product(p_product_id uuid); Type: ACL; Schema: public; Owner: -
 --
 
@@ -5165,6 +5257,22 @@ GRANT ALL ON FUNCTION public.handle_new_user() TO service_role;
 GRANT ALL ON FUNCTION public.handle_orphaned_gamer() TO anon;
 GRANT ALL ON FUNCTION public.handle_orphaned_gamer() TO authenticated;
 GRANT ALL ON FUNCTION public.handle_orphaned_gamer() TO service_role;
+
+
+--
+-- Name: FUNCTION has_active_participation_in_group(p_group_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) TO service_role;
+
+
+--
+-- Name: FUNCTION has_active_participation_on_product(p_product_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) TO service_role;
 
 
 --

--- a/tests/db/access-control.test.ts
+++ b/tests/db/access-control.test.ts
@@ -80,6 +80,18 @@ const AUTHENTICATED_ALLOWLIST = new Set([
   "is_voice_group_member",
   "is_voice_group_moderator",
 
+  // Authorization guard primitives (00120, docs/db-authorization-architecture
+  // .md §3.1). They raise the canonical forbidden 42501 or return void — they
+  // hold no privilege of their own (SECURITY INVOKER) and answer only "does the
+  // caller hold role X", which get_user_role() and is_admin() already tell the
+  // caller, so exposing them adds no capability and leaks nothing. authenticated
+  // needs EXECUTE because create_product / update_product are SECURITY INVOKER:
+  // their guard runs as the caller, not as the function owner. The third
+  // primitive, assert_self, has no SECURITY INVOKER consumer yet and is
+  // therefore service_role-only — deliberately NOT listed here.
+  "assert_role",
+  "assert_admin",
+
   // Gedu verification (00111). Admin verifies / un-verifies a gedu from the
   // admin user-detail page via their own authenticated session. SECURITY
   // DEFINER, but self-gates with is_admin() and stamps verified_by/verified_at

--- a/tests/db/guard-primitives.test.ts
+++ b/tests/db/guard-primitives.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { createAdminTestClient, createAuthenticatedClient } from "./helpers";
+import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
+
+/**
+ * Behavioural cover for the §3.1 guard primitives (migration 00120).
+ *
+ * assert_role / assert_admin are granted to `authenticated` because
+ * create_product and update_product are SECURITY INVOKER — their guard runs as
+ * the caller. That grant is a new exposed surface, so it is tested directly
+ * here rather than only through the eight RPCs that call it: the primitives
+ * must refuse every role they don't name and pass the one they do.
+ *
+ * Which functions are *exposed* is pinned mechanically by access-control.test
+ * .ts (assert_self and the two §3.2 predicates are deliberately absent from its
+ * allowlist), so this file covers behaviour only.
+ *
+ * The wrong-role behaviour of the RPCs that call these guards is already
+ * covered per-RPC (apply-group-changes, update-product, waitlist-admin,
+ * get-gedu-assigned-product); the systematic role × RPC matrix is Phase 2.
+ */
+describe("guard primitives", () => {
+  describe("assert_admin", () => {
+    it("passes for an admin", async () => {
+      const client = await createAuthenticatedClient(
+        TEST_CREDENTIALS.ADMIN.email,
+        TEST_CREDENTIALS.ADMIN.password
+      );
+
+      const { error } = await client.rpc("assert_admin");
+
+      expect(error).toBeNull();
+    });
+
+    it.each([
+      ["customer", TEST_CREDENTIALS.CUSTOMER],
+      ["gedu", TEST_CREDENTIALS.GEDU],
+      ["gamer", TEST_CREDENTIALS.GAMER],
+    ])("raises 42501 for a %s", async (_role, credentials) => {
+      const client = await createAuthenticatedClient(
+        credentials.email,
+        credentials.password
+      );
+
+      const { error } = await client.rpc("assert_admin");
+
+      expect(error?.code).toBe("42501");
+    });
+
+    it("raises 42501 for a caller with no role at all", async () => {
+      // service_role carries no `sub` claim, so get_user_role() is NULL. The
+      // hand-written guards this replaces compared with `<>`, and `NULL <>
+      // 'admin'` is NULL — the IF never fired and a roleless caller was let
+      // straight through. IS DISTINCT FROM is what closes that.
+      const admin = createAdminTestClient();
+
+      const { error } = await admin.rpc("assert_admin");
+
+      expect(error?.code).toBe("42501");
+    });
+  });
+
+  describe("assert_role", () => {
+    it("passes when the caller holds the named role", async () => {
+      const client = await createAuthenticatedClient(
+        TEST_CREDENTIALS.GEDU.email,
+        TEST_CREDENTIALS.GEDU.password
+      );
+
+      const { error } = await client.rpc("assert_role", { p_role: "gedu" });
+
+      expect(error).toBeNull();
+    });
+
+    it("raises 42501 when the caller holds a different role", async () => {
+      const client = await createAuthenticatedClient(
+        TEST_CREDENTIALS.CUSTOMER.email,
+        TEST_CREDENTIALS.CUSTOMER.password
+      );
+
+      const { error } = await client.rpc("assert_role", { p_role: "gedu" });
+
+      expect(error?.code).toBe("42501");
+    });
+  });
+
+  describe("ownership predicates", () => {
+    it("answer false for a caller with no participation context", async () => {
+      // service_role has no auth.uid(), so the predicates can only answer
+      // false. Enough to pin the signature, the grant and the fail-closed
+      // default until Phase 4 wires them into policies with real fixtures.
+      const admin = createAdminTestClient();
+
+      const onProduct = await admin.rpc("has_active_participation_on_product", {
+        p_product_id: TEST_IDS.ADMIN,
+      });
+      const inGroup = await admin.rpc("has_active_participation_in_group", {
+        p_group_id: TEST_IDS.ADMIN,
+      });
+
+      expect(onProduct.error).toBeNull();
+      expect(onProduct.data).toBe(false);
+      expect(inGroup.error).toBeNull();
+      expect(inGroup.data).toBe(false);
+    });
+  });
+});

--- a/tests/db/guard-primitives.test.ts
+++ b/tests/db/guard-primitives.test.ts
@@ -9,7 +9,8 @@ import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
  * create_product and update_product are SECURITY INVOKER — their guard runs as
  * the caller. That grant is a new exposed surface, so it is tested directly
  * here rather than only through the eight RPCs that call it: the primitives
- * must refuse every role they don't name and pass the one they do.
+ * must refuse every role they don't name and pass the one they do — and, for
+ * now, reproduce the hand-written guards' NULL-role pass-through verbatim.
  *
  * Which functions are *exposed* is pinned mechanically by access-control.test
  * .ts (assert_self and the two §3.2 predicates are deliberately absent from its
@@ -47,16 +48,19 @@ describe("guard primitives", () => {
       expect(error?.code).toBe("42501");
     });
 
-    it("raises 42501 for a caller with no role at all", async () => {
-      // service_role carries no `sub` claim, so get_user_role() is NULL. The
-      // hand-written guards this replaces compared with `<>`, and `NULL <>
-      // 'admin'` is NULL — the IF never fired and a roleless caller was let
-      // straight through. IS DISTINCT FROM is what closes that.
+    it("KNOWN GAP: lets a caller with no role through", async () => {
+      // service_role carries no `sub` claim, so get_user_role() is NULL, and
+      // `NULL <> 'admin'` is NULL — the IF never fires. The hand-written guards
+      // this primitive replaces behaved the same way, and that pass-through is
+      // load-bearing today: update-product.test.ts and gedu-registration.test.ts
+      // drive admin-gated RPCs through the service-role client. Pinned here so
+      // the hole is visible and Phase 2 closes it as a deliberate test change,
+      // not a surprise.
       const admin = createAdminTestClient();
 
       const { error } = await admin.rpc("assert_admin");
 
-      expect(error?.code).toBe("42501");
+      expect(error).toBeNull();
     });
   });
 


### PR DESCRIPTION
Phase 1 of `docs/db-authorization-architecture.md` — one canonical authorization
assertion for every role-gated function body, plus the ownership predicate three
policies currently re-derive inline. Strictly additive; no policy rewrites (Phase 4)
and no route changes (Phase 3).

Migration: `supabase/migrations/00120_auth_guard_primitives.sql` (pushed to staging,
types + `schema.sql` regenerated in the same commit).

## Added — guard primitives (§3.1)

| Function | Behaviour |
|---|---|
| `assert_role(user_role)` | raises `42501` unless the caller holds the named role |
| `assert_admin()` | delegates to `assert_role('admin')` — one raise site |
| `assert_self(uuid)` | raises `42501` unless `auth.uid()` is the referenced user |

All three read the caller's role **live** via `get_user_role()`, never from a JWT
claim, so demoting or deleting an account takes effect mid-session. All are
`SECURITY INVOKER` — an assertion must carry no privilege of its own.

## Added — ownership predicates (§3.2)

`has_active_participation_on_product(uuid)` and `has_active_participation_in_group(uuid)`
— the "caller is party to an active participation" `EXISTS` subquery currently inlined
in `customers_read_assignments_via_gamers`, `customers_read_groups_via_gamers` and
`gamers_read_own_group`. `SECURITY DEFINER` for the same reason `is_voice_group_member`
is (a policy reading `participations` inline re-enters that table's RLS), still bounded
to `auth.uid()` so they can only answer about the caller. **No policy composes from
them yet** — that's Phase 4.

## Converted to guard-first bodies

The `42501` set found by grepping `schema.sql`. Bodies were extracted verbatim from
`schema.sql` and the guard block is the only edit (`CREATE OR REPLACE`, so grants are
preserved):

`apply_group_changes`, `create_product`, `demote_to_waitlist`,
`get_gedu_assigned_product`, `get_my_assigned_products`,
`get_product_groups_with_details`, `promote_from_waitlist`, `update_product`.

`get_gedu_assigned_product`'s *second* `42501` raise (the "you aren't assigned to this
product" gate) is an ownership check with no matching primitive yet, and is left as is.

## Judgment calls

**The NULL-role pass-through is preserved, deliberately — and this one bit me.** The
hand-written guards compare with `<>`, so when the caller has no `profiles` row
`get_user_role()` is NULL, `NULL <> 'admin'` is NULL, the `IF` never fires, and the
caller is let **through**. I first "fixed" this with `IS DISTINCT FROM`, having grepped
for `service_role` callers and found none — the grep was truncated and I missed that
`tests/db/update-product.test.ts` drives `update_product` through the service-role
client. CI failed seven tests, which is the system working. Phase 1 promised a pure
refactor, so `assert_role` now reproduces `<>` verbatim, hole included, and the hole is
pinned by a `KNOWN GAP` test so it can't move in either direction unnoticed. Closing it
needs the Phase 2 matrix to pin every caller *and* to give those db tests a caller that
actually holds the role — recorded in the doc under Phase 2. `assert_self` has no legacy
callers and does fail closed; `assert_role` still refuses a NULL *argument*, since
nothing can satisfy an assertion that names no role.

**Grant surface.** `assert_role` / `assert_admin` are granted to `authenticated` and
allowlisted, because `create_product` and `update_product` are `SECURITY INVOKER` —
their guard runs as the caller, so the caller needs `EXECUTE`. The exposure adds no
capability: the assertions answer only "do you hold role X", which `get_user_role()`
and `is_admin()` already tell the caller. `assert_self` and both predicates get
`service_role` only — they're reached from `SECURITY DEFINER` bodies (which execute as
the owner) and have no policy consumer yet; the phase that puts them in a policy grants
them then. `REVOKE ALL … FROM PUBLIC` on all five, per the no-default-grants regime.

**Message unification.** `create_product` / `update_product` said "Only admins can
create/update products"; they now say "Forbidden" like every other guard. The ERRCODE —
what routes and db tests actually match on — is unchanged, and the route-level
`requireRole("admin")` means this message was already unreachable through the API.

**`set_gedu_verified` deliberately not converted.** It's admin-gated (`is_admin()`) but
raises a generic error, so the `42501` grep doesn't find it — and a db test calls it
through the service-role client, i.e. it depends on the same NULL-role pass-through.
Reconciling it is the same piece of Phase 2 work.

**Staging kept in sync without a second migration.** 00120 is idempotent (`CREATE OR
REPLACE` / `REVOKE` / `GRANT` only), so the correction above was applied by repairing
the migration history and re-pushing the corrected file, rather than stacking an 00121
that undoes part of 00120.

## Tests

- `tests/db/access-control.test.ts` — `assert_role` / `assert_admin` added to the
  authenticated allowlist with the intent comment above. The absence of `assert_self`
  and the two predicates is what mechanically pins their narrower grant.
- `tests/db/guard-primitives.test.ts` (new) — per-role pass/refuse for `assert_admin`
  and `assert_role`, the `KNOWN GAP` roleless-caller case, and a fail-closed check on
  the two predicates.
- Existing per-RPC `42501` tests (apply-group-changes, update-product, waitlist-admin,
  get-gedu-assigned-product) are unchanged and cover the conversions.

`npm run lint` and `npm run type-check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
