### PR TITLE
refactor(db-auth): Phase 2 — verification spine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,11 @@ always-on tripwires:
   regenerated before committing** — DB tests and type-check depend on
   `database.types.ts` matching the schema.
 - **Every new object (table, view, sequence, function) needs an explicit `GRANT`** — no
-  Data API access by default, not even for `service_role`. Grant per role, and add any
-  `authenticated`/`anon` function to the allowlist in `tests/db/access-control.test.ts`.
+  Data API access by default, not even for `service_role`. Grant per role. A function
+  exposed to `authenticated`/`anon` additionally has to be **classified in the DB test
+  suite's authorization spine** — role-gated (guard-first body + its permitted roles) or
+  self-scoping (named to a scope test) — and a table that gains a write grant needs a
+  write-IDOR case. The spine's completeness checks fail the build otherwise.
 - **All new tables must enable RLS**, and **RLS INSERT/UPDATE policies must authorize
   both the actor AND the target** (checking only `column = auth.uid()` is an IDOR hole).
 

--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -1,10 +1,11 @@
 # Database Authorization Architecture
 
 **Status:** target architecture + migration plan. The conventions in §2–§3 are how new
-code is written today; §5 Phase 1 (guard primitives + ownership predicates) has landed,
-and the verification spine (§3.4) and the route sweep (§5 Phase 3) are not yet built.
-This is the single source of truth for the refactor — when someone says "let's do the DB
-authorization refactor," this is the doc to read and act on.
+code is written today; §5 Phase 1 (guard primitives + ownership predicates) and Phase 2
+(the §3.4 verification spine) have landed, and the route sweep (§5 Phase 3) and RLS
+completeness (Phase 4) are not yet built. This is the single source of truth for the
+refactor — when someone says "let's do the DB authorization refactor," this is the doc to
+read and act on.
 
 **Execution contract.** This doc is written so a fresh Claude Code session can execute
 the refactor from it. Before acting on any phase:
@@ -172,21 +173,28 @@ to construct it.
 
 ### Existing verification
 
-What the DB test suite already covers (don't rebuild this — extend it):
+What the DB test suite covers (don't rebuild this — extend it):
 
-- **Static** (the access-control test): function-grant allowlists for `authenticated`
-  and `anon`; every public table has RLS; every `SECURITY DEFINER` function sets
-  `search_path`; table-level write grants match an allowlist. Column-level grants are
-  explicitly out of scope today.
-- **Behavioral, handwritten per-target**: wrong-role 42501 tests for the admin- and
-  gedu-gated RPCs; SELECT-side IDOR tests (customer A cannot read customer B's rows)
-  for participations, payments, refunds, groups, and products; scope tests for the
-  self-scoping `get_my_*` and PIN RPCs.
+- **The spine** (§3.4, landed in Phase 2): static conformance, the behavioral role × RPC
+  matrix, the write-path IDOR loop, the column-grant audit, and the completeness check
+  that ties the exposed surface to one of two classifications. Adding an exposed
+  function, a write grant, or a column grant without its annotation and test now fails
+  CI.
+- **Static, grant-level** (the access-control test): every public table has RLS; every
+  `SECURITY DEFINER` function sets `search_path`; table-level write grants match a
+  bidirectional allowlist; `anon` holds no table write grant. The *function*-grant
+  allowlists it used to carry were retired when the spine subsumed them.
+- **Behavioral, handwritten per-target**: SELECT-side IDOR tests (customer A cannot read
+  customer B's rows) for participations, payments, refunds, groups, and products; the
+  per-RPC happy-path and business-rule tests. These are the fixture-bearing coverage the
+  fixture-free matrix cannot replace.
 - **Substrate**: `tests/db/helpers.ts` signs in as any seeded role (admin, customer,
-  second customer, gedu, gamer) with deterministic UUIDs; CI runs the suite against a
-  local Supabase stack.
+  second customer, gedu, gamer) with deterministic UUIDs, hands out an `anon` client and
+  a raw access token, and can post an RPC call straight to PostgREST (which is how the
+  matrix passes `null` for every argument without fighting the generated arg types); CI
+  runs the suite against a local Supabase stack.
 
-The spine (§3.4) systematizes this; it is not greenfield.
+The spine systematized this; it was not greenfield.
 
 ---
 
@@ -286,8 +294,8 @@ guarantees nothing escapes both.
    and every allowlist entry names its scope test. This closes the two silent holes:
    an RPC annotated permissively passes check 2 vacuously, and an allowlisted function
    with no scope test is vetted by nothing. Allowlist growth is this design's failure
-   mode; check 5 is what polices it. Once 1+2+5 are in place they subsume the current
-   grant-allowlist test — retire it then, not before.
+   mode; check 5 is what polices it. 1+2+5 subsume the old grant-allowlist test, which
+   was retired with them (§5 Phase 2).
 
 ### 3.5 The RPC shape under this architecture
 
@@ -382,30 +390,51 @@ bodies (the small `42501` set — regrep `schema.sql` to enumerate) to call them
 policy rewrites in this phase — the predicates exist but no policy composes from them
 until Phase 4, so they carry no `authenticated` grant yet.
 
-Two things Phase 2 inherits from it:
+Both items it deferred were closed in Phase 2: the role assertion's NULL-role
+pass-through (`<>` → `IS DISTINCT FROM`) and the unconverted `set_gedu_verified`.
 
-- **The role assertion still lets a caller with *no* role through.** The comparison is
-  `<>`, so a NULL role (no `profiles` row — a `service_role` connection, or a session
-  whose profile was deleted) evaluates to NULL, the `IF` never fires, and the caller
-  passes. Phase 1 reproduced that verbatim rather than fixing it, because it is
-  load-bearing: db tests drive admin-gated RPCs through the service-role client and only
-  work because of it. Closing it means switching to `IS DISTINCT FROM` *and* giving those
-  tests a caller that actually holds the role — which is matrix work, so it belongs here
-  in Phase 2, not in a refactor that promised no behavior change. (The self assertion has
-  no legacy callers and already fails closed.)
-- **`set_gedu_verified` is still unconverted.** It is role-gated (`is_admin()`) but
-  raises a generic error rather than `42501`, so the `42501` grep does not find it — and
-  it depends on the same NULL-role pass-through. Reconciling it (canonical code + a
-  caller that actually holds the role) is the same piece of work.
+### Phase 2 — the verification spine — **landed**
 
-### Phase 2 — the verification spine
+The five checks of §3.4 live in the DB test suite. The two classifications — role-gated
+RPCs with their permitted roles, and self-scoping helpers with the scope test that vets
+each one — are the spine's data; everything else is derived from the PostgreSQL catalogs
+at test time, so the surface cannot drift out from under them. The grant-level function
+allowlists were retired once checks 1+2+5 were green, as planned.
 
-Implement the five checks of §3.4 in the DB test suite. Build the matrix annotations
-and the self-scoping allowlist (seed both from the current access-control allowlist
-and its intent comments); write scope tests for any allowlisted function that lacks
-one. Keep the current grant-allowlist test until checks 1+2+5 subsume it, then retire
-it. After this phase, a forgotten guard, a vacuous annotation, or an unvetted exposure
-fails CI.
+Three judgment calls worth carrying forward:
+
+- **Check 1 is applied to every plpgsql function exposed to `authenticated`, not only
+  the `SECURITY DEFINER` ones.** `create_product`/`update_product` are `SECURITY
+  INVOKER` and would have escaped the narrower reading, which is why the guard
+  primitives carry an `authenticated` grant in the first place. The partition is
+  "role-gated or self-scoping", and it is the same partition check 5 enforces.
+- **The matrix asserts both directions.** For a disallowed (role, RPC) pair the call
+  must come back `42501`; for a permitted one it must come back *anything but* `42501`.
+  Without the second half, annotating every role as permitted would pass vacuously —
+  which §3.4 names as the check's own failure mode. One RPC opts out of the positive
+  half (`get_gedu_assigned_product` raises a second `42501` for a gedu with no
+  assignment, which is its ownership gate, not its role gate); the opt-out carries its
+  reason inline.
+- **INSERT is out of scope for the write-IDOR loop.** A blocked INSERT and a constraint
+  violation are both "an error", so the check would risk passing for the wrong reason
+  unless every case carried a fully valid payload. UPDATE/DELETE need no payload: RLS
+  simply filters the row out and the statement affects zero rows. INSERT `WITH CHECK`
+  stays with the per-feature RLS tests, which do supply valid payloads.
+
+What Phase 3 inherits:
+
+- **Every new RPC needs a matrix annotation or an allowlist entry with a scope test**,
+  and every new write grant needs an IDOR case — the completeness checks fail the build
+  otherwise. That is the intended cost, and it is what the per-route checklist below
+  already anticipates.
+- **A dead grant worth folding into a later phase**: `authenticated` holds `UPDATE` on
+  `whatsapp_messages` with no UPDATE policy behind it, so it authorizes nothing today.
+  The IDOR loop covers it, but the grant should be revoked when that table is next
+  touched.
+- **The Phase 1 grant asymmetry stands**: `assert_self` and the two §3.2 participation
+  predicates remain `service_role`-only, because nothing composes from them yet. The
+  phase that puts them in a policy or a `SECURITY INVOKER` body grants them then — and
+  check 5 will require the classification at that point.
 
 ### Phase 3 — the route sweep
 

--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -431,6 +431,11 @@ What Phase 3 inherits:
   `whatsapp_messages` with no UPDATE policy behind it, so it authorizes nothing today.
   The IDOR loop covers it, but the grant should be revoked when that table is next
   touched.
+- **`can_read_product` answers `NULL`, not `false`, for a caller with no profiles row.**
+  Its first disjunct compares `get_user_role()` to `'admin'`, which is NULL for `anon`,
+  and `NULL OR false` is NULL. Harmless where it is used — a policy's `USING` clause
+  treats NULL as deny — and the scope test pins both the NULL and the deny. Worth a
+  `COALESCE(…, false)` when Phase 4 next touches that predicate, so the boolean is total.
 - **The Phase 1 grant asymmetry stands**: `assert_self` and the two §3.2 participation
   predicates remain `service_role`-only, because nothing composes from them yet. The
   phase that puts them in a policy or a `SECURITY INVOKER` body grants them then — and

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1229,6 +1229,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      _list_column_grants: {
+        Args: { p_grantee: string }
+        Returns: {
+          column_name: string
+          privilege_type: string
+          table_name: string
+        }[]
+      }
       _list_cron_jobs: {
         Args: never
         Returns: {
@@ -1237,12 +1245,17 @@ export type Database = {
           schedule: string
         }[]
       }
-      _list_rpc_access: {
+      _list_function_authorization_surface: {
         Args: never
         Returns: {
           anon_access: boolean
+          argument_names: string[]
           authenticated_access: boolean
+          body: string
+          function_language: string
           function_name: string
+          is_security_definer: boolean
+          is_strict: boolean
         }[]
       }
       _list_security_definer_without_search_path: {

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -146,8 +146,8 @@ CLI v2.106.0, and hosted DBs since `00099` proactively revoked the legacy auto-e
 default privileges (ahead of Supabase's 2026-10-30 platform flip); `00095` backfilled
 explicit grants for everything older. Grant deliberately per role —
 `GRANT EXECUTE ... TO authenticated` for browser-called RPCs, `TO service_role` for
-admin-client-called ones — and add any function exposed to `authenticated`/`anon` to the
-allowlist in `tests/db/access-control.test.ts`. A forgotten grant fails closed as
+admin-client-called ones — and classify any function exposed to `authenticated`/`anon`
+in the DB test suite's authorization spine (see below). A forgotten grant fails closed as
 `permission denied` in CI's DB tests; never "fix" that with blanket `ON ALL TABLES`
 grants or by re-adding auto-expose `ALTER DEFAULT PRIVILEGES` — the failure is the
 feature. The `REVOKE EXECUTE` boilerplate in older migrations is historical and harmless.
@@ -161,9 +161,27 @@ is a privilege escalation vector.
 Checking only `column = auth.uid()` is insufficient — also verify the user is authorized
 to reference the target entity (prevents IDOR).
 
-The DB test `tests/db/access-control.test.ts` enforces the function and RLS rules — it
-queries PostgreSQL catalogs and fails if any non-allowlisted function is callable or any
-table lacks RLS. (DB tests run against a real Postgres in CI — see `tests/CLAUDE.md`.)
+**Rule: an exposed function's *body* is verified, not just its grant.** The DB test
+suite's **authorization spine** (`docs/db-authorization-architecture.md` §3.4) queries the
+PostgreSQL catalogs and requires every function reachable by `authenticated` to be one of
+two things, with nothing escaping both:
+
+- **Role-gated** — a `plpgsql` body whose *first statement* is a guard primitive
+  (`PERFORM public.assert_admin();` / `assert_role(…)` / `assert_self(…)`, all raising
+  ERRCODE `42501`), annotated with the roles it permits. The spine then signs in as every
+  other role, calls it with all-NULL arguments, and requires the forbidden error — and
+  signs in as a permitted role and requires anything *but* it, so a permissive annotation
+  cannot pass vacuously.
+- **Self-scoping** — every read and write keyed to `auth.uid()`, no guard by design,
+  named to a scope test that proves it cannot answer about anyone else. `LANGUAGE sql`
+  functions have no first statement, so they can only ever be this.
+
+Alongside it: no exposed function may be `STRICT` (a `STRICT` function skips its body on
+NULL input, so its guard would never run); no privilege-bearing column may be reachable by
+an `UPDATE` grant, at table or column level; and every table `authenticated` can UPDATE or
+DELETE needs a write-IDOR case proving a wrong user's statement affects zero rows. RLS
+coverage (every table has it) and the table-level write-grant allowlist live in the
+access-control test. (DB tests run against a real Postgres in CI — see `tests/CLAUDE.md`.)
 
 ## `now()` is frozen at transaction start
 

--- a/supabase/migrations/00121_auth_verification_spine.sql
+++ b/supabase/migrations/00121_auth_verification_spine.sql
@@ -1,0 +1,168 @@
+-- Phase 2 of the DB authorization refactor (docs/db-authorization-architecture.md
+-- §3.4 / §5 Phase 2): the verification spine.
+--
+-- The spine itself is test code. This migration supplies the three things the
+-- tests cannot express from the client side, plus the two behaviour changes
+-- Phase 1 explicitly deferred to Phase 2.
+--
+-- 1. CATALOG INTROSPECTION for the static checks
+--
+--    _list_function_authorization_surface() replaces _list_rpc_access(). The old
+--    RPC answered only "can authenticated/anon EXECUTE this?", which is the
+--    grant-level half Phase 1's doc calls insufficient. The spine's check 1 also
+--    needs the function's language (plpgsql bodies have a first statement; sql
+--    bodies do not), whether it is SECURITY DEFINER, whether it is STRICT (a
+--    STRICT function returns NULL on NULL input WITHOUT running its body, which
+--    would silently void the all-NULL calling convention of the role × RPC
+--    matrix), the body itself — so the test can assert the guard primitive really
+--    is the first statement — and the input argument names, so the matrix can
+--    BUILD its all-NULL argument object from the catalog instead of a
+--    hand-copied parameter list that goes stale the first time someone adds a
+--    parameter. One RPC, one round trip, no overlap.
+--
+--    _list_column_grants(text) closes the blind spot named in the access-control
+--    test's own comment: information_schema.table_privileges cannot see
+--    column-level grants, so `profiles`' column-scoped UPDATE was untestable and
+--    a column grant on a "grant-locked" table would pass every check we had.
+--    information_schema.column_privileges is the union of relation-level and
+--    attribute-level ACLs, i.e. the *effective* per-column privilege — exactly
+--    what §3.4 check 4 audits.
+--
+-- 2. assert_role NO LONGER LETS A ROLELESS CALLER THROUGH (§5 Phase 1 inherited
+--    item 1). `(SELECT get_user_role()) <> p_role` is NULL — not true — when the
+--    caller has no profiles row, so the IF never fired and the caller passed.
+--    IS DISTINCT FROM makes it fail closed.
+--
+--    Verified safe before writing this: no src/ path calls a converted role-gated
+--    RPC through createAdminClient. Every call site
+--    (apply_group_changes, create_product, update_product,
+--    get_product_groups_with_details, promote_from_waitlist, demote_to_waitlist,
+--    get_gedu_assigned_product, get_my_assigned_products, set_gedu_verified)
+--    runs on the user-bound client from requireRole(), or on the browser client
+--    through a service class. No pg_cron job and no other SQL function calls one
+--    either. The only callers that relied on the pass-through were db tests
+--    driving admin RPCs through the service-role client; they now sign in as the
+--    seeded admin instead.
+--
+--    Who this newly refuses, deliberately: a session whose profiles row was
+--    deleted mid-session, and a service_role connection. Both SHOULD be refused —
+--    the first is the revocation case §3.1 exists for, the second has no business
+--    impersonating a role it cannot name.
+--
+-- 3. set_gedu_verified CONVERTED to the canonical guard (§5 Phase 1 inherited
+--    item 2). It was role-gated by a hand-written `IF NOT is_admin()` that raised
+--    a generic error, which is why the `42501` grep did not find it in Phase 1.
+--    Its refusal code becomes 42501 like every other role-gated RPC; the route
+--    layer keys on status, not on this message, and the only DB test asserting on
+--    it asserted "an error, any error". search_path moves to the canonical empty
+--    form while we are here (§3.5) — the body was already fully qualified.
+
+-- ---------------------------------------------------------------------------
+-- 1. Catalog introspection for §3.4 checks 1, 4 and 5
+-- ---------------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS public._list_rpc_access();
+DROP FUNCTION IF EXISTS public._list_function_authorization_surface();
+
+CREATE FUNCTION public._list_function_authorization_surface()
+RETURNS TABLE(
+  function_name text,
+  function_language text,
+  is_security_definer boolean,
+  is_strict boolean,
+  authenticated_access boolean,
+  anon_access boolean,
+  argument_names text[],
+  body text
+)
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+  SELECT
+    p.proname::text,
+    l.lanname::text,
+    p.prosecdef,
+    p.proisstrict,
+    pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE'),
+    pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE'),
+    -- proargnames carries OUT/TABLE column names after the input args, so slice
+    -- to pronargs. NULL when the function takes no arguments at all.
+    COALESCE(p.proargnames[1:p.pronargs], '{}'::text[]),
+    p.prosrc::text
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+  JOIN pg_catalog.pg_language  l ON l.oid = p.prolang
+  WHERE n.nspname = 'public'
+    -- Trigger functions are not a callable surface: PostgREST cannot invoke them
+    -- and PostgreSQL only runs them from a trigger context. Same exclusion the
+    -- RPC-access view this replaces used.
+    AND p.prorettype <> 'pg_catalog.trigger'::pg_catalog.regtype;
+$$;
+
+CREATE OR REPLACE FUNCTION public._list_column_grants(p_grantee text)
+RETURNS TABLE(table_name text, column_name text, privilege_type text)
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+  SELECT c.table_name::text, c.column_name::text, c.privilege_type::text
+  FROM information_schema.column_privileges c
+  WHERE c.grantee = p_grantee
+    AND c.table_schema = 'public'
+  ORDER BY 1, 2, 3;
+$$;
+
+REVOKE ALL ON FUNCTION public._list_function_authorization_surface() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._list_function_authorization_surface() TO service_role;
+
+REVOKE ALL ON FUNCTION public._list_column_grants(p_grantee text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._list_column_grants(p_grantee text) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. assert_role fails closed on a roleless caller
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.assert_role(p_role public.user_role) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path = ''
+    AS $$
+BEGIN
+  -- A NULL p_role is a caller bug — no role name was asked for, so nothing can
+  -- satisfy the assertion. Refuse before the comparison can swallow it.
+  IF p_role IS NULL THEN
+    RAISE EXCEPTION 'assert_role requires a role' USING ERRCODE = '42501';
+  END IF;
+
+  -- IS DISTINCT FROM, not `<>`: a caller with no profiles row has a NULL role,
+  -- and `NULL <> 'admin'` is NULL, which an IF treats as false — that let a
+  -- roleless caller straight through. NULL is distinct from every role, so this
+  -- form refuses them.
+  IF (SELECT public.get_user_role()) IS DISTINCT FROM p_role THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. set_gedu_verified on the canonical guard
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.set_gedu_verified(p_gedu_id uuid, p_verified boolean) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+BEGIN
+  PERFORM public.assert_admin();
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.profiles WHERE id = p_gedu_id AND role = 'gedu'
+  ) THEN
+    RAISE EXCEPTION 'set_gedu_verified: % is not a gedu', p_gedu_id;
+  END IF;
+
+  UPDATE public.gedu_profiles
+  SET verified    = p_verified,
+      verified_at = CASE WHEN p_verified THEN now() ELSE NULL END,
+      verified_by = CASE WHEN p_verified THEN (SELECT auth.uid()) ELSE NULL END
+  WHERE user_id = p_gedu_id;
+END;
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -170,6 +170,22 @@ CREATE TYPE public.user_role AS ENUM (
 
 
 --
+-- Name: _list_column_grants(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._list_column_grants(p_grantee text) RETURNS TABLE(table_name text, column_name text, privilege_type text)
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+  SELECT c.table_name::text, c.column_name::text, c.privilege_type::text
+  FROM information_schema.column_privileges c
+  WHERE c.grantee = p_grantee
+    AND c.table_schema = 'public'
+  ORDER BY 1, 2, 3;
+$$;
+
+
+--
 -- Name: _list_cron_jobs(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -183,21 +199,32 @@ $$;
 
 
 --
--- Name: _list_rpc_access(); Type: FUNCTION; Schema: public; Owner: -
+-- Name: _list_function_authorization_surface(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public._list_rpc_access() RETURNS TABLE(function_name text, authenticated_access boolean, anon_access boolean)
+CREATE FUNCTION public._list_function_authorization_surface() RETURNS TABLE(function_name text, function_language text, is_security_definer boolean, is_strict boolean, authenticated_access boolean, anon_access boolean, argument_names text[], body text)
     LANGUAGE sql STABLE SECURITY DEFINER
     SET search_path TO ''
     AS $$
   SELECT
-    p.proname::text AS function_name,
-    has_function_privilege('authenticated', p.oid, 'EXECUTE') AS authenticated_access,
-    has_function_privilege('anon', p.oid, 'EXECUTE') AS anon_access
+    p.proname::text,
+    l.lanname::text,
+    p.prosecdef,
+    p.proisstrict,
+    pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE'),
+    pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE'),
+    -- proargnames carries OUT/TABLE column names after the input args, so slice
+    -- to pronargs. NULL when the function takes no arguments at all.
+    COALESCE(p.proargnames[1:p.pronargs], '{}'::text[]),
+    p.prosrc::text
   FROM pg_catalog.pg_proc p
   JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+  JOIN pg_catalog.pg_language  l ON l.oid = p.prolang
   WHERE n.nspname = 'public'
-    AND p.prorettype != 'pg_catalog.trigger'::pg_catalog.regtype;
+    -- Trigger functions are not a callable surface: PostgREST cannot invoke them
+    -- and PostgreSQL only runs them from a trigger context. Same exclusion the
+    -- RPC-access view this replaces used.
+    AND p.prorettype <> 'pg_catalog.trigger'::pg_catalog.regtype;
 $$;
 
 
@@ -381,11 +408,11 @@ BEGIN
     RAISE EXCEPTION 'assert_role requires a role' USING ERRCODE = '42501';
   END IF;
 
-  -- `<>` (not IS DISTINCT FROM) is deliberate and behaviour-preserving: it
-  -- reproduces the hand-written guards exactly, including their NULL-role
-  -- pass-through for callers with no profiles row. See the header note — closing
-  -- that is Phase 2 work, once the matrix has pinned every caller.
-  IF (SELECT public.get_user_role()) <> p_role THEN
+  -- IS DISTINCT FROM, not `<>`: a caller with no profiles row has a NULL role,
+  -- and `NULL <> 'admin'` is NULL, which an IF treats as false — that let a
+  -- roleless caller straight through. NULL is distinct from every role, so this
+  -- form refuses them.
+  IF (SELECT public.get_user_role()) IS DISTINCT FROM p_role THEN
     RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
   END IF;
 END;
@@ -2060,12 +2087,10 @@ $$;
 
 CREATE FUNCTION public.set_gedu_verified(p_gedu_id uuid, p_verified boolean) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER
-    SET search_path TO 'public'
+    SET search_path TO ''
     AS $$
 BEGIN
-  IF NOT public.is_admin() THEN
-    RAISE EXCEPTION 'set_gedu_verified: only admins may verify gedus';
-  END IF;
+  PERFORM public.assert_admin();
 
   IF NOT EXISTS (
     SELECT 1 FROM public.profiles WHERE id = p_gedu_id AND role = 'gedu'
@@ -2076,7 +2101,7 @@ BEGIN
   UPDATE public.gedu_profiles
   SET verified    = p_verified,
       verified_at = CASE WHEN p_verified THEN now() ELSE NULL END,
-      verified_by = CASE WHEN p_verified THEN (select auth.uid()) ELSE NULL END
+      verified_by = CASE WHEN p_verified THEN (SELECT auth.uid()) ELSE NULL END
   WHERE user_id = p_gedu_id;
 END;
 $$;
@@ -4966,6 +4991,14 @@ GRANT USAGE ON SCHEMA public TO service_role;
 
 
 --
+-- Name: FUNCTION _list_column_grants(p_grantee text); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public._list_column_grants(p_grantee text) FROM PUBLIC;
+GRANT ALL ON FUNCTION public._list_column_grants(p_grantee text) TO service_role;
+
+
+--
 -- Name: FUNCTION _list_cron_jobs(); Type: ACL; Schema: public; Owner: -
 --
 
@@ -4974,11 +5007,11 @@ GRANT ALL ON FUNCTION public._list_cron_jobs() TO service_role;
 
 
 --
--- Name: FUNCTION _list_rpc_access(); Type: ACL; Schema: public; Owner: -
+-- Name: FUNCTION _list_function_authorization_surface(); Type: ACL; Schema: public; Owner: -
 --
 
-REVOKE ALL ON FUNCTION public._list_rpc_access() FROM PUBLIC;
-GRANT ALL ON FUNCTION public._list_rpc_access() TO service_role;
+REVOKE ALL ON FUNCTION public._list_function_authorization_surface() FROM PUBLIC;
+GRANT ALL ON FUNCTION public._list_function_authorization_surface() TO service_role;
 
 
 --

--- a/tests/db/access-control.test.ts
+++ b/tests/db/access-control.test.ts
@@ -5,19 +5,21 @@ import type { Database } from "@/types/database.types";
 import { createAdminTestClient } from "./helpers";
 
 /**
- * Row shapes of the catalog-introspection RPCs (`_list_rpc_access`,
- * `_list_table_grants`). These query information_schema/pg_catalog, so no
- * src contract exists (or should) — validating the shape at runtime in the
- * test is the honest move.
+ * Grant- and schema-level access control: which tables `authenticated` and
+ * `anon` may write, that every SECURITY DEFINER function pins its search_path,
+ * and that every table has RLS.
+ *
+ * The *function*-grant allowlists that used to live here are gone. They proved
+ * someone had meant to expose a function, not that its body enforced anything —
+ * an admin-only RPC with a forgotten role check passed them. They are superseded
+ * by authorization-spine.test.ts (docs/db-authorization-architecture.md §3.4),
+ * whose checks 1, 2 and 5 together require every function exposed to
+ * `authenticated` to be classified as role-gated (and then behaviourally proven
+ * to refuse every other role) or self-scoping (and then named to a scope test),
+ * with the anon surface pinned the same way. That is a strict superset of what
+ * the allowlists asserted, so keeping both would be two places to update and one
+ * of them weaker.
  */
-const rpcAccessRows = z.array(
-  z.object({
-    function_name: z.string(),
-    authenticated_access: z.boolean(),
-    anon_access: z.boolean(),
-  })
-);
-
 const tableGrantRows = z.array(
   z.object({
     table_name: z.string(),
@@ -25,132 +27,11 @@ const tableGrantRows = z.array(
   })
 );
 
-/**
- * Allowlist of functions that authenticated users can call via PostgREST /rpc/.
- * If a new function should be public, add it here. Otherwise, REVOKE EXECUTE
- * from authenticated/anon/public in the migration.
- */
-const AUTHENTICATED_ALLOWLIST = new Set([
-  "get_user_role",
-  "is_admin",
-  "is_parent_of",
-  // RLS predicate for product-scoped read policies (00069). Evaluated in the
-  // caller's context by the read_*_via_product policies (TO anon,
-  // authenticated), so the role must hold EXECUTE — same as get_user_role.
-  "can_read_product",
-  "get_my_gamers",
-  "get_my_parents",
-  // Read-time signals for the dashboard payment-problem + access-until badges
-  // (00093, supersedes 00085). auth.uid()-scoped (customer_id OR gamer_id),
-  // returns participation id + status + current_period_end — no money. Called
-  // from the browser by both parents and gamers.
-  "get_my_participation_subscription_states",
-
-  "create_product",
-  "update_product",
-
-  "get_product_groups_with_details",
-  "apply_group_changes",
-  "get_gedu_assigned_product",
-  "get_my_assigned_products",
-
-  // Admin waitlist transitions from the groups panel (00118). SECURITY-checked
-  // internally (get_user_role() = 'admin'), so they run with the admin's own
-  // JWT — like apply_group_changes, their drag-UI sibling — hence authenticated
-  // EXECUTE. A non-admin caller is rejected by the internal role gate.
-  "promote_from_waitlist",
-  "demote_to_waitlist",
-  // "You're #N" read for parents/gamers (00118). SECURITY DEFINER so it can
-  // count rows the caller's RLS hides, but owner-authorized (customer_id OR
-  // gamer_id) and returns only the integer position — no other family's data.
-  "get_waitlist_position",
-
-  // Parent PIN (00075). auth.uid()-scoped, touch only the caller's own
-  // customer_profiles row; called from the PIN API routes via the user's
-  // server client. The pin_hash itself is never returned to the client.
-  "set_my_pin",
-  "verify_my_pin",
-  "pin_is_set",
-
-  // Voice zones (00103). RLS predicate helpers for voice_zones /
-  // voice_private_zone_occupants — evaluated in the caller's context by those
-  // tables' policies, so authenticated must hold EXECUTE (same rationale as
-  // can_read_product). SECURITY DEFINER with SET search_path; they only ever
-  // return a boolean derived from the caller's auth.uid(), no data leak.
-  "is_voice_group_member",
-  "is_voice_group_moderator",
-
-  // Authorization guard primitives (00120, docs/db-authorization-architecture
-  // .md §3.1). They raise the canonical forbidden 42501 or return void — they
-  // hold no privilege of their own (SECURITY INVOKER) and answer only "does the
-  // caller hold role X", which get_user_role() and is_admin() already tell the
-  // caller, so exposing them adds no capability and leaks nothing. authenticated
-  // needs EXECUTE because create_product / update_product are SECURITY INVOKER:
-  // their guard runs as the caller, not as the function owner. The third
-  // primitive, assert_self, has no SECURITY INVOKER consumer yet and is
-  // therefore service_role-only — deliberately NOT listed here.
-  "assert_role",
-  "assert_admin",
-
-  // Gedu verification (00111). Admin verifies / un-verifies a gedu from the
-  // admin user-detail page via their own authenticated session. SECURITY
-  // DEFINER, but self-gates with is_admin() and stamps verified_by/verified_at
-  // server-side. (register_gedu, which grants the gedu role, is service_role
-  // only — never authenticated — so it intentionally is NOT listed here.)
-  "set_gedu_verified",
-]);
-
-/**
- * Allowlist of functions that anonymous (unauthenticated) users can call.
- */
-const ANON_ALLOWLIST = new Set([
-  // See AUTHENTICATED_ALLOWLIST: the child-table read policies are
-  // TO anon, authenticated, so anon evaluates can_read_product too (it
-  // returns true only for the public visible-published branch).
-  "can_read_product",
-]);
-
 describe("Access Control", () => {
   let admin: SupabaseClient<Database>;
 
   beforeAll(() => {
     admin = createAdminTestClient();
-  });
-
-  it("only allowlisted RPCs are callable by authenticated users", async () => {
-    const { data, error } = await admin.rpc("_list_rpc_access");
-
-    expect(error).toBeNull();
-    expect(data).not.toBeNull();
-
-    const authenticatedFunctions = rpcAccessRows
-      .parse(data)
-      .filter((row) => row.authenticated_access)
-      .map((row) => row.function_name);
-
-    const unexpected = authenticatedFunctions.filter(
-      (name) => !AUTHENTICATED_ALLOWLIST.has(name)
-    );
-
-    expect(unexpected).toEqual([]);
-  });
-
-  it("only allowlisted RPCs are callable by anon users", async () => {
-    const { data, error } = await admin.rpc("_list_rpc_access");
-
-    expect(error).toBeNull();
-    expect(data).not.toBeNull();
-
-    const anonFunctions = rpcAccessRows
-      .parse(data)
-      .filter((row) => row.anon_access)
-      .map((row) => row.function_name);
-
-    const unexpected = anonFunctions.filter(
-      (name) => !ANON_ALLOWLIST.has(name)
-    );
-
-    expect(unexpected).toEqual([]);
   });
 
   it("table-level grants match allowlist (bidirectional: no excess, no missing)", async () => {
@@ -167,7 +48,11 @@ describe("Access Control", () => {
     // profiles is intentionally NOT in this allowlist: it uses column-level
     // UPDATE grants on (first_name, last_name, phone, spoken_languages) rather
     // than table-level UPDATE. Column privileges live in information_schema
-    // .column_privileges and are out of scope for _list_table_grants.
+    // .column_privileges — out of scope for _list_table_grants, and covered by
+    // the column-grant audit in authorization-spine.test.ts.
+    //
+    // Every table listed here also needs a write-IDOR case in
+    // write-idor.test.ts; that file fails if one is missing.
     const WRITE_GRANT_ALLOWLIST = new Map<string, Set<string>>([
       ["parent_gamer", new Set(["DELETE"])],
       ["gamer_profiles", new Set(["UPDATE"])],

--- a/tests/db/authorization-spine.test.ts
+++ b/tests/db/authorization-spine.test.ts
@@ -1,0 +1,567 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import type { Database } from "@/types/database.types";
+import { accessTokenFor, callRpcRaw, createAdminTestClient } from "./helpers";
+import { TEST_CREDENTIALS } from "./constants";
+
+/**
+ * The verification spine — docs/db-authorization-architecture.md §3.4.
+ *
+ * Four of the five checks live here (the write-path IDOR loop is check 3, in
+ * write-idor.test.ts, because it needs table fixtures rather than catalog
+ * introspection):
+ *
+ *   1. Static conformance — every plpgsql function reachable by `authenticated`
+ *      guards first or is declared self-scoping; `sql`-language functions are
+ *      self-scoping by construction; nothing is anon-reachable unguarded; no
+ *      exposed function is STRICT.
+ *   2. Behavioural role × RPC matrix — every role-gated RPC refuses every role
+ *      it does not name, called with all-NULL arguments.
+ *   4. Column-grant audit — no UPDATE privilege reaches a privilege-bearing
+ *      column, and the column-level write surface is confined to `profiles`.
+ *   5. Completeness — every exposed function is in exactly one of the two
+ *      classifications, and every self-scoping entry names a real scope test.
+ *
+ * Checks 1, 2 and 5 interlock: 1 forces a guard to exist, 2 proves the guard
+ * behaves as annotated, 5 guarantees nothing escapes both. They replace the
+ * grant-level "is this function on the allowlist" test that access-control.test
+ * .ts used to carry — that test proved someone had *meant* to expose a function,
+ * not that its body enforced anything.
+ */
+
+const ROLES = ["admin", "customer", "gedu", "gamer"] as const;
+type Role = (typeof ROLES)[number];
+
+const CREDENTIALS: Record<Role, { email: string; password: string }> = {
+  admin: TEST_CREDENTIALS.ADMIN,
+  customer: TEST_CREDENTIALS.CUSTOMER,
+  gedu: TEST_CREDENTIALS.GEDU,
+  gamer: TEST_CREDENTIALS.GAMER,
+};
+
+/** The canonical forbidden SQLSTATE every guard primitive raises. */
+const FORBIDDEN = "42501";
+
+// ---------------------------------------------------------------------------
+// Classification 1 of 2 — role-gated RPCs (check 2's annotations)
+// ---------------------------------------------------------------------------
+
+interface RoleGatedRpc {
+  /** Roles whose calls get past the guard. Everyone else must get 42501. */
+  permittedRoles: readonly Role[];
+  /**
+   * Set only when a permitted role ALSO hits a 42501 further down the body on
+   * all-NULL arguments, which makes the positive half of the matrix
+   * unassertable. The string is the reason, and it is deliberately narrow — the
+   * positive assertion is what stops a permissive annotation from passing check
+   * 2 vacuously, so opting out of it needs to be visible.
+   */
+  permittedAlsoForbiddenOnNullArgs?: string;
+}
+
+const ROLE_GATED_RPCS: Record<string, RoleGatedRpc> = {
+  // --- admin-gated ---------------------------------------------------------
+  apply_group_changes: { permittedRoles: ["admin"] },
+  create_product: { permittedRoles: ["admin"] },
+  update_product: { permittedRoles: ["admin"] },
+  get_product_groups_with_details: { permittedRoles: ["admin"] },
+  promote_from_waitlist: { permittedRoles: ["admin"] },
+  demote_to_waitlist: { permittedRoles: ["admin"] },
+  set_gedu_verified: { permittedRoles: ["admin"] },
+
+  // --- gedu-gated ----------------------------------------------------------
+  get_my_assigned_products: { permittedRoles: ["gedu"] },
+  get_gedu_assigned_product: {
+    permittedRoles: ["gedu"],
+    permittedAlsoForbiddenOnNullArgs:
+      "past the role guard, a gedu with no assignment on the (NULL) product is " +
+      "refused by a second 42501 — the ownership half of this RPC's gate. Its " +
+      "positive path is covered by get-gedu-assigned-product.test.ts.",
+  },
+
+  // --- the guard primitives themselves -------------------------------------
+  // Exposed to `authenticated` because create_product / update_product are
+  // SECURITY INVOKER, so their guard runs as the caller (see migration 00120).
+  // They are role-gated by definition, so the matrix covers them like any other.
+  assert_admin: { permittedRoles: ["admin"] },
+  // No role passes: the all-NULL convention hands it a NULL role name, which it
+  // refuses outright rather than letting the comparison swallow it. That refusal
+  // is the whole point of the NULL branch, so pinning it here is not a
+  // technicality — it is the check.
+  assert_role: { permittedRoles: [] },
+};
+
+// ---------------------------------------------------------------------------
+// Classification 2 of 2 — self-scoping helpers (check 5's allowlist)
+// ---------------------------------------------------------------------------
+
+/**
+ * Functions with no role gate *by design*: every read and write is keyed to
+ * `auth.uid()`, so an authenticated caller getting an answer about themselves is
+ * the intent. Their failure mode is not "wrong role got in" but *scope leakage* —
+ * returning someone else's row — which no static check can see. So each entry
+ * names the test that proves the scoping, and check 5 verifies that test exists
+ * and mentions the function. An entry with no scope test is vetted by nothing;
+ * allowlist growth is this design's failure mode.
+ */
+const SELF_SCOPING: Record<string, { scopeTest: string; why: string }> = {
+  get_user_role: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "returns the caller's own role, read from their own profiles row",
+  },
+  is_admin: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "boolean about the caller; the named admin predicate for RLS policies",
+  },
+  is_parent_of: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "answers only 'am I the parent of X', bounded to the caller's uid",
+  },
+  can_read_product: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "read predicate behind the product policies; anon-reachable on purpose, and its anon branch returns true only for published+visible products",
+  },
+  get_my_gamers: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "the caller's own linked gamers",
+  },
+  get_my_parents: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "the caller's own linked parents",
+  },
+  is_voice_group_member: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "boolean about the caller's own membership of a voice group",
+  },
+  is_voice_group_moderator: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "boolean about the caller's own moderator standing in a voice group",
+  },
+  get_my_participation_subscription_states: {
+    scopeTest: "tests/db/get-my-participation-subscription-states.test.ts",
+    why: "billing-state signals for participations the caller is party to",
+  },
+  get_waitlist_position: {
+    scopeTest: "tests/db/waitlist-admin.test.ts",
+    why: "owner-authorized: returns NULL rather than a position for a row the caller neither purchased nor is the gamer on",
+  },
+  set_my_pin: {
+    scopeTest: "tests/db/parent-pin.test.ts",
+    why: "writes the caller's own customer_profiles.pin_hash",
+  },
+  verify_my_pin: {
+    scopeTest: "tests/db/parent-pin.test.ts",
+    why: "compares against the caller's own pin_hash; never returns it",
+  },
+  pin_is_set: {
+    scopeTest: "tests/db/parent-pin.test.ts",
+    why: "boolean about the caller's own PIN",
+  },
+};
+
+/**
+ * Functions `anon` may execute. `can_read_product` is the sole member: the
+ * product read policies are `TO anon, authenticated`, so anon evaluates the
+ * predicate itself.
+ */
+const ANON_ALLOWLIST = new Set(["can_read_product"]);
+
+/**
+ * check 1 exempts `assert_role` from the guard-first rule: it *is* the guard.
+ * Requiring the primitive to open by calling itself is circular. `assert_admin`
+ * is deliberately not exempt — it delegates to `assert_role`, so it satisfies
+ * the rule on its own merits and the check should keep saying so.
+ */
+const GUARD_PRIMITIVE_EXEMPT = new Set(["assert_role"]);
+
+/**
+ * Privilege-bearing columns: a column whose value decides what its own row's
+ * owner is allowed to do, or that carries money / seats / enrollment state. No
+ * UPDATE privilege may reach them, whether granted at table or column level —
+ * a broad table grant must never quietly make a privilege column writable.
+ */
+const PRIVILEGE_COLUMN_DENYLIST: readonly (readonly [string, string])[] = [
+  // The canonical one: writable `role` is self-promotion to admin.
+  ["profiles", "role"],
+  // Verification gates gedu group assignment and voice-room moderation; the
+  // audit columns are stamped server-side by set_gedu_verified.
+  ["gedu_profiles", "verified"],
+  ["gedu_profiles", "verified_at"],
+  ["gedu_profiles", "verified_by"],
+  // Enrollment state — a writable status is a free seat.
+  ["participations", "status"],
+  ["participations", "customer_id"],
+  ["participations", "gamer_id"],
+  ["participations", "group_id"],
+  // Money.
+  ["payments", "amount_cents"],
+  ["refunds", "amount_cents"],
+  ["family_subscriptions", "status"],
+  ["family_subscriptions", "current_period_end"],
+  // Seat accounting — the rollup the capacity gate reads.
+  ["product_seat_counts", "active_count"],
+  ["product_seat_counts", "reserving_count"],
+  ["product_seat_counts", "waitlist_count"],
+  // The parent PIN hash.
+  ["customer_profiles", "pin_hash"],
+];
+
+/**
+ * The only table whose UPDATE surface is column-scoped rather than table-wide.
+ * Pinned exactly: these four are the safe profile fields a user may edit.
+ */
+const PROFILES_UPDATABLE_COLUMNS = [
+  "first_name",
+  "last_name",
+  "phone",
+  "spoken_languages",
+];
+
+// ---------------------------------------------------------------------------
+// Catalog plumbing
+// ---------------------------------------------------------------------------
+
+const functionSurfaceRows = z.array(
+  z.object({
+    function_name: z.string(),
+    function_language: z.string(),
+    is_security_definer: z.boolean(),
+    is_strict: z.boolean(),
+    authenticated_access: z.boolean(),
+    anon_access: z.boolean(),
+    argument_names: z.array(z.string()),
+    body: z.string(),
+  })
+);
+
+type FunctionSurface = z.infer<typeof functionSurfaceRows>[number];
+
+const columnGrantRows = z.array(
+  z.object({
+    table_name: z.string(),
+    column_name: z.string(),
+    privilege_type: z.string(),
+  })
+);
+
+const tableGrantRows = z.array(
+  z.object({ table_name: z.string(), privilege_type: z.string() })
+);
+
+/** Strips SQL comments so the first-statement scan can't be fooled by prose. */
+function stripSqlComments(body: string): string {
+  return body.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+}
+
+/**
+ * The first executable statement of a plpgsql body: everything between the
+ * opening `BEGIN` (past any DECLARE section) and the first `;`.
+ */
+function firstStatementOf(body: string): string {
+  const source = stripSqlComments(body);
+  const begin = /\bBEGIN\b/i.exec(source);
+  if (!begin) return "";
+
+  const rest = source.slice(begin.index + begin[0].length);
+  const terminator = rest.indexOf(";");
+  return (terminator === -1 ? rest : rest.slice(0, terminator)).trim();
+}
+
+/**
+ * The canonical guard call. Schema-qualified because every guarded function sets
+ * an empty (or narrow) search_path, so an unqualified call would not resolve —
+ * requiring the qualified form here keeps the one greppable shape §3.1 promises.
+ */
+const GUARD_CALL = /^PERFORM\s+public\.assert_(role|admin|self)\s*\(/i;
+
+describe("authorization spine (§3.4)", () => {
+  let admin: SupabaseClient<Database>;
+  let surface: FunctionSurface[];
+  let exposed: FunctionSurface[];
+  const tokens = new Map<Role, string>();
+
+  /** The signed-in access token for a role, seeded in beforeAll. */
+  function tokenFor(role: Role): string {
+    const jwt = tokens.get(role);
+    if (jwt === undefined) throw new Error(`no access token for ${role}`);
+    return jwt;
+  }
+
+  beforeAll(async () => {
+    admin = createAdminTestClient();
+
+    const { data, error } = await admin.rpc(
+      "_list_function_authorization_surface"
+    );
+    expect(error).toBeNull();
+    surface = functionSurfaceRows.parse(data);
+    exposed = surface.filter((fn) => fn.authenticated_access);
+
+    for (const role of ROLES) {
+      tokens.set(
+        role,
+        await accessTokenFor(
+          CREDENTIALS[role].email,
+          CREDENTIALS[role].password
+        )
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Check 1 — static conformance
+  // -------------------------------------------------------------------------
+
+  describe("check 1 — static conformance", () => {
+    it("every plpgsql function exposed to authenticated guards first or is declared self-scoping", () => {
+      const offenders = exposed
+        .filter((fn) => fn.function_language === "plpgsql")
+        .filter((fn) => !(fn.function_name in SELF_SCOPING))
+        .filter((fn) => !GUARD_PRIMITIVE_EXEMPT.has(fn.function_name))
+        .filter((fn) => !GUARD_CALL.test(firstStatementOf(fn.body)))
+        .map((fn) => `${fn.function_name}: ${firstStatementOf(fn.body)}`);
+
+      expect(
+        offenders,
+        "a role-gated function must open with a §3.1 guard primitive — " +
+          "add `PERFORM public.assert_…();` as its first statement, or classify " +
+          "it as self-scoping with a scope test"
+      ).toEqual([]);
+    });
+
+    it("every sql-language function exposed to authenticated is classified self-scoping", () => {
+      // `LANGUAGE sql` has no statement order, so "guard first" is meaningless
+      // there. That is only safe while every such function is self-scoping — at
+      // which point check 5's scope-test requirement is what vets it.
+      const offenders = exposed
+        .filter((fn) => fn.function_language === "sql")
+        .filter((fn) => !(fn.function_name in SELF_SCOPING))
+        .map((fn) => fn.function_name);
+
+      expect(
+        offenders,
+        "a role-gated function cannot be LANGUAGE sql — it has no first " +
+          "statement to guard with; rewrite it as plpgsql"
+      ).toEqual([]);
+    });
+
+    it("no function is reachable by anon unless allowlisted", () => {
+      const offenders = surface
+        .filter((fn) => fn.anon_access)
+        .map((fn) => fn.function_name)
+        .filter((name) => !ANON_ALLOWLIST.has(name));
+
+      expect(offenders).toEqual([]);
+    });
+
+    it("no exposed function is declared STRICT", () => {
+      // A STRICT function returns NULL on NULL input *without running its body*,
+      // so its guard never executes and check 2's all-NULL calls would silently
+      // pass against an unguarded function.
+      const offenders = surface
+        .filter((fn) => fn.authenticated_access || fn.anon_access)
+        .filter((fn) => fn.is_strict)
+        .map((fn) => fn.function_name);
+
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Check 2 — behavioural role × RPC matrix
+  // -------------------------------------------------------------------------
+
+  describe("check 2 — role × RPC matrix", () => {
+    /** All-NULL argument object, built from the catalog's parameter names. */
+    function nullArgsFor(functionName: string): Record<string, null> {
+      const fn = exposed.find((row) => row.function_name === functionName);
+      if (!fn) throw new Error(`${functionName} is not exposed to authenticated`);
+      return Object.fromEntries(fn.argument_names.map((name) => [name, null]));
+    }
+
+    const pairs = Object.entries(ROLE_GATED_RPCS).flatMap(([name, annotation]) =>
+      ROLES.map((role) => ({ name, role, annotation }))
+    );
+
+    const refusals = pairs.filter(
+      ({ role, annotation }) => !annotation.permittedRoles.includes(role)
+    );
+    const passes = pairs.filter(
+      ({ role, annotation }) =>
+        annotation.permittedRoles.includes(role) &&
+        !annotation.permittedAlsoForbiddenOnNullArgs
+    );
+
+    it.each(refusals.map(({ name, role }) => [name, role] as const))(
+      "%s refuses a %s",
+      async (name, role) => {
+        const result = await callRpcRaw(tokenFor(role), name, nullArgsFor(name));
+
+        expect(
+          result.code,
+          `${name} let a ${role} past its guard (status ${result.status}, ${result.message})`
+        ).toBe(FORBIDDEN);
+      }
+    );
+
+    it.each(passes.map(({ name, role }) => [name, role] as const))(
+      "%s admits a %s past the guard",
+      async (name, role) => {
+        // The negative half alone would pass vacuously if every role were
+        // annotated as permitted. This asserts the other direction: the named
+        // role is *not* refused — it gets through the guard and fails (or
+        // succeeds) on the merits of its NULL arguments instead.
+        const result = await callRpcRaw(tokenFor(role), name, nullArgsFor(name));
+
+        expect(
+          result.code,
+          `${name} refused a ${role}, which its annotation names as permitted`
+        ).not.toBe(FORBIDDEN);
+      }
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Check 4 — column-grant audit
+  // -------------------------------------------------------------------------
+
+  describe("check 4 — column-grant audit", () => {
+    async function columnGrants(grantee: string) {
+      const { data, error } = await admin.rpc("_list_column_grants", {
+        p_grantee: grantee,
+      });
+      expect(error).toBeNull();
+      return columnGrantRows.parse(data);
+    }
+
+    it("no privilege-bearing column is updatable by authenticated or anon", async () => {
+      const denied = new Set(
+        PRIVILEGE_COLUMN_DENYLIST.map(([table, column]) => `${table}.${column}`)
+      );
+
+      for (const grantee of ["authenticated", "anon"]) {
+        const offenders = (await columnGrants(grantee))
+          .filter((row) => row.privilege_type === "UPDATE")
+          .map((row) => `${row.table_name}.${row.column_name}`)
+          .filter((key) => denied.has(key));
+
+        expect(offenders, `${grantee} can UPDATE a privilege column`).toEqual(
+          []
+        );
+      }
+    });
+
+    it("column-level UPDATE outside a table-level grant is confined to profiles", async () => {
+      // information_schema.column_privileges is the union of table-level and
+      // column-level ACLs, so subtracting the tables that hold a table-wide
+      // UPDATE grant (already pinned by access-control.test.ts) leaves exactly
+      // the column-scoped ones. `profiles` is the only intended member.
+      const { data, error } = await admin.rpc("_list_table_grants", {
+        p_grantee: "authenticated",
+      });
+      expect(error).toBeNull();
+
+      const tableWideUpdate = new Set(
+        tableGrantRows
+          .parse(data)
+          .filter((row) => row.privilege_type === "UPDATE")
+          .map((row) => row.table_name)
+      );
+
+      const columnScoped = [
+        ...new Set(
+          (await columnGrants("authenticated"))
+            .filter((row) => row.privilege_type === "UPDATE")
+            .map((row) => row.table_name)
+            .filter((table) => !tableWideUpdate.has(table))
+        ),
+      ].sort();
+
+      expect(columnScoped).toEqual(["profiles"]);
+    });
+
+    it("profiles exposes exactly the safe columns for UPDATE", async () => {
+      const updatable = (await columnGrants("authenticated"))
+        .filter(
+          (row) => row.table_name === "profiles" && row.privilege_type === "UPDATE"
+        )
+        .map((row) => row.column_name)
+        .sort();
+
+      expect(updatable).toEqual([...PROFILES_UPDATABLE_COLUMNS].sort());
+    });
+
+    it("anon holds no column-level write privilege anywhere", async () => {
+      // The table-level sibling of this assertion lives in access-control.test
+      // .ts; column privileges are invisible to it, which is the hole this
+      // closes.
+      const writes = (await columnGrants("anon")).filter(
+        (row) => row.privilege_type !== "SELECT"
+      );
+
+      expect(writes).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Check 5 — completeness
+  // -------------------------------------------------------------------------
+
+  describe("check 5 — completeness", () => {
+    it("every function exposed to authenticated is classified exactly once", () => {
+      const unclassified = exposed
+        .map((fn) => fn.function_name)
+        .filter((name) => !(name in ROLE_GATED_RPCS) && !(name in SELF_SCOPING));
+
+      expect(
+        unclassified,
+        "a newly exposed function must be annotated in ROLE_GATED_RPCS (with " +
+          "its permitted roles) or in SELF_SCOPING (with a scope test)"
+      ).toEqual([]);
+
+      const both = Object.keys(ROLE_GATED_RPCS).filter(
+        (name) => name in SELF_SCOPING
+      );
+      expect(both, "a function cannot be both role-gated and self-scoping").toEqual(
+        []
+      );
+    });
+
+    it("every classified function is actually exposed", () => {
+      // The other direction: a stale annotation for a function that was dropped
+      // or un-granted silently shrinks the matrix.
+      const exposedNames = new Set(exposed.map((fn) => fn.function_name));
+      const stale = [
+        ...Object.keys(ROLE_GATED_RPCS),
+        ...Object.keys(SELF_SCOPING),
+      ].filter((name) => !exposedNames.has(name));
+
+      expect(stale).toEqual([]);
+    });
+
+    it("every self-scoping entry names a scope test that exercises it", () => {
+      const offenders: string[] = [];
+
+      for (const [name, entry] of Object.entries(SELF_SCOPING)) {
+        const file = join(process.cwd(), entry.scopeTest);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- the path is a repo-relative literal from the SELF_SCOPING table above, not input; reading it is the point of the check
+        if (!existsSync(file)) {
+          offenders.push(`${name}: ${entry.scopeTest} does not exist`);
+          continue;
+        }
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- same literal path, already proven to exist one line above
+        if (!readFileSync(file, "utf8").includes(name)) {
+          offenders.push(`${name}: ${entry.scopeTest} never mentions it`);
+        }
+      }
+
+      expect(
+        offenders,
+        "a self-scoping function is vetted by its scope test and nothing else"
+      ).toEqual([]);
+    });
+  });
+});

--- a/tests/db/exposed-function-scope.test.ts
+++ b/tests/db/exposed-function-scope.test.ts
@@ -216,13 +216,28 @@ describe("self-scoping exposed functions", () => {
         expect(data).toBe(true);
       }
 
-      // An unrelated customer and an anonymous visitor are not parties to it.
-      for (const client of [customer2, anon]) {
-        const { data } = await client.rpc("can_read_product", {
-          p_product_id: PRIVATE_PRODUCT,
-        });
-        expect(data).toBe(false);
-      }
+      // An unrelated customer is not a party to it.
+      const asCustomer2 = await customer2.rpc("can_read_product", {
+        p_product_id: PRIVATE_PRODUCT,
+      });
+      expect(asCustomer2.data).toBe(false);
+
+      // anon answers NULL, not false, and that is worth pinning rather than
+      // hiding behind a truthiness check: anon has no profiles row, so
+      // `get_user_role() = 'admin'` is NULL, and `NULL OR false OR false` is
+      // NULL under SQL's three-valued logic. It is not a leak — a policy's
+      // USING clause treats NULL as deny, which is exactly what read_products
+      // relies on, and the read below proves it.
+      const asAnon = await anon.rpc("can_read_product", {
+        p_product_id: PRIVATE_PRODUCT,
+      });
+      expect(asAnon.data).toBeNull();
+
+      const visible = await anon
+        .from("products")
+        .select("id")
+        .eq("id", PRIVATE_PRODUCT);
+      expect(visible.data).toEqual([]);
     });
   });
 

--- a/tests/db/exposed-function-scope.test.ts
+++ b/tests/db/exposed-function-scope.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+import {
+  createAdminTestClient,
+  createAnonTestClient,
+  createAuthenticatedClient,
+} from "./helpers";
+import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
+import { createTestProduct, deleteTestProducts } from "./product-helpers";
+
+/**
+ * Scope tests for the self-scoping functions exposed to `authenticated` that had
+ * no direct coverage before the §3.4 verification spine.
+ *
+ * These functions carry no role gate by design — every answer is keyed to
+ * `auth.uid()`. That makes their failure mode *scope leakage* (answering about
+ * someone else) rather than "wrong role got in", which no static check can see.
+ * authorization-spine.test.ts's check 5 requires each one to name a scope test;
+ * this file is that test for eight of them, and it is what makes their entry on
+ * the self-scoping allowlist mean something.
+ *
+ * The others are covered where they already were:
+ * parent-pin.test.ts (set_my_pin / verify_my_pin / pin_is_set),
+ * waitlist-admin.test.ts (get_waitlist_position), and
+ * get-my-participation-subscription-states.test.ts.
+ *
+ * Product UUIDs 5a1, 5a2 (see the product-helpers allocation registry).
+ */
+
+/** Published + visible: readable by the whole world, including anon. */
+const PUBLIC_PRODUCT = "00000000-0000-0000-0000-0000000005a1";
+/**
+ * Draft + invisible, carrying the group fixtures. Nobody reaches it through the
+ * public branch, so each remaining branch of can_read_product (admin, enrolled
+ * gamer, purchasing parent, assigned gedu) is isolated on it.
+ */
+const PRIVATE_PRODUCT = "00000000-0000-0000-0000-0000000005a2";
+const GROUP_ID = "00000000-0000-0000-0000-0000000005a3";
+
+describe("self-scoping exposed functions", () => {
+  let admin: SupabaseClient<Database>;
+  let anon: SupabaseClient<Database>;
+  let adminAuth: SupabaseClient<Database>;
+  let customer: SupabaseClient<Database>;
+  let customer2: SupabaseClient<Database>;
+  let gedu: SupabaseClient<Database>;
+  let gamer: SupabaseClient<Database>;
+
+  beforeAll(async () => {
+    admin = createAdminTestClient();
+    anon = createAnonTestClient();
+    adminAuth = await createAuthenticatedClient(
+      TEST_CREDENTIALS.ADMIN.email,
+      TEST_CREDENTIALS.ADMIN.password,
+    );
+    customer = await createAuthenticatedClient(
+      TEST_CREDENTIALS.CUSTOMER.email,
+      TEST_CREDENTIALS.CUSTOMER.password,
+    );
+    customer2 = await createAuthenticatedClient(
+      TEST_CREDENTIALS.CUSTOMER_2.email,
+      TEST_CREDENTIALS.CUSTOMER_2.password,
+    );
+    gedu = await createAuthenticatedClient(
+      TEST_CREDENTIALS.GEDU.email,
+      TEST_CREDENTIALS.GEDU.password,
+    );
+    gamer = await createAuthenticatedClient(
+      TEST_CREDENTIALS.GAMER.email,
+      TEST_CREDENTIALS.GAMER.password,
+    );
+
+    await deleteTestProducts(admin, [PUBLIC_PRODUCT, PRIVATE_PRODUCT]);
+
+    await createTestProduct(admin, {
+      id: PUBLIC_PRODUCT,
+      status: "pending",
+      isVisible: true,
+      seatCount: null,
+    });
+    await createTestProduct(admin, {
+      id: PRIVATE_PRODUCT,
+      status: "draft",
+      isVisible: false,
+      seatCount: null,
+    });
+
+    await admin
+      .from("product_groups")
+      .insert({ id: GROUP_ID, product_id: PRIVATE_PRODUCT, name: "Scope" });
+    await admin.from("gedu_group_assignments").insert({
+      group_id: GROUP_ID,
+      gedu_id: TEST_IDS.GEDU,
+      product_id: PRIVATE_PRODUCT,
+    });
+    await admin.from("participations").insert({
+      product_id: PRIVATE_PRODUCT,
+      group_id: GROUP_ID,
+      gamer_id: TEST_IDS.GAMER,
+      customer_id: TEST_IDS.CUSTOMER,
+      status: "active",
+    });
+  });
+
+  afterAll(async () => {
+    await deleteTestProducts(admin, [PUBLIC_PRODUCT, PRIVATE_PRODUCT]);
+  });
+
+  describe("get_user_role", () => {
+    it("returns the caller's own role and no one else's", async () => {
+      expect((await adminAuth.rpc("get_user_role")).data).toBe("admin");
+      expect((await customer.rpc("get_user_role")).data).toBe("customer");
+      expect((await gedu.rpc("get_user_role")).data).toBe("gedu");
+      expect((await gamer.rpc("get_user_role")).data).toBe("gamer");
+    });
+  });
+
+  describe("is_admin", () => {
+    it("is true only for the admin", async () => {
+      expect((await adminAuth.rpc("is_admin")).data).toBe(true);
+      expect((await customer.rpc("is_admin")).data).toBe(false);
+      expect((await gedu.rpc("is_admin")).data).toBe(false);
+      expect((await gamer.rpc("is_admin")).data).toBe(false);
+    });
+  });
+
+  describe("is_parent_of", () => {
+    it("answers about the caller's own links only", async () => {
+      const own = await customer.rpc("is_parent_of", {
+        gamer_uuid: TEST_IDS.GAMER,
+      });
+      expect(own.data).toBe(true);
+
+      // The second customer is parent to nobody — the same gamer, asked by a
+      // different caller, must not come back true.
+      const other = await customer2.rpc("is_parent_of", {
+        gamer_uuid: TEST_IDS.GAMER,
+      });
+      expect(other.data).toBe(false);
+
+      // And a gamer is not their own parent.
+      const self = await gamer.rpc("is_parent_of", {
+        gamer_uuid: TEST_IDS.GAMER,
+      });
+      expect(self.data).toBe(false);
+    });
+  });
+
+  /**
+   * The links as the database sees them, read with RLS bypassed. Comparing
+   * against this rather than against a hardcoded list keeps the assertion exact
+   * without coupling it to whatever links other db-test files have created and
+   * cleaned up around it.
+   */
+  async function linkedGamersOf(parentId: string): Promise<string[]> {
+    const { data } = await admin
+      .from("parent_gamer")
+      .select("gamer_id")
+      .eq("parent_id", parentId);
+    return (data ?? []).map((row) => row.gamer_id).sort();
+  }
+
+  describe("get_my_gamers", () => {
+    it("returns the caller's own linked gamers only", async () => {
+      const expected = await linkedGamersOf(TEST_IDS.CUSTOMER);
+      // Non-vacuity: an empty expectation would make the equality below hold
+      // even if the function returned nothing at all.
+      expect(expected).toContain(TEST_IDS.GAMER);
+
+      const mine = await customer.rpc("get_my_gamers");
+      expect(mine.error).toBeNull();
+      expect((mine.data ?? []).map((row) => row.id).sort()).toEqual(expected);
+
+      const theirs = await customer2.rpc("get_my_gamers");
+      expect((theirs.data ?? []).map((row) => row.id).sort()).toEqual(
+        await linkedGamersOf(TEST_IDS.CUSTOMER_2),
+      );
+
+      // A gamer has no children of their own, however many they are linked to.
+      const asGamer = await gamer.rpc("get_my_gamers");
+      expect(asGamer.data).toEqual([]);
+    });
+  });
+
+  describe("get_my_parents", () => {
+    it("returns the caller's own linked parents only", async () => {
+      const mine = await gamer.rpc("get_my_parents");
+      expect(mine.error).toBeNull();
+      expect((mine.data ?? []).map((row) => row.id)).toEqual([
+        TEST_IDS.CUSTOMER,
+      ]);
+
+      const asCustomer = await customer.rpc("get_my_parents");
+      expect(asCustomer.data).toEqual([]);
+    });
+  });
+
+  describe("can_read_product", () => {
+    it("is true for everyone, session or not, on a published visible product", async () => {
+      for (const client of [anon, customer2, gamer, gedu, adminAuth]) {
+        const { data } = await client.rpc("can_read_product", {
+          p_product_id: PUBLIC_PRODUCT,
+        });
+        expect(data).toBe(true);
+      }
+    });
+
+    it("is true on an unpublished product only for parties to it", async () => {
+      // admin (sees everything), the enrolled gamer, the purchasing parent, and
+      // the assigned gedu — one branch of the predicate each.
+      for (const client of [adminAuth, gamer, customer, gedu]) {
+        const { data } = await client.rpc("can_read_product", {
+          p_product_id: PRIVATE_PRODUCT,
+        });
+        expect(data).toBe(true);
+      }
+
+      // An unrelated customer and an anonymous visitor are not parties to it.
+      for (const client of [customer2, anon]) {
+        const { data } = await client.rpc("can_read_product", {
+          p_product_id: PRIVATE_PRODUCT,
+        });
+        expect(data).toBe(false);
+      }
+    });
+  });
+
+  describe("is_voice_group_member", () => {
+    it("is true only for the admin, the enrolled gamer and the assigned gedu", async () => {
+      for (const client of [adminAuth, gamer, gedu]) {
+        const { data } = await client.rpc("is_voice_group_member", {
+          p_group_id: GROUP_ID,
+        });
+        expect(data).toBe(true);
+      }
+
+      // The purchasing parent is not a room member — membership is the gamer's,
+      // not the family's.
+      for (const client of [customer, customer2]) {
+        const { data } = await client.rpc("is_voice_group_member", {
+          p_group_id: GROUP_ID,
+        });
+        expect(data).toBe(false);
+      }
+    });
+  });
+
+  describe("is_voice_group_moderator", () => {
+    it("is true only for the admin and the assigned gedu", async () => {
+      for (const client of [adminAuth, gedu]) {
+        const { data } = await client.rpc("is_voice_group_moderator", {
+          p_group_id: GROUP_ID,
+        });
+        expect(data).toBe(true);
+      }
+
+      // A member is not a moderator: the enrolled gamer must not moderate.
+      for (const client of [gamer, customer, customer2]) {
+        const { data } = await client.rpc("is_voice_group_moderator", {
+          p_group_id: GROUP_ID,
+        });
+        expect(data).toBe(false);
+      }
+    });
+  });
+});

--- a/tests/db/gedu-registration.test.ts
+++ b/tests/db/gedu-registration.test.ts
@@ -29,8 +29,10 @@ describe("gedu registration + verification RPCs", () => {
   });
 
   afterAll(async () => {
-    // Restore the seeded gedu to its verified baseline in case a test flipped it.
-    await admin.rpc("set_gedu_verified", {
+    // Restore the seeded gedu to its verified baseline in case a test flipped
+    // it. Through the signed-in admin, not the service-role client: since 00121
+    // the RPC's guard refuses a caller with no profiles row.
+    await adminClient.rpc("set_gedu_verified", {
       p_gedu_id: TEST_IDS.GEDU,
       p_verified: true,
     });
@@ -156,12 +158,15 @@ describe("gedu registration + verification RPCs", () => {
       expect(afterVerify?.verified_by).toBe(TEST_IDS.ADMIN);
     });
 
-    it("rejects a non-admin caller", async () => {
+    it("rejects a non-admin caller with the canonical 42501", async () => {
+      // 00121 moved this RPC onto assert_admin(), so its refusal now carries the
+      // same forbidden ERRCODE as every other role-gated RPC instead of a
+      // generic raise. That is what let the role × RPC matrix pick it up.
       const { error } = await geduClient.rpc("set_gedu_verified", {
         p_gedu_id: TEST_IDS.GEDU,
         p_verified: false,
       });
-      expect(error).not.toBeNull();
+      expect(error?.code).toBe("42501");
     });
   });
 });

--- a/tests/db/guard-primitives.test.ts
+++ b/tests/db/guard-primitives.test.ts
@@ -9,16 +9,16 @@ import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
  * create_product and update_product are SECURITY INVOKER — their guard runs as
  * the caller. That grant is a new exposed surface, so it is tested directly
  * here rather than only through the eight RPCs that call it: the primitives
- * must refuse every role they don't name and pass the one they do — and, for
- * now, reproduce the hand-written guards' NULL-role pass-through verbatim.
+ * must refuse every role they don't name, pass the one they do, and — since
+ * migration 00121 — refuse a caller who holds no role at all.
  *
- * Which functions are *exposed* is pinned mechanically by access-control.test
- * .ts (assert_self and the two §3.2 predicates are deliberately absent from its
- * allowlist), so this file covers behaviour only.
- *
- * The wrong-role behaviour of the RPCs that call these guards is already
- * covered per-RPC (apply-group-changes, update-product, waitlist-admin,
- * get-gedu-assigned-product); the systematic role × RPC matrix is Phase 2.
+ * Which functions are *exposed* is pinned mechanically by
+ * authorization-spine.test.ts's completeness check (assert_self and the two §3.2
+ * predicates are deliberately absent from its classifications, so they must
+ * stay unexposed), so this file covers behaviour only. The systematic role × RPC
+ * matrix — including these primitives — lives in that file too; what is here is
+ * the primitives' own edge cases, which the matrix's all-NULL convention cannot
+ * express.
  */
 describe("guard primitives", () => {
   describe("assert_admin", () => {
@@ -48,19 +48,20 @@ describe("guard primitives", () => {
       expect(error?.code).toBe("42501");
     });
 
-    it("KNOWN GAP: lets a caller with no role through", async () => {
-      // service_role carries no `sub` claim, so get_user_role() is NULL, and
-      // `NULL <> 'admin'` is NULL — the IF never fires. The hand-written guards
-      // this primitive replaces behaved the same way, and that pass-through is
-      // load-bearing today: update-product.test.ts and gedu-registration.test.ts
-      // drive admin-gated RPCs through the service-role client. Pinned here so
-      // the hole is visible and Phase 2 closes it as a deliberate test change,
-      // not a surprise.
+    it("refuses a caller with no role", async () => {
+      // service_role carries no `sub` claim, so get_user_role() is NULL. Under
+      // the `<>` comparison this primitive shipped with, `NULL <> 'admin'` was
+      // NULL, the IF never fired, and the caller went straight through — the
+      // pass-through Phase 1 inherited from the hand-written guards it replaced.
+      // 00121 switched the comparison to IS DISTINCT FROM, so a roleless caller
+      // is now refused like any other non-admin. This is the inverse of the
+      // KNOWN GAP assertion that stood here, kept in place so the closure is
+      // visible in the diff rather than just an absent test.
       const admin = createAdminTestClient();
 
       const { error } = await admin.rpc("assert_admin");
 
-      expect(error).toBeNull();
+      expect(error?.code).toBe("42501");
     });
   });
 
@@ -83,6 +84,33 @@ describe("guard primitives", () => {
       );
 
       const { error } = await client.rpc("assert_role", { p_role: "gedu" });
+
+      expect(error?.code).toBe("42501");
+    });
+
+    it("refuses a caller with no role, even for a role that exists", async () => {
+      // The direct test of the 00121 `<>` → IS DISTINCT FROM change: a real role
+      // name, a caller whose get_user_role() is NULL. The matrix in
+      // authorization-spine.test.ts only ever hands this primitive a NULL role
+      // name, so this case is only assertable here.
+      const admin = createAdminTestClient();
+
+      const { error } = await admin.rpc("assert_role", { p_role: "gedu" });
+
+      expect(error?.code).toBe("42501");
+    });
+  });
+
+  describe("assert_self", () => {
+    it("refuses a caller who is not the referenced user", async () => {
+      // service_role only (no SECURITY INVOKER consumer yet), so the service-role
+      // client is the caller here. auth.uid() is NULL, which IS DISTINCT FROM any
+      // user id — the fail-closed default the primitive shipped with.
+      const admin = createAdminTestClient();
+
+      const { error } = await admin.rpc("assert_self", {
+        p_user_id: TEST_IDS.CUSTOMER,
+      });
 
       expect(error?.code).toBe("42501");
     });

--- a/tests/db/helpers.ts
+++ b/tests/db/helpers.ts
@@ -16,6 +16,17 @@ export function createAdminTestClient(): SupabaseClient<Database> {
 }
 
 /**
+ * Unauthenticated client — carries the `anon` role, so it sees exactly the
+ * public surface. Use to prove a public read policy or predicate really is
+ * reachable (or not) without a session.
+ */
+export function createAnonTestClient(): SupabaseClient<Database> {
+  return createClient<Database>(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/**
  * Signs in via Supabase Auth and returns a client that respects RLS.
  * Each call creates a fresh client instance (no shared session state).
  */
@@ -33,4 +44,77 @@ export async function createAuthenticatedClient(
   }
 
   return client;
+}
+
+/**
+ * Signs in and returns the raw access token, for callers that need to hit
+ * PostgREST directly rather than through the typed supabase-js client.
+ */
+export async function accessTokenFor(
+  email: string,
+  password: string
+): Promise<string> {
+  const client = createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data, error } = await client.auth.signInWithPassword({
+    email,
+    password,
+  });
+  if (error) {
+    throw new Error(`Failed to sign in as ${email}: ${error.message}`);
+  }
+
+  return data.session.access_token;
+}
+
+/** What PostgREST said: the HTTP status plus the PostgreSQL SQLSTATE, if any. */
+export interface RawRpcResult {
+  status: number;
+  /** SQLSTATE from the PostgREST error body — `null` when the call succeeded. */
+  code: string | null;
+  message: string | null;
+}
+
+/**
+ * Calls an RPC over PostgREST with an arbitrary argument object.
+ *
+ * The typed `supabase.rpc()` helper cannot express the role × RPC matrix's
+ * calling convention — deliberately passing `null` for every parameter, so the
+ * call reaches the function's guard without per-RPC fixtures — because the
+ * generated argument types forbid it, and casting around them would be the
+ * suppression the code-style rule warns about. This posts the same request the
+ * browser posts, and hands back the SQLSTATE the matrix asserts on.
+ */
+export async function callRpcRaw(
+  accessToken: string,
+  functionName: string,
+  args: Record<string, unknown>
+): Promise<RawRpcResult> {
+  const response = await fetch(`${supabaseUrl}/rest/v1/rpc/${functionName}`, {
+    method: "POST",
+    headers: {
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(args),
+  });
+
+  if (response.ok) {
+    return { status: response.status, code: null, message: null };
+  }
+
+  const body: unknown = await response.json().catch(() => null);
+  const error =
+    body !== null && typeof body === "object"
+      ? (body as { code?: unknown; message?: unknown })
+      : {};
+
+  return {
+    status: response.status,
+    code: typeof error.code === "string" ? error.code : null,
+    message: typeof error.message === "string" ? error.message : null,
+  };
 }

--- a/tests/db/product-helpers.ts
+++ b/tests/db/product-helpers.ts
@@ -15,6 +15,9 @@ import { TEST_IDS } from "./constants";
  *
  * Allocation registry — keep this current when adding a v2 db test. The
  * suffix is the last byte of the UUID (`...0000000005XX`):
+ *   5a1–5a3        exposed-function-scope.test.ts (5a3 is its product_groups id)
+ *   5a4–5a9        write-idor.test.ts (5a4 is the product; 5a5–5a9 are the
+ *                  group / zone / calendar / holiday / slot fixtures it seeds)
  *   5b1–5b5        participations-race.test.ts
  *   5b6–5b7        participations-rls.test.ts
  *   5b8–5b9        participations-external.test.ts

--- a/tests/db/site-details-rls.test.ts
+++ b/tests/db/site-details-rls.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database.types";
-import { createAdminTestClient, createAuthenticatedClient } from "./helpers";
+import {
+  createAdminTestClient,
+  createAnonTestClient,
+  createAuthenticatedClient,
+} from "./helpers";
 import { TEST_IDS, TEST_CREDENTIALS } from "./constants";
 
 /**
@@ -19,16 +23,6 @@ import { TEST_IDS, TEST_CREDENTIALS } from "./constants";
  * docs/products-architecture.md § "Extend site_details read
  * policy to purchasing customers" for the planned policy shape.
  */
-
-const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321";
-const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
-
-function createAnonTestClient(): SupabaseClient<Database> {
-  return createClient<Database>(supabaseUrl, anonKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-}
 
 describe("site_details RLS", () => {
   let admin: SupabaseClient<Database>;

--- a/tests/db/update-product.test.ts
+++ b/tests/db/update-product.test.ts
@@ -29,10 +29,22 @@ const PRODUCT_ID = "00000000-0000-0000-0000-0000000005f1";
 const MUNI_PRODUCT_ID = "00000000-0000-0000-0000-0000000005f2";
 
 describe("update_product", () => {
+  /** Service-role client — bypasses RLS, used to seed and to read back. */
   let admin: SupabaseClient<Database>;
+  /**
+   * The RPC caller. It has to be a *signed-in* admin, not the service-role
+   * client: the guard reads the caller's live role via get_user_role(), and
+   * since 00121 a caller with no profiles row (which is what a service-role
+   * connection is) is refused rather than waved through.
+   */
+  let adminAuth: SupabaseClient<Database>;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     admin = createAdminTestClient();
+    adminAuth = await createAuthenticatedClient(
+      TEST_CREDENTIALS.ADMIN.email,
+      TEST_CREDENTIALS.ADMIN.password,
+    );
   });
 
   afterAll(async () => {
@@ -78,7 +90,7 @@ describe("update_product", () => {
   it("admin can update parent fields and wipe-and-replace children", async () => {
     await freshProduct();
 
-    const { data, error } = await admin.rpc("update_product", {
+    const { data, error } = await adminAuth.rpc("update_product", {
       p_id: PRODUCT_ID,
       p_billing_mode: "paid",
       p_translations: [
@@ -158,7 +170,7 @@ describe("update_product", () => {
       .update({ status: "cancelled" })
       .eq("id", PRODUCT_ID);
 
-    const { error } = await admin.rpc("update_product", {
+    const { error } = await adminAuth.rpc("update_product", {
       p_id: PRODUCT_ID,
       p_billing_mode: "paid",
       p_translations: [{ locale: "en", name: "Whatever", short_description: "" }],
@@ -212,7 +224,7 @@ describe("update_product", () => {
     // sv-only still resolves for every viewer.
     await freshProduct();
 
-    const { error } = await admin.rpc("update_product", {
+    const { error } = await adminAuth.rpc("update_product", {
       p_id: PRODUCT_ID,
       p_billing_mode: "paid",
       p_translations: [{ locale: "sv", name: "Bara svenska", short_description: "" }],
@@ -237,7 +249,7 @@ describe("update_product", () => {
   it("rejects an empty translation set", async () => {
     await freshProduct();
 
-    const { error } = await admin.rpc("update_product", {
+    const { error } = await adminAuth.rpc("update_product", {
       p_id: PRODUCT_ID,
       p_billing_mode: "paid",
       p_translations: [],
@@ -255,7 +267,7 @@ describe("update_product", () => {
 
   it("returns no_data_found for an unknown product id", async () => {
     const fakeId = "00000000-0000-0000-0000-0000000005ff";
-    const { error } = await admin.rpc("update_product", {
+    const { error } = await adminAuth.rpc("update_product", {
       p_id: fakeId,
       p_billing_mode: "paid",
       p_translations: [{ locale: "en", name: "Doesn't exist", short_description: "" }],
@@ -282,7 +294,7 @@ describe("update_product", () => {
       { type: "paragraph", text: "Build a redstone door together." },
     ];
 
-    const { error } = await admin.rpc("update_product", {
+    const { error } = await adminAuth.rpc("update_product", {
       p_id: PRODUCT_ID,
       p_billing_mode: "paid",
       p_translations: [
@@ -341,7 +353,7 @@ describe("update_product", () => {
   it("round-trips per-session fees through update_product", async () => {
     await freshProduct();
 
-    const { error } = await admin.rpc("update_product", {
+    const { error } = await adminAuth.rpc("update_product", {
       p_id: PRODUCT_ID,
       p_billing_mode: "paid",
       p_translations: [{ locale: "en", name: "Fees", short_description: "" }],

--- a/tests/db/write-idor.test.ts
+++ b/tests/db/write-idor.test.ts
@@ -1,0 +1,763 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import type { Database } from "@/types/database.types";
+import { createAdminTestClient, createAuthenticatedClient } from "./helpers";
+import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
+import { createTestProduct, deleteTestProducts } from "./product-helpers";
+
+/**
+ * Check 3 of the verification spine — the write-path IDOR loop
+ * (docs/db-authorization-architecture.md §3.4).
+ *
+ * For every table `authenticated` may UPDATE or DELETE, a row is seeded through
+ * the service-role client (RLS bypassed) and then attacked through a user-bound
+ * client that has no business touching it. The assertion is threefold: the
+ * attacker's statement affects zero rows, the row is still there afterwards, and
+ * — the part that stops the whole thing passing vacuously — the row was there to
+ * begin with.
+ *
+ * The existing IDOR tests are SELECT-side ("customer A cannot *read* customer
+ * B's rows"). This is the write half: the half that mutates state.
+ *
+ * The loop is closed at the end: the set of tables covered here must equal the
+ * set the database actually grants UPDATE/DELETE on, so a new write grant fails
+ * CI until someone writes its IDOR case. INSERT is deliberately out of scope —
+ * a blocked INSERT and a constraint violation both come back as an error, so the
+ * check would risk passing for the wrong reason; INSERT WITH CHECK is covered by
+ * the per-feature RLS tests, which supply valid payloads.
+ *
+ * Attackers are chosen to be the sharpest wrong actor available, not the
+ * weakest: the parent against their own child's profile, a group *member*
+ * against a moderator-only zone, the confined gamer against their own
+ * confinement row. A test where the attacker fails the role clause AND the
+ * ownership clause proves less than one where only ownership stands between
+ * them and the row.
+ */
+
+const PRODUCT = "00000000-0000-0000-0000-0000000005a4";
+const GROUP = "00000000-0000-0000-0000-0000000005a5";
+const ZONE = "00000000-0000-0000-0000-0000000005a6";
+const CALENDAR = "00000000-0000-0000-0000-0000000005a7";
+const HOLIDAY = "00000000-0000-0000-0000-0000000005a8";
+const SLOT = "00000000-0000-0000-0000-0000000005a9";
+const WHATSAPP_PHONE = "358900000005";
+const WHATSAPP_MESSAGE_ID = "write-idor-seeded-message";
+
+const tableGrantRows = z.array(
+  z.object({ table_name: z.string(), privilege_type: z.string() })
+);
+
+const ATTACKERS = ["customer", "customer2", "gedu", "gamer"] as const;
+type Attacker = (typeof ATTACKERS)[number];
+
+const ATTACKER_CREDENTIALS: Record<
+  Attacker,
+  { email: string; password: string }
+> = {
+  customer: TEST_CREDENTIALS.CUSTOMER,
+  customer2: TEST_CREDENTIALS.CUSTOMER_2,
+  gedu: TEST_CREDENTIALS.GEDU,
+  gamer: TEST_CREDENTIALS.GAMER,
+};
+
+/** What a write attempt actually achieved. */
+interface Outcome {
+  rows: number;
+  error: PostgrestError | null;
+}
+
+function outcomeOf(result: {
+  data: unknown[] | null;
+  error: PostgrestError | null;
+}): Outcome {
+  return { rows: result.data?.length ?? 0, error: result.error };
+}
+
+type Attempt = (client: SupabaseClient<Database>) => Promise<Outcome>;
+
+interface IdorCase {
+  attacker: Attacker;
+  /** Why this attacker is the sharp one for this table. */
+  why: string;
+  /** Reads the victim row through the service-role client. */
+  probe: (admin: SupabaseClient<Database>) => Promise<unknown>;
+  update?: Attempt;
+  remove?: Attempt;
+}
+
+/**
+ * `authenticated` holds column-level UPDATE on `profiles` rather than a
+ * table-level grant, so it is invisible to `_list_table_grants` and has to be
+ * named here explicitly. The column-grant audit (spine check 4) pins which
+ * columns those are; this pins that they are still only the caller's own.
+ */
+const COLUMN_GRANT_ONLY_TABLES = ["profiles"];
+
+const CASES: Record<string, IdorCase> = {
+  products: {
+    attacker: "customer2",
+    why: "products are admin-only; any authenticated user holds the raw grant",
+    probe: async (admin) =>
+      (await admin.from("products").select("*").eq("id", PRODUCT).maybeSingle())
+        .data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("products")
+          .update({ is_visible: true, seat_count: 999 })
+          .eq("id", PRODUCT)
+          .select("id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client.from("products").delete().eq("id", PRODUCT).select("id")
+      ),
+  },
+
+  schedule_slots: {
+    attacker: "customer2",
+    why: "moving a session's time is an admin action",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("schedule_slots")
+          .select("*")
+          .eq("id", SLOT)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("schedule_slots")
+          .update({ start_time: "23:00" })
+          .eq("id", SLOT)
+          .select("id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("schedule_slots")
+          .delete()
+          .eq("id", SLOT)
+          .select("id")
+      ),
+  },
+
+  product_prices: {
+    attacker: "customer2",
+    why: "a writable price is a self-service discount",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("product_prices")
+          .select("*")
+          .eq("product_id", PRODUCT)
+          .eq("currency", "eur")
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("product_prices")
+          .update({ price_cents: 0 })
+          .eq("product_id", PRODUCT)
+          .eq("currency", "eur")
+          .select("product_id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("product_prices")
+          .delete()
+          .eq("product_id", PRODUCT)
+          .eq("currency", "eur")
+          .select("product_id")
+      ),
+  },
+
+  product_translations: {
+    attacker: "customer2",
+    why: "public-facing copy on someone else's product",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("product_translations")
+          .select("*")
+          .eq("product_id", PRODUCT)
+          .eq("locale", "en")
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("product_translations")
+          .update({ name: "Defaced" })
+          .eq("product_id", PRODUCT)
+          .eq("locale", "en")
+          .select("product_id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("product_translations")
+          .delete()
+          .eq("product_id", PRODUCT)
+          .eq("locale", "en")
+          .select("product_id")
+      ),
+  },
+
+  holiday_calendars: {
+    attacker: "customer2",
+    why: "publicly readable, admin-writable — the classic read/write mismatch",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("holiday_calendars")
+          .select("*")
+          .eq("id", CALENDAR)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("holiday_calendars")
+          .update({ name: "Defaced" })
+          .eq("id", CALENDAR)
+          .select("id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("holiday_calendars")
+          .delete()
+          .eq("id", CALENDAR)
+          .select("id")
+      ),
+  },
+
+  calendar_holidays: {
+    attacker: "customer2",
+    why: "deleting a holiday silently reinstates a cancelled session",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("calendar_holidays")
+          .select("*")
+          .eq("id", HOLIDAY)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("calendar_holidays")
+          .update({ reason: "Defaced" })
+          .eq("id", HOLIDAY)
+          .select("id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("calendar_holidays")
+          .delete()
+          .eq("id", HOLIDAY)
+          .select("id")
+      ),
+  },
+
+  product_holiday_calendars: {
+    attacker: "customer2",
+    why: "unlinking a calendar from someone else's product",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("product_holiday_calendars")
+          .select("*")
+          .eq("product_id", PRODUCT)
+          .eq("calendar_id", CALENDAR)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("product_holiday_calendars")
+          .update({ created_at: new Date(0).toISOString() })
+          .eq("product_id", PRODUCT)
+          .eq("calendar_id", CALENDAR)
+          .select("product_id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("product_holiday_calendars")
+          .delete()
+          .eq("product_id", PRODUCT)
+          .eq("calendar_id", CALENDAR)
+          .select("product_id")
+      ),
+  },
+
+  site_details: {
+    attacker: "gedu",
+    why: "a gedu can *read* site addresses — read access must not imply write",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("site_details")
+          .select("*")
+          .eq("location_id", TEST_IDS.LOCATION_SITE)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("site_details")
+          .update({ address: "Defaced" })
+          .eq("location_id", TEST_IDS.LOCATION_SITE)
+          .select("location_id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("site_details")
+          .delete()
+          .eq("location_id", TEST_IDS.LOCATION_SITE)
+          .select("location_id")
+      ),
+  },
+
+  site_staff_details: {
+    attacker: "gedu",
+    why: "same read/write asymmetry as site_details",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("site_staff_details")
+          .select("*")
+          .eq("location_id", TEST_IDS.LOCATION_SITE)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("site_staff_details")
+          .update({ notes: "Defaced" })
+          .eq("location_id", TEST_IDS.LOCATION_SITE)
+          .select("location_id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("site_staff_details")
+          .delete()
+          .eq("location_id", TEST_IDS.LOCATION_SITE)
+          .select("location_id")
+      ),
+  },
+
+  voice_zones: {
+    attacker: "gamer",
+    why: "the gamer is a member of this group — they can see the zone, and only the moderator clause stops them editing it",
+    probe: async (admin) =>
+      (await admin.from("voice_zones").select("*").eq("id", ZONE).maybeSingle())
+        .data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("voice_zones")
+          .update({ is_locked: false, name: "Unlocked" })
+          .eq("id", ZONE)
+          .select("id")
+      ),
+    remove: async (client) =>
+      outcomeOf(
+        await client.from("voice_zones").delete().eq("id", ZONE).select("id")
+      ),
+  },
+
+  voice_private_zone_occupants: {
+    attacker: "gamer",
+    why: "the gamer IS the occupant — 'a gamer cannot free themselves' is the whole point of the private-zone model",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("voice_private_zone_occupants")
+          .select("*")
+          .eq("zone_id", ZONE)
+          .eq("user_id", TEST_IDS.GAMER)
+          .maybeSingle()
+      ).data,
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("voice_private_zone_occupants")
+          .delete()
+          .eq("zone_id", ZONE)
+          .eq("user_id", TEST_IDS.GAMER)
+          .select("id")
+      ),
+  },
+
+  gedu_locations: {
+    attacker: "customer2",
+    why: "coverage rows are self-managed by gedus; nobody else may touch them",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("gedu_locations")
+          .select("*")
+          .eq("gedu_id", TEST_IDS.GEDU)
+          .eq("location_id", TEST_IDS.LOCATION_COUNTRY)
+          .maybeSingle()
+      ).data,
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("gedu_locations")
+          .delete()
+          .eq("gedu_id", TEST_IDS.GEDU)
+          .eq("location_id", TEST_IDS.LOCATION_COUNTRY)
+          .select("gedu_id")
+      ),
+  },
+
+  gamer_profiles: {
+    attacker: "customer",
+    why: "the linked *parent* — who may read this row — must still not write it; the only self-update policy is the gamer's own",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("gamer_profiles")
+          .select("*")
+          .eq("user_id", TEST_IDS.GAMER)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("gamer_profiles")
+          .update({ date_of_birth: "2001-01-01" })
+          .eq("user_id", TEST_IDS.GAMER)
+          .select("user_id")
+      ),
+  },
+
+  parent_gamer: {
+    attacker: "customer2",
+    why: "another customer severing someone else's parent link",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("parent_gamer")
+          .select("*")
+          .eq("id", TEST_IDS.PARENT_GAMER_LINK)
+          .maybeSingle()
+      ).data,
+    remove: async (client) =>
+      outcomeOf(
+        await client
+          .from("parent_gamer")
+          .delete()
+          .eq("id", TEST_IDS.PARENT_GAMER_LINK)
+          .select("id")
+      ),
+  },
+
+  whatsapp_contacts: {
+    attacker: "customer2",
+    why: "the WhatsApp inbox is admin-only",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("whatsapp_contacts")
+          .select("*")
+          .eq("phone", WHATSAPP_PHONE)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("whatsapp_contacts")
+          .update({ wa_name: "Defaced" })
+          .eq("phone", WHATSAPP_PHONE)
+          .select("phone")
+      ),
+  },
+
+  whatsapp_messages: {
+    attacker: "customer2",
+    why: "rewriting someone else's message history",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("whatsapp_messages")
+          .select("*")
+          .eq("id", WHATSAPP_MESSAGE_ID)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("whatsapp_messages")
+          .update({ body: "Defaced", status: "failed" })
+          .eq("id", WHATSAPP_MESSAGE_ID)
+          .select("id")
+      ),
+  },
+
+  profiles: {
+    attacker: "customer2",
+    why: "column-granted UPDATE still has to be scoped to the caller's own row",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("profiles")
+          .select("*")
+          .eq("id", TEST_IDS.CUSTOMER)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("profiles")
+          .update({ first_name: "Defaced" })
+          .eq("id", TEST_IDS.CUSTOMER)
+          .select("id")
+      ),
+  },
+};
+
+describe("write-path IDOR (§3.4 check 3)", () => {
+  let admin: SupabaseClient<Database>;
+  const clients = new Map<Attacker, SupabaseClient<Database>>();
+
+  function clientFor(attacker: Attacker): SupabaseClient<Database> {
+    const client = clients.get(attacker);
+    if (client === undefined) throw new Error(`no client for ${attacker}`);
+    return client;
+  }
+
+  beforeAll(async () => {
+    admin = createAdminTestClient();
+
+    for (const attacker of ATTACKERS) {
+      clients.set(
+        attacker,
+        await createAuthenticatedClient(
+          ATTACKER_CREDENTIALS[attacker].email,
+          ATTACKER_CREDENTIALS[attacker].password
+        )
+      );
+    }
+
+    await deleteTestProducts(admin, [PRODUCT]);
+    await admin.from("holiday_calendars").delete().eq("id", CALENDAR);
+    await admin.from("whatsapp_messages").delete().eq("id", WHATSAPP_MESSAGE_ID);
+    await admin.from("whatsapp_contacts").delete().eq("phone", WHATSAPP_PHONE);
+
+    await createTestProduct(admin, { id: PRODUCT, seatCount: null });
+
+    await admin
+      .from("schedule_slots")
+      .insert({
+        id: SLOT,
+        product_id: PRODUCT,
+        weekday: 2,
+        start_time: "16:00",
+        duration_minutes: 60,
+      });
+    await admin
+      .from("product_prices")
+      .insert({ product_id: PRODUCT, currency: "eur", price_cents: 4000 });
+    await admin.from("product_translations").insert({
+      product_id: PRODUCT,
+      locale: "en",
+      name: "IDOR fixture",
+      short_description: "Seeded by write-idor.test.ts",
+    });
+
+    await admin
+      .from("holiday_calendars")
+      .insert({ id: CALENDAR, name: "IDOR calendar", timezone: "UTC" });
+    await admin
+      .from("calendar_holidays")
+      .insert({ id: HOLIDAY, calendar_id: CALENDAR, date: "2099-01-01" });
+    await admin
+      .from("product_holiday_calendars")
+      .insert({ product_id: PRODUCT, calendar_id: CALENDAR });
+
+    await admin.from("site_details").upsert({
+      location_id: TEST_IDS.LOCATION_SITE,
+      address: "Seeded by write-idor.test.ts",
+      notes: "Seeded",
+    });
+    await admin.from("site_staff_details").upsert({
+      location_id: TEST_IDS.LOCATION_SITE,
+      notes: "Seeded by write-idor.test.ts",
+    });
+
+    // The gamer is an active participant in GROUP, which makes them a voice
+    // *member* — the sharp attacker for the two voice tables.
+    await admin
+      .from("product_groups")
+      .insert({ id: GROUP, product_id: PRODUCT, name: "IDOR" });
+    await admin.from("participations").insert({
+      product_id: PRODUCT,
+      group_id: GROUP,
+      gamer_id: TEST_IDS.GAMER,
+      customer_id: TEST_IDS.CUSTOMER,
+      status: "active",
+    });
+    await admin.from("voice_zones").insert({
+      id: ZONE,
+      group_id: GROUP,
+      name: "Private",
+      icon: "ghost",
+      color: "indigo",
+      is_locked: true,
+      created_by: TEST_IDS.ADMIN,
+    });
+    await admin.from("voice_private_zone_occupants").insert({
+      zone_id: ZONE,
+      group_id: GROUP,
+      user_id: TEST_IDS.GAMER,
+      placed_by: TEST_IDS.ADMIN,
+      session_opens_at: new Date().toISOString(),
+    });
+
+    await admin
+      .from("gedu_locations")
+      .delete()
+      .eq("gedu_id", TEST_IDS.GEDU)
+      .eq("location_id", TEST_IDS.LOCATION_COUNTRY);
+    await admin.from("gedu_locations").insert({
+      gedu_id: TEST_IDS.GEDU,
+      location_id: TEST_IDS.LOCATION_COUNTRY,
+    });
+
+    await admin
+      .from("whatsapp_contacts")
+      .insert({ phone: WHATSAPP_PHONE, wa_name: "IDOR fixture" });
+    await admin.from("whatsapp_messages").insert({
+      id: WHATSAPP_MESSAGE_ID,
+      phone: WHATSAPP_PHONE,
+      direction: "inbound",
+      status: "received",
+      body: "Seeded by write-idor.test.ts",
+    });
+  });
+
+  afterAll(async () => {
+    await deleteTestProducts(admin, [PRODUCT]);
+    await admin.from("holiday_calendars").delete().eq("id", CALENDAR);
+    await admin.from("whatsapp_messages").delete().eq("id", WHATSAPP_MESSAGE_ID);
+    await admin.from("whatsapp_contacts").delete().eq("phone", WHATSAPP_PHONE);
+    await admin
+      .from("gedu_locations")
+      .delete()
+      .eq("gedu_id", TEST_IDS.GEDU)
+      .eq("location_id", TEST_IDS.LOCATION_COUNTRY);
+    await admin
+      .from("site_details")
+      .delete()
+      .eq("location_id", TEST_IDS.LOCATION_SITE);
+    await admin
+      .from("site_staff_details")
+      .delete()
+      .eq("location_id", TEST_IDS.LOCATION_SITE);
+  });
+
+  async function assertBlocked(testCase: IdorCase, attempt: Attempt) {
+    const before = await testCase.probe(admin);
+    expect(
+      before,
+      "the victim row was never seeded — this attack would pass vacuously"
+    ).not.toBeNull();
+
+    const result = await attempt(clientFor(testCase.attacker));
+
+    expect(result.rows, `rows written: ${JSON.stringify(result)}`).toBe(0);
+    expect(await testCase.probe(admin), "the victim row changed").toEqual(
+      before
+    );
+  }
+
+  for (const [table, testCase] of Object.entries(CASES)) {
+    describe(table, () => {
+      const update = testCase.update;
+      const remove = testCase.remove;
+
+      if (update) {
+        it(`refuses an UPDATE by a ${testCase.attacker}`, async () => {
+          await assertBlocked(testCase, update);
+        });
+      }
+
+      if (remove) {
+        it(`refuses a DELETE by a ${testCase.attacker}`, async () => {
+          await assertBlocked(testCase, remove);
+        });
+      }
+    });
+  }
+
+  it("covers every table authenticated can UPDATE or DELETE", async () => {
+    const { data, error } = await admin.rpc("_list_table_grants", {
+      p_grantee: "authenticated",
+    });
+    expect(error).toBeNull();
+
+    const granted = new Set(
+      tableGrantRows
+        .parse(data)
+        .filter(
+          (row) =>
+            row.privilege_type === "UPDATE" || row.privilege_type === "DELETE"
+        )
+        .map((row) => row.table_name)
+    );
+    for (const table of COLUMN_GRANT_ONLY_TABLES) granted.add(table);
+
+    const covered = new Set(Object.keys(CASES));
+
+    const uncovered = [...granted].filter((table) => !covered.has(table)).sort();
+    expect(
+      uncovered,
+      "a table gained a write grant without an IDOR case — add one above"
+    ).toEqual([]);
+
+    const stale = [...covered].filter((table) => !granted.has(table)).sort();
+    expect(stale, "an IDOR case names a table with no write grant").toEqual([]);
+  });
+
+  it("declares the right kind of attempt for each granted privilege", async () => {
+    // A case that seeds a fixture but never attempts the privilege the database
+    // actually grants is worse than no case at all — it reads as coverage.
+    const { data } = await admin.rpc("_list_table_grants", {
+      p_grantee: "authenticated",
+    });
+
+    const grants = tableGrantRows.parse(data);
+    const missing: string[] = [];
+
+    for (const [table, testCase] of Object.entries(CASES)) {
+      const privileges = new Set(
+        grants
+          .filter((row) => row.table_name === table)
+          .map((row) => row.privilege_type)
+      );
+      // profiles' UPDATE is column-level, so it never appears above.
+      if (COLUMN_GRANT_ONLY_TABLES.includes(table)) privileges.add("UPDATE");
+
+      if (privileges.has("UPDATE") && !testCase.update) {
+        missing.push(`${table}.UPDATE`);
+      }
+      if (privileges.has("DELETE") && !testCase.remove) {
+        missing.push(`${table}.DELETE`);
+      }
+    }
+
+    expect(missing.sort()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Phase 2 of the DB authorization refactor — `docs/db-authorization-architecture.md` §3.4 / §5 Phase 2.

**Stacked on `refactor/db-auth-phase1` (#74).** Base is that branch, not `dev`. Review this diff on its own; merge Phase 1 first.

Phase 1 gave every role-gated function one canonical guard. This phase makes that mechanical: a forgotten guard, a permissively-annotated RPC, or a newly exposed function with nothing vetting it now fails CI.

The spine's only hand-maintained data is two classification tables — **role-gated RPCs** with their permitted roles, and **self-scoping helpers** with the scope test that vets each one. Everything else is derived from the PostgreSQL catalogs at test time, so the exposed surface cannot drift out from under it.

## The five checks

| # | Check | Where | Shape |
|---|---|---|---|
| 1 | Static conformance | `authorization-spine.test.ts` | Every plpgsql function reachable by `authenticated` opens with a §3.1 guard primitive or is declared self-scoping. `LANGUAGE sql` can only ever be self-scoping (no first statement to guard with). Nothing anon-reachable unless allowlisted. No exposed function is `STRICT`. |
| 2 | Role × RPC matrix | `authorization-spine.test.ts` | 11 annotated RPCs × 4 roles. Disallowed pairs must come back `42501`; **permitted pairs must come back anything but `42501`**. |
| 3 | Write-path IDOR loop | `write-idor.test.ts` | 17 tables, 27 UPDATE/DELETE attempts. Each asserts the victim row was seeded, the statement wrote zero rows, and the row is byte-identical afterwards. |
| 4 | Column-grant audit | `authorization-spine.test.ts` | A denylist of privilege-bearing columns, plus the live assertion that the only column-scoped UPDATE surface is `profiles`' four safe fields. |
| 5 | Completeness | `authorization-spine.test.ts` | Every exposed function in exactly one classification, no stale annotations, every self-scoping entry names a scope test that exists and mentions it. |

Counts: **24** functions exposed to `authenticated` → **11** matrix annotations + **13** self-scoping entries, disjoint and exhaustive. **1** anon-reachable function (`can_read_product`). Scope-test coverage went from 5/13 to **13/13** — the eight that had none (`get_user_role`, `is_admin`, `is_parent_of`, `can_read_product`, `get_my_gamers`, `get_my_parents`, `is_voice_group_member`, `is_voice_group_moderator`) get one in the new `exposed-function-scope.test.ts`.

## Inherited items — both closed

**The NULL-role pass-through is closed** (`<>` → `IS DISTINCT FROM` in `assert_role`). Before writing the migration I swept `src/` for runtime paths that call a converted role-gated RPC through `createAdminClient`, since staging runs this the moment it is pushed. **There are none.** Every call site of the nine role-gated RPCs runs on the user-bound client from `requireRole()` or on the browser client through a service class; the `createAdminClient` calls that co-exist in those route files are for storage and auth-admin work. No `pg_cron` job and no other SQL function calls one either. The only callers that relied on the pass-through were db tests driving admin RPCs through the service-role client — `update-product.test.ts` and `gedu-registration.test.ts` now sign in as the seeded admin. The `KNOWN GAP` test is flipped to its inverse rather than deleted, so the closure is visible in the diff.

Newly refused, deliberately: a session whose `profiles` row was deleted mid-flight (the revocation case §3.1 exists for) and a `service_role` connection (which has no business impersonating a role it cannot name).

**`set_gedu_verified` is converted** to `assert_admin()`, so its refusal carries the canonical `42501`. Its `search_path` moved to the canonical empty form while it was open — the body was already fully qualified.

## Retirement

The grant-level function allowlists in `access-control.test.ts` are **gone**. They proved someone had *meant* to expose a function, not that its body enforced anything; checks 1+2+5 are a strict superset. The table-grant, RLS and `search_path` checks stay exactly where they were.

## Judgment calls

- **Check 1 is applied to every plpgsql function exposed to `authenticated`, not only `SECURITY DEFINER` ones.** `create_product`/`update_product` are `SECURITY INVOKER` and would have escaped the narrower reading — which is precisely why the guard primitives carry an `authenticated` grant at all. The partition is "role-gated or self-scoping", the same one check 5 enforces.
- **The matrix asserts both directions.** §3.4 names "an RPC annotated permissively passes check 2 vacuously" as this check's own failure mode; the positive half is what kills it. Exactly one RPC opts out (`get_gedu_assigned_product` raises a second `42501` for a gedu with no assignment — that is its *ownership* gate, not its role gate), and the opt-out carries its reason inline.
- **`assert_role` is exempt from check 1** — it *is* the guard; requiring it to open by calling itself is circular. `assert_admin` is deliberately not exempt, and passes on its own merits.
- **INSERT is out of scope for the IDOR loop.** A blocked INSERT and a constraint violation both surface as "an error", so the check would risk passing for the wrong reason unless every case carried a fully valid payload. UPDATE/DELETE need none — RLS filters the row out and the statement affects zero rows. INSERT `WITH CHECK` stays with the per-feature RLS tests, which do supply valid payloads. Every write-granted table has at least one of UPDATE/DELETE, so nothing is left uncovered.
- **The matrix posts to PostgREST directly** rather than through `supabase.rpc()`. Passing `null` for every argument is the whole calling convention, and the generated arg types forbid it — casting around them would be exactly the suppression the code-style rule warns about. The raw call is what the browser sends anyway.
- **Attackers in the IDOR loop are the sharpest wrong actor available**, not the weakest: the linked parent against their own child's `gamer_profiles` row, a voice group *member* against a moderator-only zone, the confined gamer against their own confinement row. A case where the attacker fails both the role clause and the ownership clause proves less than one where only ownership stands in the way.

## Migration `00121_auth_verification_spine.sql`

Supplies what the tests cannot express client-side: `_list_function_authorization_surface()` (language, `SECURITY DEFINER`, `STRICT`, argument names, body, per-role EXECUTE — replacing the narrower `_list_rpc_access()`) and `_list_column_grants(text)` (`information_schema.column_privileges`, the union of table- and column-level ACLs, which is what closes check 4's blind spot). Plus the two behaviour changes above. Pushed to staging, types regenerated, `schema.sql` dumped.

## Noted for Phase 3

- Every new RPC needs a matrix annotation or an allowlist entry with a scope test; every new write grant needs an IDOR case. That is the intended cost and the per-route checklist already anticipates it.
- **A dead grant**: `authenticated` holds `UPDATE` on `whatsapp_messages` with no UPDATE policy behind it, so it authorizes nothing today. Covered by the IDOR loop; should be revoked when that table is next touched.
- `assert_self` and the two §3.2 participation predicates stay `service_role`-only — nothing composes from them yet. The phase that puts them in a policy grants them then, and check 5 will require the classification at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Late finding (fixed in the second commit)

`can_read_product` answers SQL `NULL`, not `false`, for a caller with no `profiles` row: its first disjunct compares `get_user_role()` to `'admin'`, which is NULL for `anon`, and `NULL OR false OR false` is NULL. Harmless where it is used — a policy's `USING` clause treats NULL as deny — and the scope test now pins both the NULL and the deny (an `anon` read of the same product comes back empty) rather than papering over it with a truthiness check. Recorded in the doc as a `COALESCE(…, false)` worth adding when Phase 4 next touches that predicate.
