### PR TITLE
refactor(db-auth): Phase 3 — route sweep

### DIFF
--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -1,11 +1,10 @@
 # Database Authorization Architecture
 
 **Status:** target architecture + migration plan. The conventions in §2–§3 are how new
-code is written today; §5 Phase 1 (guard primitives + ownership predicates) and Phase 2
-(the §3.4 verification spine) have landed, and the route sweep (§5 Phase 3) and RLS
-completeness (Phase 4) are not yet built. This is the single source of truth for the
-refactor — when someone says "let's do the DB authorization refactor," this is the doc to
-read and act on.
+code is written today; §5 Phase 1 (guard primitives + ownership predicates), Phase 2 (the
+§3.4 verification spine) and Phase 3 (the route sweep) have landed; RLS completeness
+(Phase 4) is not yet built. This is the single source of truth for the refactor — when
+someone says "let's do the DB authorization refactor," this is the doc to read and act on.
 
 **Execution contract.** This doc is written so a fresh Claude Code session can execute
 the refactor from it. Before acting on any phase:
@@ -132,10 +131,14 @@ the verification spine treats each kind differently:
 - **Boolean predicates consumed by RLS policies**: `is_admin()`,
   `can_read_product()`, `is_parent_of()` — `STABLE SECURITY DEFINER`, return a
   boolean, never raise. `can_read_product` is the only function granted to `anon`.
-- **The participation state machine** (`join_waitlist`, `create_participation`,
-  `cancel_participation`, `confirm_reservation`, …): granted to **service_role
-  only** — not callable by `authenticated` at all. Routes invoke these via the
-  admin client today; that indirection is what Phase 3 removes.
+- **The participation state machine** (the waitlist-join, participation-create,
+  participation-cancel and reservation-confirm functions): granted to **service_role
+  only** — not callable by `authenticated` at all. Phase 3 put guarded,
+  `authenticated`-facing entry points in front of the ones a signed-in user may
+  legitimately drive, and left the engines themselves service_role-only. The ones
+  that remain reachable *only* by service_role are the ones whose callers genuinely
+  have no session: the Stripe webhook's cancel and confirm paths, and checkout's
+  reservation handling.
 
 Several of these are `LANGUAGE sql`, where "first statement" has no meaning — all
 current `sql`-language functions are predicates or self-scoping helpers, which is
@@ -427,10 +430,10 @@ What Phase 3 inherits:
   and every new write grant needs an IDOR case — the completeness checks fail the build
   otherwise. That is the intended cost, and it is what the per-route checklist below
   already anticipates.
-- **A dead grant worth folding into a later phase**: `authenticated` holds `UPDATE` on
-  `whatsapp_messages` with no UPDATE policy behind it, so it authorizes nothing today.
-  The IDOR loop covers it, but the grant should be revoked when that table is next
-  touched.
+- **A dead grant worth folding into a later phase**: `authenticated` held `UPDATE` on
+  `whatsapp_messages` with no UPDATE policy behind it, so it authorized nothing. Phase 3
+  revoked it while converting that route, and retired its IDOR case with it — the grant
+  layer now refuses those writes outright, which is the stronger guarantee.
 - **`can_read_product` answers `NULL`, not `false`, for a caller with no profiles row.**
   Its first disjunct compares `get_user_role()` to `'admin'`, which is NULL for `anon`,
   and `NULL OR false` is NULL. Harmless where it is used — a policy's `USING` clause
@@ -441,7 +444,7 @@ What Phase 3 inherits:
   phase that puts them in a policy or a `SECURITY INVOKER` body grants them then — and
   check 5 will require the classification at that point.
 
-### Phase 3 — the route sweep
+### Phase 3 — the route sweep — **landed**
 
 **Selection criteria** (use these, not a frozen list — regenerate with
 `git grep -l createAdminClient src/` and triage): a route is a conversion candidate if
@@ -453,33 +456,14 @@ context.
 The conversions come in three distinct shapes — triage each candidate into one:
 
 1. **Grant-plus-guard** (cheapest; the RPC already exists but is service_role-only,
-   and the route calls it via the admin client): add the guard primitive to the RPC
-   body, grant it to `authenticated`, switch the route to the user-bound client,
-   annotate it in the matrix. The waitlist-join, feedback-submission, and
-   admin-participation-cancel routes are this shape today.
+   and the route calls it via the admin client): guard the RPC, expose it to
+   `authenticated`, switch the route to the user-bound client, annotate it in the
+   matrix.
 2. **New RPC** (the route does direct admin-client writes to a grant-locked table):
-   write the Model C/D RPC per §3.5. The admin "comp-enroll a gamer onto a product"
-   route is the natural worked example.
+   write the Model C/D RPC per §3.5.
 3. **Client swap to Model B** (the route touches only normal tables): switch to the
    user-bound client and verify RLS grants the role the operation, both actor and
-   target halves. Candidates at time of writing: the admin outbound-WhatsApp write,
-   the PIN-forgot read, the external-account (Minecraft) upsert, and the voice-token
-   route's membership reads (which may instead justify a read predicate — investigate
-   before converting). Two carry extra work: the locale-update route uses the admin
-   client only to dodge a server-client *typing* issue — root-cause that rather than
-   carrying the workaround into the conversion; and the locations CRUD needs grant
-   changes too (`authenticated` currently lacks UPDATE on locations), not just a
-   client swap.
-
-**Verified non-candidates** (criterion (c), confirmed in triage — re-verify, don't
-assume): the auth-admin routes (gedu creation, password reset, PIN reset token flow,
-account switch, gamer metadata sync, gamer creation), the Stripe and WhatsApp
-webhooks, storage-upload portions of product create/update (their data writes already
-go through user-client RPCs), the Stripe-customer helper used by checkout and the
-billing portal (checkout's data reads already use the user client — its earlier
-"cross-user seat reads" concern turned out not to exist), and the family-list route
-(a gamer legitimately reads siblings beyond their own RLS view; the route scopes the
-admin client to the verified caller's family).
+   target halves.
 
 **Per-route checklist** before converting:
 1. No storage writes, no Auth Admin API calls remain on the converted path.
@@ -492,13 +476,122 @@ admin client to the verified caller's family).
 Batch by shape: the grant-plus-guard set first (smallest diff, settles the pattern),
 then Model B swaps, then new RPCs.
 
+#### The triage, machine-readably
+
+Every module that used the service-role client at triage time, with the write model it
+landed on. The route-layer refactor instance in `docs/refactor-playbook.md` consumes
+this as its own step-2 classification, so keep the shape stable and re-derive rather
+than edit when the surface changes. `shape` is the conversion shape above (`1`
+grant-plus-guard, `2` new RPC, `3` Model B swap) or `-` for a module that stayed Model
+A. Twelve of the twenty-nine modules dropped the service-role client entirely; three
+kept it for a narrowed purpose.
+
+```csv
+module,model,shape,justification
+src/app/api/participations/waitlist/route.ts,C,1,customer waitlist-join now runs on the user client against a customer-guarded RPC that reads the actor from the session
+src/app/api/feedback/route.ts,C+A,1,the submission write moved to a self-scoping RPC on the user client; the admin client survives only for the notification fan-out (every admin's email; a gamer's parent's) which is not in the submitter's RLS view and must not be returnable from an RPC
+src/app/api/admin/whatsapp/send/route.ts,B,3,contacts upsert + message insert run under the pre-existing admin-only policies; the message policy also pins direction to outbound
+src/app/api/auth/pin/forgot/route.ts,B,3,reads the caller's own PIN hash, already inside their RLS view
+src/app/api/minecraft/account/route.ts,B,3,self-write policies added; the row key comes from the session and never from the request
+src/app/api/user/locale/route.ts,B,3,column-level UPDATE grant on the locale column added; the pre-existing self-update policy scopes it
+src/app/api/admin/locations/create/route.ts,B,3,INSERT grant added so the pre-existing admin-only write policy is reachable
+src/app/api/admin/locations/[id]/route.ts,B,3,as above for UPDATE
+src/app/api/admin/products/[id]/participations/route.ts,C,2,participations is grant-locked; admin comp-enroll became an admin-guarded RPC carrying the product-type gate and parent resolution
+src/app/api/admin/products/[id]/participations/[participationId]/route.ts,C,2,same table; admin un-enroll became an admin-guarded RPC carrying the product-membership pair check and the live-subscription refusal
+src/app/api/admin/products/create/route.ts,A,-,admin client is used ONLY for a privileged-bucket storage upload; the data writes already run on the user client
+src/app/api/admin/products/[id]/update/route.ts,A,-,as above, plus storage deletes of superseded images
+src/app/api/auth/forgot-password/route.ts,A,-,Auth Admin API (recovery link generation)
+src/app/api/auth/pin/reset/route.ts,A,-,resolves its user from a signed token rather than a session, so there is no caller to act as
+src/app/api/auth/switch-account/route.ts,A,-,Auth Admin API (user lookup + magic-link generation)
+src/app/api/gamers/create/route.ts,A,-,Auth Admin API (user creation, with delete-on-failure compensation)
+src/app/api/gamers/[id]/route.ts,A,-,Auth Admin API (metadata + password updates) interleaved with writes to a LINKED user's rows; the parent-writes-gamer policy is Phase 4 work
+src/app/api/gedu/register/route.ts,A,-,Auth Admin API (self-registration creates the auth user before any session exists)
+src/app/api/webhooks/stripe/products/route.ts,A,-,webhook; no session by construction
+src/app/api/webhooks/whatsapp/route.ts,A,-,webhook; no session by construction
+src/app/api/minecraft/join-check/route.ts,A,-,server-to-server, authenticated by a shared API key rather than a user session
+src/app/api/checkout/products/create/route.ts,A,-,caches a Stripe customer id onto the grant-locked billing table; an authenticated write path there would let a user point their billing row at someone else's Stripe customer
+src/app/api/parent/billing-portal/route.ts,A,-,same Stripe-customer helper as checkout
+src/app/api/family/list/route.ts,A,-,a gamer legitimately reads siblings beyond their own RLS view; the resolver is scoped to the verified caller's family
+src/app/select-profile/page.tsx,A,-,same family resolver as the family-list route
+src/services/family/family.server.ts,A,-,the shared family resolver itself
+src/lib/pin-session-server.ts,A,-,resolves a PIN-reset token to a user id with no session in hand; shared by the reset page and the reset route
+src/app/api/voice/token/route.ts,A,-,see the judgment call below — the self-healing occupancy prune is a cross-user system write no participant is authorized to make
+src/lib/supabase/admin.ts,-,-,the client factory itself
+```
+
+#### Judgment calls
+
+- **The deployment window forced additive conversions rather than in-place guards.**
+  A migration reaches the shared staging database the moment it is pushed, but the code
+  running against that database only changes when the PR stack merges. Guarding an RPC
+  that the currently-deployed routes call through the service-role client would refuse
+  those calls — the caller has no `auth.uid()`, hence no role — and break staging for
+  the whole window. The rejected alternative was an `auth.uid() IS NULL` escape hatch
+  inside the guard: that reopens exactly the roleless-caller hole Phase 2 closed, in the
+  one place every guarded function shares, and "transitional" allowances in shared
+  primitives have a way of becoming permanent. So the grant-plus-guard shape landed as
+  *new* guarded entry points beside the untouched service_role-only engines. Nothing was
+  weakened for even one request, and no allowance needs remembering to remove — only two
+  now-redundant signatures need retiring (see the inherited items).
+- **The admin cancel route was not the shape the plan expected.** It was sketched as
+  grant-plus-guard; re-verification found the underlying cancel RPC is also called by
+  the Stripe webhook, which has no session by definition and must keep calling it as
+  service_role *permanently*. A role guard on that body would break the webhook for
+  good, not just through the deployment window. It stays a service_role-only engine and
+  the admin-facing entry point wraps it — which is also what lets the wrapper hold
+  admin-specific preconditions the webhook must not have.
+- **Moving route logic into an RPC closed a real race, not just a layer.** The
+  admin un-enroll path refuses to delete a participation that still has a live Stripe
+  subscription, because the CASCADE would orphan a subscription that keeps billing with
+  no DB row behind it. In the route that check and the delete were separate statements;
+  in the RPC they share a transaction and the product lock.
+- **The locale route's admin client was not a typing problem.** It carried a comment
+  blaming a `@supabase/ssr` version whose bug made `.update()` resolve as `never`. That
+  dependency has since moved two majors and the workaround was obsolete; the real reason
+  the write could not run as the user was a missing column grant. Root-caused and
+  removed rather than carried forward.
+- **The voice-token route stays Model A, deliberately.** Its membership reads would
+  convert cleanly, but the same handler performs a self-healing prune of stale
+  private-zone occupancy from *previous* session windows — a cross-user maintenance
+  DELETE that no individual participant is authorized to make (the delete policy is
+  moderator-only, and most joiners are not moderators). Converting only the reads would
+  leave the handler holding the service-role client anyway, so the trust boundary would
+  not move; it would only add a way for an RLS subtlety to lock a gamer out of a live
+  voice session. A member-scoped prune RPC is the obvious way to finish this and is
+  recorded as a Phase 4 candidate rather than forced here.
+- **The feedback route is a partial conversion and is recorded as such.** Its write is
+  Model C; its notification fan-out stays Model A. Folding the recipient lookup into the
+  RPC would make every admin's email address readable by any authenticated caller who
+  invoked that RPC directly, which is worse than the thing it would fix.
+
+What Phase 4 inherits:
+
+- **Two now-redundant function signatures.** The engines behind the waitlist-join and
+  feedback-submission entry points still carry their pre-Phase-3 signatures, which take
+  the caller's identity as a parameter. They are unreferenced by application code once
+  this stack deploys; drop them then, and drop their `service_role` grants with them.
+  Nothing depends on the timing beyond "after the deploy".
+- **A member-scoped voice-occupancy prune** would let the voice-token route convert; see
+  the judgment call above for why it was not forced into this phase.
+- **The parent-writes-linked-gamer policy** is the last thing keeping the gamer-update
+  route's data writes on the admin client (its Auth Admin calls keep it Model A
+  regardless). Phase 4 already plans this policy; landing it shrinks that route's
+  service-role surface to the auth work alone.
+- **`can_read_product` answers `NULL`, not `false`,** for a caller with no profiles row
+  — carried forward from Phase 2, still worth a total-boolean fix when that predicate is
+  next touched.
+- **The Phase 1 grant asymmetry still stands** for the self-assertion primitive and the
+  two §3.2 participation predicates: nothing composes from them yet, so they remain
+  `service_role`-only. Phase 4 is the phase that puts them in a policy.
+
 ### Phase 4 — RLS completeness
 
 Refactor existing write policies to compose from the §3.2 predicates so the write-IDOR
 loop passes everywhere; migrate inline `(SELECT get_user_role()) = 'admin'` policy
 comparisons to `is_admin()` opportunistically as policies are touched. Ship pending
 features that add write policies (e.g. a parent updating their linked gamer's profile
-fields) on the same predicates.
+fields) on the same predicates. Start from the inherited-items list at the end of
+Phase 3 — it is the backlog this phase clears.
 
 ---
 

--- a/src/app/api/admin/locations/[id]/route.ts
+++ b/src/app/api/admin/locations/[id]/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/api/json-body.server";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { updateLocationBody } from "@/services/locations/locations.contracts";
 
-// See ../create/route.ts — `locations` writes go through the admin client
-// because table DML is revoked from `authenticated`.
+// See ../create/route.ts — `locations` writes run on the user-bound client
+// behind the admin_manage_locations policy.
 
 export async function PATCH(
   request: Request,
@@ -15,6 +14,7 @@ export async function PATCH(
     forbiddenMessage: "Only admins can update locations",
   });
   if (result instanceof NextResponse) return result;
+  const { supabase } = result;
 
   const { id } = await params;
   if (!id) {
@@ -24,8 +24,7 @@ export async function PATCH(
   const body = await parseJsonBody(request, updateLocationBody);
   if (body instanceof NextResponse) return body;
 
-  const admin = createAdminClient();
-  const { data, error } = await admin
+  const { data, error } = await supabase
     .from("locations")
     .update(body)
     .eq("id", id)
@@ -33,7 +32,8 @@ export async function PATCH(
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    const status = error.code === "42501" ? 403 : 400;
+    return NextResponse.json({ error: error.message }, { status });
   }
   return NextResponse.json(data);
 }

--- a/src/app/api/admin/locations/create/route.ts
+++ b/src/app/api/admin/locations/create/route.ts
@@ -1,31 +1,34 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/api/json-body.server";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { createLocationBody } from "@/services/locations/locations.contracts";
 
-// `locations` is admin-only reference data — DML grants on the table are
-// revoked from `authenticated` (see migration 00021). Writes have to go
-// through the service-role admin client, which bypasses the grant.
+// `locations` is admin-only reference data. The write runs on the USER-bound
+// client: `authenticated` holds INSERT/UPDATE on the table and the
+// admin_manage_locations policy decides who may use it, so the route's role
+// check and the database's own answer have to agree before a row lands.
 
 export async function POST(request: Request) {
   const result = await requireRole("admin", {
     forbiddenMessage: "Only admins can create locations",
   });
   if (result instanceof NextResponse) return result;
+  const { supabase } = result;
 
   const body = await parseJsonBody(request, createLocationBody);
   if (body instanceof NextResponse) return body;
 
-  const admin = createAdminClient();
-  const { data, error } = await admin
+  const { data, error } = await supabase
     .from("locations")
     .insert(body)
     .select()
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    // 42501 is PostgreSQL's own refusal (grant or policy); anything else is the
+    // payload failing a constraint.
+    const status = error.code === "42501" ? 403 : 400;
+    return NextResponse.json({ error: error.message }, { status });
   }
   return NextResponse.json(data);
 }

--- a/src/app/api/admin/products/[id]/participations/[participationId]/route.ts
+++ b/src/app/api/admin/products/[id]/participations/[participationId]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { parseJsonBody } from "@/lib/api/json-body.server";
 import {
+  adminRemoveParticipationRpcResult,
   demoteToWaitlistRpcResult,
   promoteFromWaitlistRpcResult,
   waitlistTransitionBody,
@@ -12,23 +12,27 @@ import {
  * DELETE /api/admin/products/[id]/participations/[participationId]
  *
  * Admin-only un-enrollment — the inverse of the comp-enrollment POST on the
- * collection route. Hard-deletes the participation via the cancel_participation
- * RPC (reason 'admin_cancelled'), which removes the row and CASCADEs any linked
+ * collection route. Hard-deletes the participation, which CASCADEs any linked
  * family_subscriptions row.
  *
- * Gated to the same product types as the add path: blocked on consumer_club,
- * where enrollment is a recurring subscription and removal must go through
- * Stripe / the parent, not an admin hard-delete.
+ * Model C, like every other handler in this file: `participations` is
+ * grant-locked, so the write goes through `admin_remove_participation`, an
+ * admin-guarded SECURITY DEFINER RPC. Three preconditions live inside it rather
+ * than here, and each is safer there than it was in TypeScript:
  *
- * No refund is issued. cancel_participation only touches our DB — it never
- * calls Stripe. For the in-scope product types (camps/events one-shot, muni
- * invoiced off-platform) there is no live Stripe subscription anyway. We assert
- * that invariant before deleting: if the participation somehow has a live
- * stripe_subscription_id we refuse and log loudly, rather than CASCADE-orphan a
- * subscription that would keep billing the customer (see the guard below).
+ *  - the participation must be on THIS product (an id from another product
+ *    could otherwise be cancelled through this URL);
+ *  - consumer clubs are refused, where removal must go through Stripe and the
+ *    parent rather than an admin hard-delete;
+ *  - a participation with a live Stripe subscription is refused, because the
+ *    CASCADE would orphan a subscription that keeps billing the customer with
+ *    no DB record and no refund. In the RPC that check shares a transaction and
+ *    a product lock with the delete, so unlike the route-level version it has no
+ *    window between checking and deleting. It is unreachable under current
+ *    invariants — only consumer_club ever has a live sub — and stays as the
+ *    thing that fails loud if that ever changes.
  *
- * Uses the admin (service-role) client: cancel_participation is granted to
- * service_role only, and participations is grant-locked against authenticated.
+ * No refund is issued: nothing here calls Stripe.
  */
 export async function DELETE(
   _request: Request,
@@ -38,100 +42,72 @@ export async function DELETE(
     forbiddenMessage: "Only admins can remove gamers from a product",
   });
   if (result instanceof NextResponse) return result;
-  const { user } = result;
+  const { supabase, user } = result;
 
   const { id: productId, participationId } = await params;
 
-  const admin = createAdminClient();
+  const { data, error } = await supabase.rpc("admin_remove_participation", {
+    p_product_id: productId,
+    p_participation_id: participationId,
+  });
 
-  // IDOR guard: the participation must belong to THIS product, or a
-  // participationId from another product could be cancelled via this URL.
-  const { data: participation, error: fetchError } = await admin
-    .from("participations")
-    .select("id, product_id")
-    .eq("id", participationId)
-    .maybeSingle();
+  if (error) {
+    if (error.code === "42501") {
+      return NextResponse.json(
+        { error: "Only admins can remove gamers from a product" },
+        { status: 403 },
+      );
+    }
+    if (error.code === "P0002") {
+      return NextResponse.json(
+        { error: "Participation not found on this product" },
+        { status: 404 },
+      );
+    }
+    // 55000 (object_not_in_prerequisite_state) is the live-subscription
+    // refusal. It means an invariant we believe holds has stopped holding, so
+    // it is logged at error level with the identifiers needed to chase it.
+    if (error.code === "55000") {
+      console.error(
+        JSON.stringify({
+          event: "admin_remove_gamer_blocked_live_subscription",
+          admin_id: user.id,
+          product_id: productId,
+          participation_id: participationId,
+          detail: error.message,
+          at: new Date().toISOString(),
+        }),
+      );
+      return NextResponse.json(
+        {
+          error:
+            "This participation has a live Stripe subscription and can't be removed here. Cancel the subscription first.",
+        },
+        { status: 500 },
+      );
+    }
+    if (error.code === "23514") {
+      return NextResponse.json(
+        {
+          error:
+            "Admin remove-gamer is not supported for consumer clubs (recurring billing). Cancel the subscription instead.",
+        },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
 
-  if (fetchError) {
-    return NextResponse.json({ error: fetchError.message }, { status: 400 });
-  }
-  if (!participation || participation.product_id !== productId) {
-    return NextResponse.json(
-      { error: "Participation not found on this product" },
-      { status: 404 },
-    );
-  }
-
-  // Block consumer_club here as well as in the UI — defense in depth, symmetric
-  // with the add-gamer gate.
-  const { data: product, error: productError } = await admin
-    .from("products")
-    .select("product_type")
-    .eq("id", productId)
-    .maybeSingle();
-
-  if (productError) {
-    return NextResponse.json({ error: productError.message }, { status: 400 });
-  }
-  if (!product) {
-    return NextResponse.json({ error: "Product not found" }, { status: 404 });
-  }
-  if (product.product_type === "consumer_club") {
-    return NextResponse.json(
-      {
-        error:
-          "Admin remove-gamer is not supported for consumer clubs (recurring billing). Cancel the subscription instead.",
-      },
-      { status: 400 },
-    );
-  }
-
-  // Money-path safety: refuse to hard-delete a participation that still has a
-  // live Stripe subscription. cancel_participation CASCADEs the
-  // family_subscriptions row away, so once it runs the orphan already exists —
-  // this guard MUST sit before the RPC, not after its return value. Under
-  // current invariants it's unreachable (only consumer_club, blocked above,
-  // ever has a live sub, and product_type is immutable), but if that ever
-  // changes, deleting here would bill the customer forever with no DB record
-  // and no refund. Fail loud instead.
-  // family_subscriptions.participation_id is UNIQUE (≤1 row, so maybeSingle is
-  // safe) and stripe_subscription_id is NOT NULL — so the mere existence of a
-  // row here means a live Stripe sub is linked.
-  const { data: liveSub, error: subError } = await admin
-    .from("family_subscriptions")
-    .select("stripe_subscription_id")
-    .eq("participation_id", participationId)
-    .maybeSingle();
-
-  if (subError) {
-    return NextResponse.json({ error: subError.message }, { status: 400 });
-  }
-  if (liveSub) {
+  const parsed = adminRemoveParticipationRpcResult.safeParse(data);
+  if (!parsed.success) {
     console.error(
-      JSON.stringify({
-        event: "admin_remove_gamer_blocked_live_subscription",
-        admin_id: user.id,
-        product_id: productId,
-        participation_id: participationId,
-        stripe_subscription_id: liveSub.stripe_subscription_id,
-        at: new Date().toISOString(),
-      }),
+      "admin_remove_participation returned an unexpected shape:",
+      parsed.error.message,
     );
     return NextResponse.json(
-      {
-        error:
-          "This participation has a live Stripe subscription and can't be removed here. Cancel the subscription first.",
-      },
+      { error: "Failed to remove gamer" },
       { status: 500 },
     );
-  }
-
-  const { data: rpcResult, error: rpcError } = await admin.rpc(
-    "cancel_participation",
-    { p_participation_id: participationId, p_reason: "admin_cancelled" },
-  );
-  if (rpcError) {
-    return NextResponse.json({ error: rpcError.message }, { status: 400 });
   }
 
   // Audit trail — mirrors admin_add_gamer so we can answer "which admin
@@ -143,7 +119,7 @@ export async function DELETE(
       admin_id: user.id,
       product_id: productId,
       participation_id: participationId,
-      result: rpcResult,
+      result: parsed.data,
       at: new Date().toISOString(),
     }),
   );
@@ -161,8 +137,8 @@ export async function DELETE(
  *  - `demote` — an active gamer dragged onto the waitlist. Sends them to the
  *    back via demote_to_waitlist (status→waitlisted, group cleared).
  *
- * Unlike the DELETE handler above, this uses the USER-context client, not the
- * admin client: both RPCs re-check get_user_role() = 'admin' internally (like
+ * Same shape as the DELETE handler above: the user-context client against an
+ * admin-guarded RPC. Both RPCs re-check the caller's role internally (like
  * apply_group_changes, their drag-UI sibling), so they must run with the
  * caller's JWT — a service-role call has no auth.uid() and would be Forbidden.
  *

--- a/src/app/api/admin/products/[id]/participations/route.ts
+++ b/src/app/api/admin/products/[id]/participations/route.ts
@@ -2,34 +2,23 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/api/json-body.server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { adminEnrollGamerRpcResult } from "@/services/participations/participations.contracts";
 
 /**
  * POST /api/admin/products/[id]/participations
  *
- * Admin-only comp-enrollment path: drops a gamer directly into a product
- * with status='active', bypassing payment, seat caps, registration windows,
- * and effective-status gates. The customer_id is resolved from parent_gamer
- * (one parent per gamer; multi-parent reckoning is future work).
+ * Admin-only comp-enrollment: drops a gamer directly into a product with
+ * status='active', bypassing payment, seat caps, registration windows, and
+ * effective-status gates.
  *
- * Blocked on consumer_club (recurring subscription/bundle billing makes a
- * no-payment comp awkward and we don't model it yet). Camps, events, and
- * municipality clubs are all in scope — camps + events are one-shot paid /
- * free, muni is invoiced off-platform via external_contract.
- *
- * Uses the admin (service-role) client for the write. participations is
- * grant-locked: REVOKE ALL FROM authenticated + GRANT SELECT only, so even
- * with the admin_full_access_participations RLS policy in place,
- * PostgreSQL rejects authenticated INSERTs at the grant level. Writes
- * happen through SECURITY DEFINER RPCs or createAdminClient by design
- * (migration 00039). We deliberately bypass create_participation here
- * because its gates (parent-of-customer, registration-opens-at,
- * effective-status, seat-cap) are exactly what this admin override should
- * sail past.
- *
- * The SECURITY DEFINER RPC + user-bound client pattern is a better
- * architectural fit for this route; conversion is planned as part of the
- * database authorization refactor.
+ * Model C. `participations` is grant-locked — `authenticated` holds SELECT and
+ * nothing else, because a stray write there is a free seat — so this runs on the
+ * user-bound client through `admin_enroll_gamer`, a SECURITY DEFINER RPC whose
+ * first statement is the admin guard. The rules that survive the override
+ * (product exists, consumer clubs out of scope, the gamer needs a linked parent
+ * to attribute the participation to) live in the RPC rather than here, so they
+ * hold for any admin calling it, not only for requests that came through this
+ * handler.
  */
 export async function POST(
   request: Request,
@@ -39,7 +28,7 @@ export async function POST(
     forbiddenMessage: "Only admins can add gamers directly to a product",
   });
   if (result instanceof NextResponse) return result;
-  const { user } = result;
+  const { supabase, user } = result;
 
   const { id: productId } = await params;
 
@@ -50,95 +39,57 @@ export async function POST(
   if (body instanceof NextResponse) return body;
   const { gamerId } = body;
 
-  const admin = createAdminClient();
+  const { data, error } = await supabase.rpc("admin_enroll_gamer", {
+    p_product_id: productId,
+    p_gamer_id: gamerId,
+  });
 
-  // Fetch product type. Consumer clubs are blocked here in addition to the
-  // UI gate — defense in depth against direct route calls.
-  const { data: product, error: productError } = await admin
-    .from("products")
-    .select("id, product_type")
-    .eq("id", productId)
-    .maybeSingle();
-
-  if (productError) {
-    return NextResponse.json({ error: productError.message }, { status: 400 });
-  }
-  if (!product) {
-    return NextResponse.json({ error: "Product not found" }, { status: 404 });
-  }
-  if (product.product_type === "consumer_club") {
-    return NextResponse.json(
-      {
-        error:
-          "Admin add-gamer is not supported for consumer clubs (recurring billing). Have the parent purchase a subscription instead.",
-      },
-      { status: 400 },
-    );
-  }
-
-  // Resolve the gamer's parent. We assume a single parent per gamer; if a
-  // gamer is somehow linked to multiple parents we pick the oldest link
-  // deterministically. Multi-parent UX is tracked for future work.
-  const { data: parentLinks, error: parentError } = await admin
-    .from("parent_gamer")
-    .select("parent_id, created_at")
-    .eq("gamer_id", gamerId)
-    .order("created_at", { ascending: true })
-    .limit(1);
-
-  if (parentError) {
-    return NextResponse.json({ error: parentError.message }, { status: 400 });
-  }
-  if (parentLinks.length === 0) {
-    return NextResponse.json(
-      { error: "Gamer has no linked parent — cannot enroll" },
-      { status: 400 },
-    );
-  }
-  const customerId = parentLinks[0].parent_id;
-
-  // Direct insert via service-role — bypasses the grant lockdown on
-  // participations (REVOKE ALL FROM authenticated) that exists to
-  // funnel writes through SECURITY DEFINER RPCs or createAdminClient.
-  const { data: inserted, error: insertError } = await admin
-    .from("participations")
-    .insert({
-      product_id: productId,
-      gamer_id: gamerId,
-      customer_id: customerId,
-      status: "active",
-    })
-    .select("id")
-    .single();
-
-  if (insertError) {
+  if (error) {
     // 23505 = the partial unique index on (product_id, gamer_id) for
     // non-reserving statuses fired — the gamer is already enrolled (active,
     // waitlisted, or completed).
-    if (insertError.code === "23505") {
+    if (error.code === "23505") {
       return NextResponse.json(
         { error: "This gamer is already enrolled on the product" },
         { status: 409 },
       );
     }
-    return NextResponse.json({ error: insertError.message }, { status: 400 });
+    if (error.code === "42501") {
+      return NextResponse.json(
+        { error: "Only admins can add gamers directly to a product" },
+        { status: 403 },
+      );
+    }
+    if (error.code === "P0002") {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 400 });
   }
 
-  // Audit log line — there's no audit column on participations per the
-  // product spec, but a server-side trail is necessary so we can answer
-  // "which admin comped this gamer onto this product?" later. Hosted log
-  // aggregation picks this up; no DB write.
+  const parsed = adminEnrollGamerRpcResult.safeParse(data);
+  if (!parsed.success) {
+    console.error(
+      "admin_enroll_gamer returned an unexpected shape:",
+      parsed.error.message,
+    );
+    return NextResponse.json({ error: "Failed to enroll gamer" }, { status: 500 });
+  }
+
+  // Audit log line — there's no audit column on participations per the product
+  // spec, but a server-side trail is necessary so we can answer "which admin
+  // comped this gamer onto this product?" later. Hosted log aggregation picks
+  // this up; no DB write.
   console.info(
     JSON.stringify({
       event: "admin_add_gamer",
       admin_id: user.id,
       product_id: productId,
       gamer_id: gamerId,
-      customer_id: customerId,
-      participation_id: inserted.id,
+      customer_id: parsed.data.customer_id,
+      participation_id: parsed.data.participation_id,
       at: new Date().toISOString(),
     }),
   );
 
-  return NextResponse.json({ participation_id: inserted.id });
+  return NextResponse.json({ participation_id: parsed.data.participation_id });
 }

--- a/src/app/api/admin/whatsapp/send/route.ts
+++ b/src/app/api/admin/whatsapp/send/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
 import { sendWhatsAppMessage } from "@/lib/whatsapp";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { WHATSAPP_DIRECTION, WHATSAPP_MESSAGE_STATUS } from "@/types";
 import { z } from "zod";
 
@@ -18,6 +17,7 @@ export async function POST(request: Request) {
       forbiddenMessage: "Only admins can send WhatsApp messages",
     });
     if (result instanceof NextResponse) return result;
+    const { supabase } = result;
 
     const json = await request.json();
     const parsed = requestSchema.safeParse(json);
@@ -37,27 +37,40 @@ export async function POST(request: Request) {
       body,
     });
 
-    // Store outbound message and upsert contact.
-    // DB errors are not checked — the message is already sent to Meta at this
-    // point, so failing the request would mislead the admin. A DB failure here
-    // is near-impossible anyway (service role, no RLS, no token expiry).
-    const admin = createAdminClient();
+    // Store outbound message and upsert contact on the USER-bound client: the
+    // whatsapp_contacts insert/update and whatsapp_messages insert policies each
+    // re-check that the caller is an admin, and the message policy additionally
+    // pins `direction` to outbound — so this route cannot forge inbound history
+    // even if it tried.
+    //
+    // Neither failure fails the request: the message is already at Meta by this
+    // point, so a 500 would tell the admin their message didn't send when it
+    // did. They are logged instead — under RLS a DB refusal here is a real
+    // signal (it used to be near-impossible under service role), so it must not
+    // be swallowed silently.
     const now = new Date().toISOString();
 
-    await admin.from("whatsapp_contacts").upsert(
-      { phone: to, last_message_at: now },
-      { onConflict: "phone" }
-    );
+    const { error: contactError } = await supabase
+      .from("whatsapp_contacts")
+      .upsert({ phone: to, last_message_at: now }, { onConflict: "phone" });
+    if (contactError) {
+      console.error("[whatsapp/send] contact upsert failed", contactError);
+    }
 
-    await admin.from("whatsapp_messages").insert({
-      id: messageId,
-      phone: to,
-      direction: WHATSAPP_DIRECTION.OUTBOUND,
-      body,
-      message_type: "text",
-      status: WHATSAPP_MESSAGE_STATUS.PENDING,
-      created_at: now,
-    });
+    const { error: messageError } = await supabase
+      .from("whatsapp_messages")
+      .insert({
+        id: messageId,
+        phone: to,
+        direction: WHATSAPP_DIRECTION.OUTBOUND,
+        body,
+        message_type: "text",
+        status: WHATSAPP_MESSAGE_STATUS.PENDING,
+        created_at: now,
+      });
+    if (messageError) {
+      console.error("[whatsapp/send] message insert failed", messageError);
+    }
 
     return NextResponse.json({ messageId });
   } catch (error) {

--- a/src/app/api/auth/pin/forgot/route.ts
+++ b/src/app/api/auth/pin/forgot/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { sendTransactionalEmail } from "@/lib/brevo";
 import { SENDER_EMAIL } from "@/lib/constants";
 import { ROUTES } from "@/lib/constants/routes";
@@ -18,7 +17,7 @@ import { getOrigin } from "@/lib/url";
 export async function POST(request: Request) {
   const auth = await requireRole("customer", { allowUnverified: true });
   if (auth instanceof NextResponse) return auth;
-  const { user, profile } = auth;
+  const { user, profile, supabase } = auth;
 
   // No email on file → nothing to send. Succeed silently (no info leak).
   if (!profile.email) {
@@ -27,9 +26,10 @@ export async function POST(request: Request) {
 
   // Bind the token to the current PIN hash so it's single-use: completing the
   // reset rotates the hash and the token stops validating (see pin-session.ts).
-  // Read via the admin client (bypasses RLS; the hash never leaves the server).
-  const admin = createAdminClient();
-  const { data: cp } = await admin
+  // Read on the user-bound client — the caller's own customer_profiles row is
+  // inside their RLS view, so nothing here needs the service-role bypass. The
+  // hash is used only to derive the signature and never leaves the server.
+  const { data: cp } = await supabase
     .from("customer_profiles")
     .select("pin_hash")
     .eq("user_id", user.id)

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: Request) {
     const result = await requireRole(["admin", "customer", "gamer", "gedu"]);
     if (result instanceof NextResponse) return result;
 
-    const { user, profile } = result;
+    const { user, profile, supabase } = result;
 
     const body = await request.json();
     const parsed = feedbackSchema.safeParse(body);
@@ -31,13 +31,14 @@ export async function POST(request: Request) {
       );
     }
 
-    const adminClient = createAdminClient();
-
-    // Atomic rate-limit check + insert via RPC (prevents concurrent bypass)
-    const { data: accepted, error: rpcError } = await adminClient.rpc("submit_feedback", {
-      p_user_id: user.id,
-      p_message: parsed.data.message,
-    });
+    // Atomic rate-limit check + insert via a self-scoping RPC on the USER-bound
+    // client: `submit_my_feedback` writes a row for `auth.uid()` and has no
+    // parameter naming a user, so this handler cannot file feedback as anyone
+    // else. It re-checks the same length bounds the schema above enforces.
+    const { data: accepted, error: rpcError } = await supabase.rpc(
+      "submit_my_feedback",
+      { p_message: parsed.data.message },
+    );
 
     if (rpcError) {
       console.error("Failed to submit feedback:", rpcError);
@@ -51,7 +52,14 @@ export async function POST(request: Request) {
       );
     }
 
-    // Get all admin emails
+    const adminClient = createAdminClient();
+
+    // From here on the work is *notification*, not the user's own write, and it
+    // stays on the service-role client by necessity: the recipient list is every
+    // admin's email address, and a gamer's reply-to is their parent's. Neither
+    // is in the submitter's RLS view, and neither may be — an RPC that returned
+    // them would be readable by any authenticated caller who invoked it
+    // directly. Nothing read here is ever echoed back in the response.
     const { data: admins, error: adminsError } = await adminClient
       .from("profiles")
       .select("email")

--- a/src/app/api/minecraft/account/route.ts
+++ b/src/app/api/minecraft/account/route.ts
@@ -1,14 +1,24 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
 
+/**
+ * PATCH /api/minecraft/account — link (or unlink) the CALLER'S OWN Minecraft
+ * account.
+ *
+ * Model B: the upsert runs on the user-bound client, so the
+ * users_insert_own_minecraft_account / users_update_own_minecraft_account
+ * policies re-derive the target row from `auth.uid()`. The row key is the
+ * session's user id and is never read from the request, so there is no way to
+ * name someone else's row here — and if that ever changed, RLS would refuse it.
+ */
 export async function PATCH(request: Request) {
   try {
     const result = await requireRole(["gamer", "gedu"], {
       forbiddenMessage: "Only gamers and gedus can update their Minecraft username",
     });
     if (result instanceof NextResponse) return result;
+    const { supabase } = result;
 
     const { minecraftUsername } = await request.json();
 
@@ -24,7 +34,6 @@ export async function PATCH(request: Request) {
       }
     }
 
-    const admin = createAdminClient();
     let upsertData: { user_id: string; minecraft_username: string | null; minecraft_uuid: string | null };
 
     if (minecraftUsername === null) {
@@ -38,7 +47,7 @@ export async function PATCH(request: Request) {
       };
     }
 
-    const { error } = await admin
+    const { error } = await supabase
       .from("minecraft_accounts")
       .upsert(upsertData, { onConflict: "user_id" });
 
@@ -47,6 +56,12 @@ export async function PATCH(request: Request) {
         return NextResponse.json(
           { error: "This Minecraft account is already linked to another user" },
           { status: 409 },
+        );
+      }
+      if (error.code === "42501") {
+        return NextResponse.json(
+          { error: "Not authorized to update this Minecraft account" },
+          { status: 403 },
         );
       }
       return NextResponse.json({ error: "Failed to update Minecraft account" }, { status: 500 });

--- a/src/app/api/participations/waitlist/route.ts
+++ b/src/app/api/participations/waitlist/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
   if (!parsed.success) {
     console.error(
       "join_product_waitlist returned an unexpected shape:",
-      parsed.error,
+      parsed.error.message,
     );
     return NextResponse.json(
       { error: "Failed to join waitlist" },

--- a/src/app/api/participations/waitlist/route.ts
+++ b/src/app/api/participations/waitlist/route.ts
@@ -1,37 +1,51 @@
 import { NextResponse } from "next/server";
 import { requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/api/json-body.server";
-import { createAdminClient } from "@/lib/supabase/admin";
 import {
   joinWaitlistBody,
   joinWaitlistRpcResult,
 } from "@/services/participations/participations.contracts";
 
+/**
+ * POST /api/participations/waitlist
+ *
+ * Model C: the user-bound client calls a guarded SECURITY DEFINER RPC. The
+ * caller's identity is not a parameter — `join_product_waitlist` reads it from
+ * `auth.uid()` — so this handler cannot waitlist anyone on behalf of anyone
+ * else, and the RPC's own guard refuses a non-customer even if this route's
+ * role check were bypassed.
+ */
 export async function POST(request: Request) {
   const result = await requireRole("customer", {
     forbiddenMessage: "Only customers can join a waitlist",
   });
   if (result instanceof NextResponse) return result;
-  const { user } = result;
+  const { supabase } = result;
 
   const body = await parseJsonBody(request, joinWaitlistBody);
   if (body instanceof NextResponse) return body;
   const { productId, gamerId } = body;
 
-  const admin = createAdminClient();
-  const { data, error } = await admin.rpc("join_waitlist", {
+  const { data, error } = await supabase.rpc("join_product_waitlist", {
     p_product_id: productId,
     p_gamer_id: gamerId,
-    p_customer_id: user.id,
   });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    // The RPC raises the canonical forbidden code when the caller is not a
+    // customer; everything else it raises (missing product, not the gamer's
+    // parent, waitlist disabled) is a request the customer may make but that
+    // this data refuses.
+    const status = error.code === "42501" ? 403 : 400;
+    return NextResponse.json({ error: error.message }, { status });
   }
 
   const parsed = joinWaitlistRpcResult.safeParse(data);
   if (!parsed.success) {
-    console.error("join_waitlist returned an unexpected shape:", parsed.error);
+    console.error(
+      "join_product_waitlist returned an unexpected shape:",
+      parsed.error,
+    );
     return NextResponse.json(
       { error: "Failed to join waitlist" },
       { status: 500 },

--- a/src/app/api/user/locale/route.ts
+++ b/src/app/api/user/locale/route.ts
@@ -1,15 +1,30 @@
 import { NextResponse } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { isSupportedLocale } from "@/lib/constants/locales";
 
+/**
+ * PATCH /api/user/locale — set the caller's own UI locale.
+ *
+ * Model B. `profiles.locale` carries a column-level UPDATE grant and the
+ * users_update_own_profile policy scopes the statement to `auth.uid()`, so the
+ * database refuses a write aimed at anyone else's row even though this handler
+ * never aims one.
+ *
+ * (The route previously used the service-role client to work around a typing
+ * problem in @supabase/ssr 0.5.2, where `.update()` resolved as `never`. That
+ * dependency is on 0.9 now and the workaround was obsolete — the grant, not the
+ * types, was the real reason the write couldn't run as the user.)
+ */
 export async function PATCH(request: Request) {
   try {
-    // `getUser()` here is the getClaims-backed server helper (local JWT
-    // verification), not GoTrue's `auth.getUser()`. We only need the user id.
-    const user = await getUser();
+    const supabase = await createClient();
 
-    if (!user) {
+    // `getClaims()` verifies the access token locally against the project JWKS —
+    // no GoTrue round-trip. We only need the subject.
+    const { data, error: claimsError } = await supabase.auth.getClaims();
+    const userId = data?.claims.sub;
+
+    if (claimsError || !userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -22,22 +37,17 @@ export async function PATCH(request: Request) {
       );
     }
 
-    // Admin client because @supabase/ssr v0.5.2's createServerClient resolves
-    // .update() as `never` — likely a mismatch with the __InternalSupabase key
-    // in the generated Database type. Try the server client again if
-    // @supabase/ssr is upgraded (current: 0.5.2, latest: 0.8.0).
-    // Safe: user.id comes from the authenticated session, not the request body.
-    const admin = createAdminClient();
-    const { error } = await admin
+    const { error } = await supabase
       .from("profiles")
       .update({ locale })
-      .eq("id", user.id);
+      .eq("id", userId);
 
     if (error) {
       console.error("Locale update error:", error);
+      const status = error.code === "42501" ? 403 : 500;
       return NextResponse.json(
         { error: "Failed to update locale" },
-        { status: 500 },
+        { status },
       );
     }
 

--- a/src/services/locations/CLAUDE.md
+++ b/src/services/locations/CLAUDE.md
@@ -16,7 +16,7 @@ Hierarchy is flexible, not rigid — not every country uses every level (Finland
 
 Standard service pattern. `LocationsService` takes an `AppSupabaseClient`:
 - **Reads** (`getAllLocations`, `getLocation`) use the injected client directly against `locations`.
-- **Writes** (`createLocation`, `updateLocation`) `fetch()` the admin API (`/api/admin/locations/...`). The `locations` table's DML grants are revoked from `authenticated`, so browser writes must go through the admin client server-side. The injected client is intentionally unused by write methods.
+- **Writes** (`createLocation`, `updateLocation`) `fetch()` the admin API (`/api/admin/locations/...`). The route re-checks the role and performs the write on the caller's own server-side client, so the admin-only write policy on `locations` is the second layer behind it; `authenticated` holds INSERT and UPDATE but no DELETE, which is why there is no delete route. The injected client is intentionally unused by write methods.
 
 `locations.queries.ts` exposes React Query hooks plus the `locationKeys` factory. `locations.contracts.ts` holds the zod schemas (`createLocationBody`, `updateLocationBody`, `locationRow`) shared by route and service; enum values derive from `Constants.public.Enums.location_type`. Re-exports in `index.ts`.
 

--- a/src/services/participations/participations.contracts.ts
+++ b/src/services/participations/participations.contracts.ts
@@ -104,3 +104,29 @@ export const demoteToWaitlistRpcResult = z.discriminatedUnion("kind", [
   }),
   z.object({ kind: z.literal("noop"), status: z.string() }),
 ]);
+
+/**
+ * `admin_enroll_gamer` RPC result (Json in codegen; structure from schema.sql).
+ * The customer id is resolved inside the function from the gamer's parent link,
+ * so the route learns it from the result rather than looking it up itself.
+ */
+export const adminEnrollGamerRpcResult = z.object({
+  participation_id: z.string(),
+  customer_id: z.string(),
+});
+
+/**
+ * `admin_remove_participation` RPC result. It delegates to
+ * `cancel_participation`, so the shape is that function's: `cancelled` with the
+ * details the audit line needs, or `noop` when the row had already gone.
+ */
+export const adminRemoveParticipationRpcResult = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("cancelled"),
+    product_id: z.string(),
+    previous_status: z.string(),
+    stripe_subscription_id: z.string().nullable(),
+    reason: z.string(),
+  }),
+  z.object({ kind: z.literal("noop") }),
+]);

--- a/src/services/pin/CLAUDE.md
+++ b/src/services/pin/CLAUDE.md
@@ -64,7 +64,10 @@ security, not a guarantee.
 - `set_my_pin(pin)` / `verify_my_pin(pin)` / `pin_is_set()` — `auth.uid()`-scoped,
   granted to `authenticated`, touch only the caller's own row.
 - `set_pin_for_user(user_id, pin)` — admin-only (REVOKE'd from `authenticated`),
-  used solely by the email-reset route via the service-role client.
+  used solely by the email-reset route via the service-role client. That route
+  resolves its user from a signed token rather than a session, so it genuinely
+  has no caller to act as; the *forgot* route, which reads the caller's own hash
+  to bind the token, uses the caller's client and its own-row read policy.
 
 There is no rate-limiting and no PIN-strength validation beyond "exactly 4
 digits". Both are **deliberate**, not oversights:
@@ -130,9 +133,9 @@ Follows the project two/three-file pattern (see root `CLAUDE.md` § Service Laye
 - `pin.service.ts` — `PinService(supabase)`. The one read (`isSet`) uses the
   injected client (`pin_is_set` is granted to `authenticated`, own-row scoped).
   All writes (`verify`, `setPin`, `forgot`, `reset`) and the unlock-aware
-  `status` read go through the API routes — they set/clear the HMAC cookie or
-  touch the admin client, neither of which the browser client can do. The
-  injected client is unused by those methods, intentionally.
+  `status` read go through the API routes — they set/clear the HMAC cookie, or
+  need the PIN hash server-side to bind a reset token, neither of which the
+  browser may do. The injected client is unused by those methods, intentionally.
 - `pin.contracts.ts` — zod schemas for the route responses (`pinStatusResponse`,
   `pinVerifyResponse`), parsed via `parseJsonResponse`.
 - `pin.queries.ts` — React Query hooks + `pinKeys`.

--- a/src/services/whatsapp/CLAUDE.md
+++ b/src/services/whatsapp/CLAUDE.md
@@ -33,7 +33,7 @@ Use the `WHATSAPP_DIRECTION` / `WHATSAPP_MESSAGE_STATUS` const objects for these
 
 **Rule: Inbound persistence is upsert, not insert.** Meta retries deliveries on transient failures, so duplicate message IDs are expected — upsert on `id` (messages) and `phone` (contacts) to stay idempotent. The admin send route inserts (the `messageId` is fresh from the Graph response).
 
-**Rule: After a successful outbound send, do not fail the request on a DB write error.** The message is already delivered to Meta by then; failing would mislead the admin. The send route records the message/contact best-effort and still returns `{ messageId }`. (A DB failure there is near-impossible — service role, no RLS, no token expiry.)
+**Rule: After a successful outbound send, do not fail the request on a DB write error.** The message is already delivered to Meta by then; failing would mislead the admin. The send route records the message/contact best-effort and still returns `{ messageId }`. Log the failure rather than swallowing it: the write runs on the caller's own client under RLS, so a refusal is a real signal about grants or policies, not the impossibility it was when the route held the service-role key.
 
 **Rule: Surface the 24-hour-window failure in plain language.** WhatsApp forbids business-initiated free-form replies more than 24h after the customer's last message. When a delivery status comes back `failed` with Meta error `131047` (or a title mentioning "re-engage"), store a support-friendly `status_error` explaining the customer must message first — not Meta's raw title.
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1277,6 +1277,14 @@ export type Database = {
           table_name: string
         }[]
       }
+      admin_enroll_gamer: {
+        Args: { p_gamer_id: string; p_product_id: string }
+        Returns: Json
+      }
+      admin_remove_participation: {
+        Args: { p_participation_id: string; p_product_id: string }
+        Returns: Json
+      }
       apply_group_changes: {
         Args: {
           p_added_groups?: Json

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1467,6 +1467,10 @@ export type Database = {
         Args: { p_group_id: string }
         Returns: boolean
       }
+      join_product_waitlist: {
+        Args: { p_gamer_id: string; p_product_id: string }
+        Returns: Json
+      }
       join_waitlist: {
         Args: {
           p_customer_id: string
@@ -1522,6 +1526,7 @@ export type Database = {
         Args: { p_message: string; p_user_id: string }
         Returns: boolean
       }
+      submit_my_feedback: { Args: { p_message: string }; Returns: boolean }
       update_product: {
         Args: {
           p_assistant_gedu_fee_cents?: number

--- a/supabase/migrations/00122_phase3_self_service_rpcs.sql
+++ b/supabase/migrations/00122_phase3_self_service_rpcs.sql
@@ -1,0 +1,114 @@
+-- Phase 3 of the DB authorization refactor (docs/db-authorization-architecture.md
+-- §5 Phase 3), batch 1 of 3: the "grant-plus-guard" shape.
+--
+-- Two routes drove a participation/feedback write through the service-role
+-- client purely because the RPC behind them was granted to service_role only.
+-- Both are things the signed-in user is themselves authorized to do, so the
+-- indirection bought nothing but a wider blast radius.
+--
+-- WHY THIS ADDS FUNCTIONS INSTEAD OF GUARDING THE EXISTING ONES
+--
+-- The obvious move — put a guard primitive at the top of join_waitlist /
+-- submit_feedback and grant them to `authenticated` — cannot be made safely in
+-- this migration. Migrations reach the shared staging database the moment they
+-- are pushed, but the code deployed against that database only changes when this
+-- refactor's PR stack merges. Through that window, staging's CURRENTLY deployed
+-- routes still call both functions through the service-role client, which has no
+-- auth.uid() and therefore no role: a guard added today refuses them and breaks
+-- staging until the merge lands.
+--
+-- The alternative fix — an `auth.uid() IS NULL` escape hatch inside the guard —
+-- reopens exactly the roleless-caller hole 00121 closed, and does so in the one
+-- place that is shared by every guarded function. So instead this migration is
+-- purely ADDITIVE: new, guarded, `authenticated`-facing entry points that the
+-- converted routes call, with the old service_role-only functions left untouched
+-- as the engine underneath. Old code keeps working, new code is guarded, and
+-- nothing is weakened for even one request. Retiring the now-redundant
+-- three-argument join_waitlist and two-argument submit_feedback signatures is an
+-- inherited Phase 4 item, safe to do once this stack has been deployed.
+--
+-- Naming note: these are the names the entry points would carry anyway. The
+-- caller's own identity is no longer a parameter — it is read from auth.uid()
+-- inside the function — so the signatures genuinely differ from the engines they
+-- delegate to, rather than being transitional aliases for them.
+
+-- ---------------------------------------------------------------------------
+-- join_product_waitlist — role-gated (customer)
+-- ---------------------------------------------------------------------------
+-- The route previously passed the caller's own id as p_customer_id. Deriving it
+-- from auth.uid() here removes the parameter a compromised route handler could
+-- get wrong: a customer can now only ever waitlist AS THEMSELVES, and the
+-- parent-of-gamer check inside join_waitlist remains the target half of the
+-- authorization (the caller must be the gamer's parent).
+
+CREATE OR REPLACE FUNCTION public.join_product_waitlist(
+  p_product_id uuid,
+  p_gamer_id   uuid
+) RETURNS jsonb
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+BEGIN
+  PERFORM public.assert_role('customer');
+
+  -- Everything else — product lock, parent-of-gamer check, waitlist_enabled
+  -- gate, idempotency, the clock_timestamp() ordering stamp — is unchanged and
+  -- lives in the engine. This function's whole job is authorization plus
+  -- pinning the actor to the session.
+  RETURN public.join_waitlist(p_product_id, p_gamer_id, (SELECT auth.uid()));
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.join_product_waitlist(uuid, uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.join_product_waitlist(uuid, uuid) TO authenticated;
+GRANT  EXECUTE ON FUNCTION public.join_product_waitlist(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION public.join_product_waitlist(uuid, uuid) IS
+  'Guarded, authenticated-facing entry point for joining a product waitlist. The customer is auth.uid(); the parent-of-gamer check lives in join_waitlist.';
+
+-- ---------------------------------------------------------------------------
+-- submit_my_feedback — self-scoping
+-- ---------------------------------------------------------------------------
+-- No role gate by design: every role may send feedback, and the row it writes is
+-- keyed to auth.uid() with no way to name another user. That makes it a
+-- self-scoping function under §3.4, classified and scope-tested as one.
+--
+-- The length bounds move in here alongside the rate limit. They used to live
+-- only in the route's zod schema, which was sufficient while the RPC was
+-- unreachable from a browser; now that `authenticated` can call it directly,
+-- validation the route enforces has to be enforced here too or it is decoration.
+
+CREATE OR REPLACE FUNCTION public.submit_my_feedback(p_message text)
+RETURNS boolean
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+DECLARE
+  v_user_id uuid := (SELECT auth.uid());
+BEGIN
+  -- Not reachable through PostgREST as `authenticated` (that role's JWT always
+  -- carries a subject), but an unattributable feedback row is worse than a
+  -- refused one, so this fails closed rather than inserting NULL.
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_message IS NULL OR length(p_message) < 10 OR length(p_message) > 2000 THEN
+    RAISE EXCEPTION 'feedback message must be between 10 and 2000 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Returns false (not an error) when the per-hour rate limit is hit; the route
+  -- maps that to 429.
+  RETURN public.submit_feedback(v_user_id, p_message);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.submit_my_feedback(text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.submit_my_feedback(text) TO authenticated;
+GRANT  EXECUTE ON FUNCTION public.submit_my_feedback(text) TO service_role;
+
+COMMENT ON FUNCTION public.submit_my_feedback(text) IS
+  'Self-scoping feedback submission: writes a feedback_submissions row for auth.uid(), rate-limited and length-bounded. Returns false when rate-limited.';

--- a/supabase/migrations/00123_phase3_model_b_grants.sql
+++ b/supabase/migrations/00123_phase3_model_b_grants.sql
@@ -1,0 +1,74 @@
+-- Phase 3 of the DB authorization refactor (docs/db-authorization-architecture.md
+-- §5 Phase 3), batch 2 of 3: the grants and policies the Model B client swaps
+-- need.
+--
+-- Four routes touched only ordinary tables through the service-role client. Each
+-- moves to the user-bound client, which means PostgreSQL's grant layer and the
+-- table's RLS policies become the second and third checks behind the route's own
+-- `requireRole` — instead of the route being the only check there was.
+--
+-- Every change here is ADDITIVE except the last, which removes a grant that
+-- authorizes nothing today, so nothing currently deployed against this database
+-- can be broken by pushing it ahead of the code (see 00122's header for why that
+-- constraint governs this whole phase).
+
+-- ---------------------------------------------------------------------------
+-- locations — admin reference data
+-- ---------------------------------------------------------------------------
+-- `admin_manage_locations` is already FOR ALL with an admin predicate on both
+-- halves; the table simply had no DML grant for `authenticated`, so the policy
+-- was unreachable and writes had to bypass it. Granting exactly the two verbs
+-- the location routes use (create, rename) leaves DELETE with no path other than
+-- the service-role client, which matches the absence of a delete route.
+
+GRANT INSERT, UPDATE ON TABLE public.locations TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- minecraft_accounts — the owner's own linked account
+-- ---------------------------------------------------------------------------
+-- Reads were already self-scoped (own row, plus a parent's view of a linked
+-- gamer's). Writes had neither grant nor policy, so linking a Minecraft name ran
+-- on the service-role client. These two policies are the write half of the same
+-- shape: the target row IS the caller, so actor and target are the same check.
+--
+-- Deliberately NOT extended to a parent writing their linked gamer's row: the
+-- parent-facing path goes through /api/gamers/[id], which is bound to the Auth
+-- Admin API for the rest of its work and stays Model A. Widening the policy for
+-- a route that cannot use it would be an unbacked grant.
+
+GRANT INSERT, UPDATE ON TABLE public.minecraft_accounts TO authenticated;
+
+CREATE POLICY users_insert_own_minecraft_account
+  ON public.minecraft_accounts
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY users_update_own_minecraft_account
+  ON public.minecraft_accounts
+  FOR UPDATE TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+-- ---------------------------------------------------------------------------
+-- profiles.locale — the fifth safe self-editable column
+-- ---------------------------------------------------------------------------
+-- `users_update_own_profile` already scopes profile UPDATEs to the caller's own
+-- row and pins `role` to its current value; the locale route bypassed it only
+-- because `locale` was missing from the column-level grant list. Locale decides
+-- which translation of the UI you see and nothing else — it carries no
+-- privilege, holds no money, and gates no enrollment — so it belongs with
+-- first_name / last_name / phone / spoken_languages rather than behind an RPC.
+
+GRANT UPDATE(locale) ON TABLE public.profiles TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- whatsapp_messages — remove the dead UPDATE grant
+-- ---------------------------------------------------------------------------
+-- Found by Phase 2's column-grant audit: `authenticated` held UPDATE on this
+-- table with no UPDATE policy behind it, so it authorized nothing — but it is
+-- one unscoped CREATE POLICY away from authorizing the rewriting of message
+-- history. The outbound-send route (the only authenticated writer, as of this
+-- batch) inserts and never updates; the inbound webhook updates delivery status
+-- through the service-role client, which is unaffected.
+
+REVOKE UPDATE ON TABLE public.whatsapp_messages FROM authenticated;

--- a/supabase/migrations/00124_phase3_admin_participation_rpcs.sql
+++ b/supabase/migrations/00124_phase3_admin_participation_rpcs.sql
@@ -1,0 +1,168 @@
+-- Phase 3 of the DB authorization refactor (docs/db-authorization-architecture.md
+-- §5 Phase 3), batch 3 of 3: the new RPCs, written to the §3.5 template.
+--
+-- The two admin participation routes were the only remaining candidates that
+-- could not be converted by a grant or a client swap. `participations` is
+-- grant-locked — `authenticated` holds SELECT and nothing else, deliberately,
+-- because a stray write there is a free seat — so an admin acting as themselves
+-- has no path to it except a SECURITY DEFINER function. These are that function,
+-- one per direction.
+--
+-- Both encode the business rules the routes were carrying in TypeScript. That is
+-- the point rather than a side effect: a rule enforced in the handler is a rule
+-- that only applies to callers who came through the handler, and these two RPCs
+-- are now reachable by any admin over PostgREST.
+--
+-- WHY NOT GUARD cancel_participation ITSELF
+--
+-- The doc's Phase 3 sketch expected admin-participation-cancel to be a
+-- grant-plus-guard conversion. Re-verifying against the current code says
+-- otherwise: `cancel_participation` is also called by the Stripe webhook, which
+-- has no session by definition and must keep calling it as service_role
+-- permanently. A role guard on its body would break that path for good, not just
+-- through the deployment window. So it stays a service_role-only engine and the
+-- admin-facing entry point wraps it — which is also what lets the wrapper hold
+-- the admin-specific preconditions the webhook must not have.
+
+-- ---------------------------------------------------------------------------
+-- admin_enroll_gamer — comp-enrollment, admin-gated
+-- ---------------------------------------------------------------------------
+-- Deliberately does NOT go through create_participation: that function's gates
+-- (parent-of-customer, registration window, effective status, seat cap) are
+-- exactly what an admin override is for. What it does keep is the pieces that
+-- are not overridable — the product must exist, consumer clubs are out of scope
+-- (recurring billing has no comp story yet), and a gamer with no linked parent
+-- has no customer to attribute the participation to.
+
+CREATE OR REPLACE FUNCTION public.admin_enroll_gamer(
+  p_product_id uuid,
+  p_gamer_id   uuid
+) RETURNS jsonb
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+DECLARE
+  v_product_type     public.product_type;
+  v_customer_id      uuid;
+  v_participation_id uuid;
+BEGIN
+  PERFORM public.assert_admin();
+
+  SELECT product_type INTO v_product_type
+    FROM public.products WHERE id = p_product_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'product % does not exist', p_product_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF v_product_type = 'consumer_club' THEN
+    RAISE EXCEPTION 'admin enrollment is not supported for consumer clubs'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- One parent per gamer is the current model; where a gamer somehow has
+  -- several links, the oldest wins so the choice is deterministic rather than
+  -- whatever the planner returned. Multi-parent reckoning is future work.
+  SELECT parent_id INTO v_customer_id
+    FROM public.parent_gamer
+    WHERE gamer_id = p_gamer_id
+    ORDER BY created_at ASC
+    LIMIT 1;
+  IF v_customer_id IS NULL THEN
+    RAISE EXCEPTION 'gamer % has no linked parent', p_gamer_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The partial unique index on (product_id, gamer_id) for non-reserving
+  -- statuses is the source of truth for "already enrolled"; it raises 23505 and
+  -- the route maps that to 409. Re-checking it here would be a race, not a
+  -- safeguard.
+  INSERT INTO public.participations (product_id, gamer_id, customer_id, status)
+  VALUES (p_product_id, p_gamer_id, v_customer_id, 'active')
+  RETURNING id INTO v_participation_id;
+
+  RETURN jsonb_build_object(
+    'participation_id', v_participation_id,
+    'customer_id', v_customer_id
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_enroll_gamer(uuid, uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.admin_enroll_gamer(uuid, uuid) TO authenticated;
+GRANT  EXECUTE ON FUNCTION public.admin_enroll_gamer(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION public.admin_enroll_gamer(uuid, uuid) IS
+  'Admin-gated comp-enrollment: drops a gamer onto a non-consumer_club product with status=active, bypassing payment, seat caps and registration windows by design.';
+
+-- ---------------------------------------------------------------------------
+-- admin_remove_participation — the inverse, admin-gated
+-- ---------------------------------------------------------------------------
+-- The product id is a parameter, not decoration: without it a participation id
+-- from a different product could be cancelled through the admin product URL.
+-- Checking the pair inside the function means the check cannot be skipped by
+-- calling the RPC directly.
+--
+-- The live-subscription refusal moves in here from the route, and moving it is
+-- an improvement rather than a relocation: the read and the delete now happen in
+-- one transaction under the same product lock cancel_participation takes, so
+-- there is no window in which a subscription can appear between the check and
+-- the CASCADE that would orphan it. Under current invariants it is unreachable
+-- (only consumer_club ever has a live sub, and that is refused above), but if
+-- that changes, deleting here would bill the customer forever with no DB record
+-- and no refund.
+
+CREATE OR REPLACE FUNCTION public.admin_remove_participation(
+  p_product_id       uuid,
+  p_participation_id uuid
+) RETURNS jsonb
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+DECLARE
+  v_row_product_id uuid;
+  v_product_type   public.product_type;
+  v_live_sub       text;
+BEGIN
+  PERFORM public.assert_admin();
+
+  SELECT product_id INTO v_row_product_id
+    FROM public.participations WHERE id = p_participation_id;
+  IF NOT FOUND OR v_row_product_id IS DISTINCT FROM p_product_id THEN
+    RAISE EXCEPTION 'participation % is not on product %',
+      p_participation_id, p_product_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  SELECT product_type INTO v_product_type
+    FROM public.products WHERE id = p_product_id;
+  IF v_product_type = 'consumer_club' THEN
+    RAISE EXCEPTION 'admin removal is not supported for consumer clubs'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- family_subscriptions.participation_id is UNIQUE and stripe_subscription_id
+  -- is NOT NULL, so the mere existence of a row means a live Stripe sub is
+  -- linked to this participation.
+  SELECT stripe_subscription_id INTO v_live_sub
+    FROM public.family_subscriptions
+    WHERE participation_id = p_participation_id;
+  IF v_live_sub IS NOT NULL THEN
+    RAISE EXCEPTION
+      'participation % still has live Stripe subscription %',
+      p_participation_id, v_live_sub
+      USING ERRCODE = 'object_not_in_prerequisite_state';
+  END IF;
+
+  RETURN public.cancel_participation(p_participation_id, 'admin_cancelled');
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_remove_participation(uuid, uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.admin_remove_participation(uuid, uuid) TO authenticated;
+GRANT  EXECUTE ON FUNCTION public.admin_remove_participation(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION public.admin_remove_participation(uuid, uuid) IS
+  'Admin-gated un-enrollment. Refuses a participation that is not on the named product, a consumer_club product, or a participation with a live Stripe subscription; otherwise delegates to cancel_participation.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1796,6 +1796,33 @@ $$;
 
 
 --
+-- Name: join_product_waitlist(uuid, uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.join_product_waitlist(p_product_id uuid, p_gamer_id uuid) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+BEGIN
+  PERFORM public.assert_role('customer');
+
+  -- Everything else — product lock, parent-of-gamer check, waitlist_enabled
+  -- gate, idempotency, the clock_timestamp() ordering stamp — is unchanged and
+  -- lives in the engine. This function's whole job is authorization plus
+  -- pinning the actor to the session.
+  RETURN public.join_waitlist(p_product_id, p_gamer_id, (SELECT auth.uid()));
+END;
+$$;
+
+
+--
+-- Name: FUNCTION join_product_waitlist(p_product_id uuid, p_gamer_id uuid); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.join_product_waitlist(p_product_id uuid, p_gamer_id uuid) IS 'Guarded, authenticated-facing entry point for joining a product waitlist. The customer is auth.uid(); the parent-of-gamer check lives in join_waitlist.';
+
+
+--
 -- Name: join_waitlist(uuid, uuid, uuid); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -2183,6 +2210,43 @@ BEGIN
   RETURN true;
 END;
 $$;
+
+
+--
+-- Name: submit_my_feedback(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.submit_my_feedback(p_message text) RETURNS boolean
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_user_id uuid := (SELECT auth.uid());
+BEGIN
+  -- Not reachable through PostgREST as `authenticated` (that role's JWT always
+  -- carries a subject), but an unattributable feedback row is worse than a
+  -- refused one, so this fails closed rather than inserting NULL.
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_message IS NULL OR length(p_message) < 10 OR length(p_message) > 2000 THEN
+    RAISE EXCEPTION 'feedback message must be between 10 and 2000 characters'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Returns false (not an error) when the per-hour rate limit is hit; the route
+  -- maps that to 429.
+  RETURN public.submit_feedback(v_user_id, p_message);
+END;
+$$;
+
+
+--
+-- Name: FUNCTION submit_my_feedback(p_message text); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.submit_my_feedback(p_message text) IS 'Self-scoping feedback submission: writes a feedback_submissions row for auth.uid(), rate-limited and length-bounded. Returns false when rate-limited.';
 
 
 --
@@ -5351,6 +5415,15 @@ GRANT ALL ON FUNCTION public.is_voice_group_moderator(p_group_id uuid) TO authen
 
 
 --
+-- Name: FUNCTION join_product_waitlist(p_product_id uuid, p_gamer_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.join_product_waitlist(p_product_id uuid, p_gamer_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.join_product_waitlist(p_product_id uuid, p_gamer_id uuid) TO authenticated;
+GRANT ALL ON FUNCTION public.join_product_waitlist(p_product_id uuid, p_gamer_id uuid) TO service_role;
+
+
+--
 -- Name: FUNCTION join_waitlist(p_product_id uuid, p_gamer_id uuid, p_customer_id uuid); Type: ACL; Schema: public; Owner: -
 --
 
@@ -5439,6 +5512,15 @@ GRANT ALL ON FUNCTION public.set_pin_for_user(p_user_id uuid, p_pin text) TO ser
 
 REVOKE ALL ON FUNCTION public.submit_feedback(p_user_id uuid, p_message text) FROM PUBLIC;
 GRANT ALL ON FUNCTION public.submit_feedback(p_user_id uuid, p_message text) TO service_role;
+
+
+--
+-- Name: FUNCTION submit_my_feedback(p_message text); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.submit_my_feedback(p_message text) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.submit_my_feedback(p_message text) TO authenticated;
+GRANT ALL ON FUNCTION public.submit_my_feedback(p_message text) TO service_role;
 
 
 --

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -280,6 +280,124 @@ $$;
 
 
 --
+-- Name: admin_enroll_gamer(uuid, uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_product_type     public.product_type;
+  v_customer_id      uuid;
+  v_participation_id uuid;
+BEGIN
+  PERFORM public.assert_admin();
+
+  SELECT product_type INTO v_product_type
+    FROM public.products WHERE id = p_product_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'product % does not exist', p_product_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  IF v_product_type = 'consumer_club' THEN
+    RAISE EXCEPTION 'admin enrollment is not supported for consumer clubs'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- One parent per gamer is the current model; where a gamer somehow has
+  -- several links, the oldest wins so the choice is deterministic rather than
+  -- whatever the planner returned. Multi-parent reckoning is future work.
+  SELECT parent_id INTO v_customer_id
+    FROM public.parent_gamer
+    WHERE gamer_id = p_gamer_id
+    ORDER BY created_at ASC
+    LIMIT 1;
+  IF v_customer_id IS NULL THEN
+    RAISE EXCEPTION 'gamer % has no linked parent', p_gamer_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- The partial unique index on (product_id, gamer_id) for non-reserving
+  -- statuses is the source of truth for "already enrolled"; it raises 23505 and
+  -- the route maps that to 409. Re-checking it here would be a race, not a
+  -- safeguard.
+  INSERT INTO public.participations (product_id, gamer_id, customer_id, status)
+  VALUES (p_product_id, p_gamer_id, v_customer_id, 'active')
+  RETURNING id INTO v_participation_id;
+
+  RETURN jsonb_build_object(
+    'participation_id', v_participation_id,
+    'customer_id', v_customer_id
+  );
+END;
+$$;
+
+
+--
+-- Name: FUNCTION admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid) IS 'Admin-gated comp-enrollment: drops a gamer onto a non-consumer_club product with status=active, bypassing payment, seat caps and registration windows by design.';
+
+
+--
+-- Name: admin_remove_participation(uuid, uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.admin_remove_participation(p_product_id uuid, p_participation_id uuid) RETURNS jsonb
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+DECLARE
+  v_row_product_id uuid;
+  v_product_type   public.product_type;
+  v_live_sub       text;
+BEGIN
+  PERFORM public.assert_admin();
+
+  SELECT product_id INTO v_row_product_id
+    FROM public.participations WHERE id = p_participation_id;
+  IF NOT FOUND OR v_row_product_id IS DISTINCT FROM p_product_id THEN
+    RAISE EXCEPTION 'participation % is not on product %',
+      p_participation_id, p_product_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  SELECT product_type INTO v_product_type
+    FROM public.products WHERE id = p_product_id;
+  IF v_product_type = 'consumer_club' THEN
+    RAISE EXCEPTION 'admin removal is not supported for consumer clubs'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- family_subscriptions.participation_id is UNIQUE and stripe_subscription_id
+  -- is NOT NULL, so the mere existence of a row means a live Stripe sub is
+  -- linked to this participation.
+  SELECT stripe_subscription_id INTO v_live_sub
+    FROM public.family_subscriptions
+    WHERE participation_id = p_participation_id;
+  IF v_live_sub IS NOT NULL THEN
+    RAISE EXCEPTION
+      'participation % still has live Stripe subscription %',
+      p_participation_id, v_live_sub
+      USING ERRCODE = 'object_not_in_prerequisite_state';
+  END IF;
+
+  RETURN public.cancel_participation(p_participation_id, 'admin_cancelled');
+END;
+$$;
+
+
+--
+-- Name: FUNCTION admin_remove_participation(p_product_id uuid, p_participation_id uuid); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.admin_remove_participation(p_product_id uuid, p_participation_id uuid) IS 'Admin-gated un-enrollment. Refuses a participation that is not on the named product, a consumer_club product, or a participation with a live Stripe subscription; otherwise delegates to cancel_participation.';
+
+
+--
 -- Name: apply_group_changes(uuid, jsonb, jsonb, uuid[], jsonb, jsonb, jsonb); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5114,6 +5232,24 @@ GRANT ALL ON FUNCTION public._list_table_grants(p_grantee text) TO service_role;
 
 REVOKE ALL ON FUNCTION public._list_tables_without_rls() FROM PUBLIC;
 GRANT ALL ON FUNCTION public._list_tables_without_rls() TO service_role;
+
+
+--
+-- Name: FUNCTION admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid) TO authenticated;
+GRANT ALL ON FUNCTION public.admin_enroll_gamer(p_product_id uuid, p_gamer_id uuid) TO service_role;
+
+
+--
+-- Name: FUNCTION admin_remove_participation(p_product_id uuid, p_participation_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+REVOKE ALL ON FUNCTION public.admin_remove_participation(p_product_id uuid, p_participation_id uuid) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.admin_remove_participation(p_product_id uuid, p_participation_id uuid) TO authenticated;
+GRANT ALL ON FUNCTION public.admin_remove_participation(p_product_id uuid, p_participation_id uuid) TO service_role;
 
 
 --

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4942,6 +4942,13 @@ ALTER TABLE public.site_staff_details ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.spoken_languages ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: minecraft_accounts users_insert_own_minecraft_account; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY users_insert_own_minecraft_account ON public.minecraft_accounts FOR INSERT TO authenticated WITH CHECK ((user_id = ( SELECT auth.uid() AS uid)));
+
+
+--
 -- Name: feedback_submissions users_read_own_feedback; Type: POLICY; Schema: public; Owner: -
 --
 
@@ -4953,6 +4960,13 @@ CREATE POLICY users_read_own_feedback ON public.feedback_submissions FOR SELECT 
 --
 
 CREATE POLICY users_read_own_minecraft_account ON public.minecraft_accounts FOR SELECT TO authenticated USING ((user_id = ( SELECT auth.uid() AS uid)));
+
+
+--
+-- Name: minecraft_accounts users_update_own_minecraft_account; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY users_update_own_minecraft_account ON public.minecraft_accounts FOR UPDATE TO authenticated USING ((user_id = ( SELECT auth.uid() AS uid))) WITH CHECK ((user_id = ( SELECT auth.uid() AS uid)));
 
 
 --
@@ -5276,6 +5290,13 @@ GRANT UPDATE(phone) ON TABLE public.profiles TO authenticated;
 --
 
 GRANT UPDATE(spoken_languages) ON TABLE public.profiles TO authenticated;
+
+
+--
+-- Name: COLUMN profiles.locale; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT UPDATE(locale) ON TABLE public.profiles TO authenticated;
 
 
 --
@@ -5702,7 +5723,7 @@ GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.holiday_calendars TO authentic
 
 GRANT SELECT ON TABLE public.locations TO anon;
 GRANT ALL ON TABLE public.locations TO service_role;
-GRANT SELECT ON TABLE public.locations TO authenticated;
+GRANT SELECT,INSERT,UPDATE ON TABLE public.locations TO authenticated;
 
 
 --
@@ -5711,7 +5732,7 @@ GRANT SELECT ON TABLE public.locations TO authenticated;
 
 GRANT SELECT ON TABLE public.minecraft_accounts TO anon;
 GRANT ALL ON TABLE public.minecraft_accounts TO service_role;
-GRANT SELECT ON TABLE public.minecraft_accounts TO authenticated;
+GRANT SELECT,INSERT,UPDATE ON TABLE public.minecraft_accounts TO authenticated;
 
 
 --
@@ -5878,7 +5899,7 @@ GRANT SELECT,INSERT,UPDATE ON TABLE public.whatsapp_contacts TO authenticated;
 
 GRANT SELECT ON TABLE public.whatsapp_messages TO anon;
 GRANT ALL ON TABLE public.whatsapp_messages TO service_role;
-GRANT SELECT,INSERT,UPDATE ON TABLE public.whatsapp_messages TO authenticated;
+GRANT SELECT,INSERT ON TABLE public.whatsapp_messages TO authenticated;
 
 
 --

--- a/tests/db/access-control.test.ts
+++ b/tests/db/access-control.test.ts
@@ -46,8 +46,8 @@ describe("Access Control", () => {
     // policy intact but silently breaks every authenticated write against
     // the table — exactly how products/games writes regressed in the past.
     // profiles is intentionally NOT in this allowlist: it uses column-level
-    // UPDATE grants on (first_name, last_name, phone, spoken_languages) rather
-    // than table-level UPDATE. Column privileges live in information_schema
+    // UPDATE grants on the safe self-editable fields rather than table-level
+    // UPDATE. Column privileges live in information_schema
     // .column_privileges — out of scope for _list_table_grants, and covered by
     // the column-grant audit in authorization-spine.test.ts.
     //
@@ -57,7 +57,18 @@ describe("Access Control", () => {
       ["parent_gamer", new Set(["DELETE"])],
       ["gamer_profiles", new Set(["UPDATE"])],
       ["whatsapp_contacts", new Set(["INSERT", "UPDATE"])],
-      ["whatsapp_messages", new Set(["INSERT", "UPDATE"])],
+      // INSERT only: the outbound-send route inserts and never updates, and the
+      // dead UPDATE grant (no policy behind it) was revoked in 00123. Delivery
+      // status is stamped by the inbound webhook on the service-role client.
+      ["whatsapp_messages", new Set(["INSERT"])],
+      // Admin-only reference data. The write policy was always there; the grant
+      // that made it reachable arrived in 00123 when the locations routes moved
+      // off the service-role client. No DELETE — there is no delete route.
+      ["locations", new Set(["INSERT", "UPDATE"])],
+      // Users link their own Minecraft account (00123). RLS derives the target
+      // row from auth.uid(), so actor and target are the same check. No DELETE:
+      // unlinking clears the columns rather than removing the row.
+      ["minecraft_accounts", new Set(["INSERT", "UPDATE"])],
       // Gedus write their own coverage rows directly from the browser
       // (setForGedu uses DELETE + INSERT). RLS enforces self-only access
       // and the role-is-gedu check on WITH CHECK.

--- a/tests/db/admin-participation-rpcs.test.ts
+++ b/tests/db/admin-participation-rpcs.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+import { createAdminTestClient, createAuthenticatedClient } from "./helpers";
+import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
+import { createTestProduct, deleteTestProducts } from "./product-helpers";
+import {
+  adminEnrollGamerRpcResult,
+  adminRemoveParticipationRpcResult,
+} from "@/services/participations/participations.contracts";
+
+/**
+ * `admin_enroll_gamer` / `admin_remove_participation` — the two RPCs Phase 3 of
+ * the DB authorization refactor wrote so the admin comp-enroll and un-enroll
+ * routes could stop holding the service-role client.
+ *
+ * The role gate itself is covered fixture-free by the spine's role × RPC matrix.
+ * What needs fixtures — and therefore lives here — is everything the routes used
+ * to enforce in TypeScript and now enforce in SQL: the product-membership check
+ * that stops a participation id from another product being cancelled through the
+ * wrong URL, the consumer_club refusals, the parent resolution, and the
+ * live-subscription refusal that exists so a CASCADE can never orphan a
+ * subscription that keeps billing.
+ *
+ * The results are parsed through the contracts schemas the routes parse with, so
+ * a shape change fails here rather than at runtime.
+ *
+ * Product UUIDs 5c8, 5c9 (see the product-helpers allocation registry).
+ */
+
+const CAMP = "00000000-0000-0000-0000-0000000005c8";
+const CLUB = "00000000-0000-0000-0000-0000000005c9";
+
+describe("admin participation RPCs", () => {
+  let admin: SupabaseClient<Database>;
+  let adminAuth: SupabaseClient<Database>;
+
+  async function clearParticipations() {
+    await admin.from("participations").delete().in("product_id", [CAMP, CLUB]);
+  }
+
+  /** The participation id for a gamer on a product, read past RLS. */
+  async function participationOn(
+    productId: string,
+    gamerId: string,
+  ): Promise<string | null> {
+    const { data } = await admin
+      .from("participations")
+      .select("id")
+      .eq("product_id", productId)
+      .eq("gamer_id", gamerId)
+      .maybeSingle();
+    return data?.id ?? null;
+  }
+
+  beforeAll(async () => {
+    admin = createAdminTestClient();
+    adminAuth = await createAuthenticatedClient(
+      TEST_CREDENTIALS.ADMIN.email,
+      TEST_CREDENTIALS.ADMIN.password,
+    );
+
+    await deleteTestProducts(admin, [CAMP, CLUB]);
+    await createTestProduct(admin, {
+      id: CAMP,
+      productType: "camp",
+      seatCount: null,
+      startDate: "2099-06-01",
+      endDate: "2099-06-05",
+    });
+    await createTestProduct(admin, {
+      id: CLUB,
+      productType: "consumer_club",
+      seatCount: null,
+    });
+  });
+
+  beforeEach(clearParticipations);
+  afterAll(async () => {
+    await deleteTestProducts(admin, [CAMP, CLUB]);
+  });
+
+  describe("admin_enroll_gamer", () => {
+    it("enrolls the gamer as active and resolves the customer from the parent link", async () => {
+      const { data, error } = await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: CAMP,
+        p_gamer_id: TEST_IDS.GAMER,
+      });
+
+      expect(error).toBeNull();
+      const parsed = adminEnrollGamerRpcResult.parse(data);
+      expect(parsed.customer_id).toBe(TEST_IDS.CUSTOMER);
+
+      const { data: row } = await admin
+        .from("participations")
+        .select("status, customer_id, gamer_id, product_id")
+        .eq("id", parsed.participation_id)
+        .single();
+
+      expect(row).toEqual({
+        status: "active",
+        customer_id: TEST_IDS.CUSTOMER,
+        gamer_id: TEST_IDS.GAMER,
+        product_id: CAMP,
+      });
+    });
+
+    it("refuses a consumer club", async () => {
+      const { error } = await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: CLUB,
+        p_gamer_id: TEST_IDS.GAMER,
+      });
+
+      expect(error?.code).toBe("23514");
+      expect(await participationOn(CLUB, TEST_IDS.GAMER)).toBeNull();
+    });
+
+    it("refuses an unknown product", async () => {
+      const { error } = await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: "00000000-0000-0000-0000-00000000dead",
+        p_gamer_id: TEST_IDS.GAMER,
+      });
+
+      expect(error?.code).toBe("P0002");
+    });
+
+    it("refuses a gamer with no linked parent", async () => {
+      // The admin account has no parent_gamer row, which is the same shape as an
+      // orphaned gamer: there is no customer to attribute the seat to.
+      const { error } = await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: CAMP,
+        p_gamer_id: TEST_IDS.ADMIN,
+      });
+
+      expect(error?.code).toBe("23514");
+    });
+
+    it("refuses a second enrollment of the same gamer", async () => {
+      await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: CAMP,
+        p_gamer_id: TEST_IDS.GAMER,
+      });
+
+      const { error } = await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: CAMP,
+        p_gamer_id: TEST_IDS.GAMER,
+      });
+
+      // The partial unique index is the source of truth, not a re-check in the
+      // body — so the refusal is a constraint violation, and it is race-free.
+      expect(error?.code).toBe("23505");
+    });
+  });
+
+  describe("admin_remove_participation", () => {
+    async function seatTheGamer(): Promise<string> {
+      const { data } = await adminAuth.rpc("admin_enroll_gamer", {
+        p_product_id: CAMP,
+        p_gamer_id: TEST_IDS.GAMER,
+      });
+      return adminEnrollGamerRpcResult.parse(data).participation_id;
+    }
+
+    it("cancels the participation and reports what it removed", async () => {
+      const participationId = await seatTheGamer();
+
+      const { data, error } = await adminAuth.rpc(
+        "admin_remove_participation",
+        { p_product_id: CAMP, p_participation_id: participationId },
+      );
+
+      expect(error).toBeNull();
+      const parsed = adminRemoveParticipationRpcResult.parse(data);
+      expect(parsed.kind).toBe("cancelled");
+      if (parsed.kind === "cancelled") {
+        expect(parsed.product_id).toBe(CAMP);
+        expect(parsed.previous_status).toBe("active");
+        expect(parsed.reason).toBe("admin_cancelled");
+      }
+
+      expect(await participationOn(CAMP, TEST_IDS.GAMER)).toBeNull();
+    });
+
+    it("refuses a participation that is not on the named product", async () => {
+      const participationId = await seatTheGamer();
+
+      // The whole reason the product id is a parameter: without the pair check,
+      // this call would cancel a participation belonging to another product.
+      const { error } = await adminAuth.rpc("admin_remove_participation", {
+        p_product_id: CLUB,
+        p_participation_id: participationId,
+      });
+
+      expect(error?.code).toBe("P0002");
+      expect(await participationOn(CAMP, TEST_IDS.GAMER)).toBe(participationId);
+    });
+
+    it("refuses an unknown participation", async () => {
+      const { error } = await adminAuth.rpc("admin_remove_participation", {
+        p_product_id: CAMP,
+        p_participation_id: "00000000-0000-0000-0000-00000000dead",
+      });
+
+      expect(error?.code).toBe("P0002");
+    });
+
+    it("refuses a participation on a consumer club", async () => {
+      // Seeded directly: admin_enroll_gamer refuses consumer clubs, and this is
+      // the other half of the same gate — removal must go through Stripe.
+      const { data: seeded } = await admin
+        .from("participations")
+        .insert({
+          product_id: CLUB,
+          gamer_id: TEST_IDS.GAMER,
+          customer_id: TEST_IDS.CUSTOMER,
+          status: "active",
+        })
+        .select("id")
+        .single();
+
+      const { error } = await adminAuth.rpc("admin_remove_participation", {
+        p_product_id: CLUB,
+        p_participation_id: seeded!.id,
+      });
+
+      expect(error?.code).toBe("23514");
+      expect(await participationOn(CLUB, TEST_IDS.GAMER)).toBe(seeded!.id);
+    });
+
+    it("refuses a participation with a live Stripe subscription", async () => {
+      // Unreachable under current invariants (only consumer_club ever carries a
+      // live sub, and that is refused a step earlier) — constructed here because
+      // the failure mode if it ever became reachable is a subscription that
+      // keeps billing with no DB row behind it.
+      const participationId = await seatTheGamer();
+      await admin.from("family_subscriptions").insert({
+        participation_id: participationId,
+        customer_id: TEST_IDS.CUSTOMER,
+        stripe_subscription_id: "sub_admin_rpc_test",
+        stripe_customer_id: "cus_admin_rpc_test",
+        currency: "eur",
+        status: "active",
+      });
+
+      const { error } = await adminAuth.rpc("admin_remove_participation", {
+        p_product_id: CAMP,
+        p_participation_id: participationId,
+      });
+
+      expect(error?.code).toBe("55000");
+      expect(await participationOn(CAMP, TEST_IDS.GAMER)).toBe(participationId);
+
+      await admin
+        .from("family_subscriptions")
+        .delete()
+        .eq("participation_id", participationId);
+    });
+  });
+});

--- a/tests/db/authorization-spine.test.ts
+++ b/tests/db/authorization-spine.test.ts
@@ -72,6 +72,13 @@ const ROLE_GATED_RPCS: Record<string, RoleGatedRpc> = {
   demote_to_waitlist: { permittedRoles: ["admin"] },
   set_gedu_verified: { permittedRoles: ["admin"] },
 
+  // --- customer-gated ------------------------------------------------------
+  // Phase 3's grant-plus-guard conversion. Past the role guard, a customer
+  // reaches the engine with a NULL product id and is refused with
+  // `no_data_found` — an error, but not the forbidden one, which is exactly what
+  // the positive half of the matrix asserts.
+  join_product_waitlist: { permittedRoles: ["customer"] },
+
   // --- gedu-gated ----------------------------------------------------------
   get_my_assigned_products: { permittedRoles: ["gedu"] },
   get_gedu_assigned_product: {
@@ -143,6 +150,10 @@ const SELF_SCOPING: Record<string, { scopeTest: string; why: string }> = {
   get_my_participation_subscription_states: {
     scopeTest: "tests/db/get-my-participation-subscription-states.test.ts",
     why: "billing-state signals for participations the caller is party to",
+  },
+  submit_my_feedback: {
+    scopeTest: "tests/db/feedback-submission.test.ts",
+    why: "writes a feedback row for auth.uid(); no parameter names a user, and every role may send feedback",
   },
   get_waitlist_position: {
     scopeTest: "tests/db/waitlist-admin.test.ts",

--- a/tests/db/authorization-spine.test.ts
+++ b/tests/db/authorization-spine.test.ts
@@ -71,6 +71,10 @@ const ROLE_GATED_RPCS: Record<string, RoleGatedRpc> = {
   promote_from_waitlist: { permittedRoles: ["admin"] },
   demote_to_waitlist: { permittedRoles: ["admin"] },
   set_gedu_verified: { permittedRoles: ["admin"] },
+  // Phase 3's new-RPC conversions. Past the admin guard, all-NULL arguments hit
+  // "no such product" / "no such participation" — an error, but not 42501.
+  admin_enroll_gamer: { permittedRoles: ["admin"] },
+  admin_remove_participation: { permittedRoles: ["admin"] },
 
   // --- customer-gated ------------------------------------------------------
   // Phase 3's grant-plus-guard conversion. Past the role guard, a customer

--- a/tests/db/authorization-spine.test.ts
+++ b/tests/db/authorization-spine.test.ts
@@ -222,13 +222,17 @@ const PRIVILEGE_COLUMN_DENYLIST: readonly (readonly [string, string])[] = [
 
 /**
  * The only table whose UPDATE surface is column-scoped rather than table-wide.
- * Pinned exactly: these four are the safe profile fields a user may edit.
+ * Pinned exactly: these five are the safe profile fields a user may edit —
+ * identity and presentation, nothing that decides what they may do. `locale`
+ * joined them in Phase 3 when the locale route stopped writing through the
+ * service-role client.
  */
 const PROFILES_UPDATABLE_COLUMNS = [
   "first_name",
   "last_name",
   "phone",
   "spoken_languages",
+  "locale",
 ];
 
 // ---------------------------------------------------------------------------

--- a/tests/db/feedback-submission.test.ts
+++ b/tests/db/feedback-submission.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+import { createAdminTestClient, createAuthenticatedClient } from "./helpers";
+import { TEST_CREDENTIALS, TEST_IDS } from "./constants";
+
+/**
+ * Scope test for `submit_my_feedback` — the self-scoping classification it
+ * carries in the §3.4 spine's allowlist (authorization-spine.test.ts, check 5).
+ *
+ * The function takes no user parameter at all: the row it writes is keyed to
+ * `auth.uid()`. That is the property under test here — not "does the insert
+ * work", but "can a caller make the row land on someone else". With no user
+ * argument to point elsewhere, the proof is that two different callers submitting
+ * identical text produce rows attributed to each of them respectively, and that
+ * the row is visible to its own author and nobody else.
+ *
+ * The rate limit is the second thing worth pinning: it is the only reason this
+ * function is safe to expose to `authenticated` at all, since the route's own
+ * throttling is now bypassable by calling PostgREST directly.
+ */
+
+const MESSAGE = "Seeded by feedback-submission.test.ts — scope probe";
+
+/**
+ * Every assertion below filters to these three, so a feedback row belonging to
+ * some other fixture can neither mask a leak nor fail an exact-match assertion.
+ */
+const SCOPED_USERS: string[] = [
+  TEST_IDS.CUSTOMER,
+  TEST_IDS.CUSTOMER_2,
+  TEST_IDS.GAMER,
+];
+
+describe("submit_my_feedback", () => {
+  let admin: SupabaseClient<Database>;
+  let customer: SupabaseClient<Database>;
+  let customer2: SupabaseClient<Database>;
+  let gamer: SupabaseClient<Database>;
+
+  async function clearFeedback() {
+    await admin
+      .from("feedback_submissions")
+      .delete()
+      .in("user_id", SCOPED_USERS);
+  }
+
+  beforeAll(async () => {
+    admin = createAdminTestClient();
+    customer = await createAuthenticatedClient(
+      TEST_CREDENTIALS.CUSTOMER.email,
+      TEST_CREDENTIALS.CUSTOMER.password,
+    );
+    customer2 = await createAuthenticatedClient(
+      TEST_CREDENTIALS.CUSTOMER_2.email,
+      TEST_CREDENTIALS.CUSTOMER_2.password,
+    );
+    gamer = await createAuthenticatedClient(
+      TEST_CREDENTIALS.GAMER.email,
+      TEST_CREDENTIALS.GAMER.password,
+    );
+    await clearFeedback();
+  });
+
+  afterEach(clearFeedback);
+  afterAll(clearFeedback);
+
+  it("attributes the row to the caller, not to any argument", async () => {
+    const { data, error } = await customer.rpc("submit_my_feedback", {
+      p_message: MESSAGE,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toBe(true);
+
+    const { data: rows } = await admin
+      .from("feedback_submissions")
+      .select("user_id, message")
+      .in("user_id", SCOPED_USERS);
+
+    expect(rows).toEqual([
+      { user_id: TEST_IDS.CUSTOMER, message: MESSAGE },
+    ]);
+  });
+
+  it("attributes identical text from a different caller to that caller", async () => {
+    await customer2.rpc("submit_my_feedback", { p_message: MESSAGE });
+
+    const { data: rows } = await admin
+      .from("feedback_submissions")
+      .select("user_id")
+      .in("user_id", SCOPED_USERS);
+
+    expect(rows).toEqual([{ user_id: TEST_IDS.CUSTOMER_2 }]);
+  });
+
+  it("is open to every role — a gamer may submit feedback", async () => {
+    // No role gate by design: this is why the function is classified
+    // self-scoping rather than role-gated.
+    const { data, error } = await gamer.rpc("submit_my_feedback", {
+      p_message: MESSAGE,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toBe(true);
+  });
+
+  it("does not let one caller read another's feedback row", async () => {
+    await customer.rpc("submit_my_feedback", { p_message: MESSAGE });
+
+    const { data: own } = await customer
+      .from("feedback_submissions")
+      .select("user_id");
+    const { data: other } = await customer2
+      .from("feedback_submissions")
+      .select("user_id");
+
+    expect(own).toEqual([{ user_id: TEST_IDS.CUSTOMER }]);
+    expect(other).toEqual([]);
+  });
+
+  it("refuses a message outside the length bounds", async () => {
+    const tooShort = await customer.rpc("submit_my_feedback", {
+      p_message: "short",
+    });
+    const tooLong = await customer.rpc("submit_my_feedback", {
+      p_message: "x".repeat(2001),
+    });
+
+    expect(tooShort.error?.code).toBe("23514");
+    expect(tooLong.error?.code).toBe("23514");
+
+    const { data: rows } = await admin
+      .from("feedback_submissions")
+      .select("user_id")
+      .in("user_id", SCOPED_USERS);
+    expect(rows).toEqual([]);
+  });
+
+  it("rate-limits the caller after six submissions in an hour", async () => {
+    for (let i = 0; i < 6; i++) {
+      const { data } = await customer.rpc("submit_my_feedback", {
+        p_message: `${MESSAGE} ${i}`,
+      });
+      expect(data).toBe(true);
+    }
+
+    // Returns false rather than raising — the route maps it to 429.
+    const { data: seventh, error } = await customer.rpc("submit_my_feedback", {
+      p_message: `${MESSAGE} 6`,
+    });
+    expect(error).toBeNull();
+    expect(seventh).toBe(false);
+
+    // The limit is per caller, not global.
+    const { data: otherCaller } = await customer2.rpc("submit_my_feedback", {
+      p_message: MESSAGE,
+    });
+    expect(otherCaller).toBe(true);
+  });
+});

--- a/tests/db/minecraft-accounts.test.ts
+++ b/tests/db/minecraft-accounts.test.ts
@@ -167,27 +167,61 @@ describe("minecraft_accounts RLS", () => {
     expect(data!.length).toBeGreaterThanOrEqual(2);
   });
 
-  // -- Write restrictions (no INSERT/UPDATE/DELETE grants for authenticated) --
+  // -- Writes: own row yes, anyone else's no, DELETE nobody --
+  //
+  // Phase 3 of the DB authorization refactor moved the account-linking route off
+  // the service-role client, which meant granting INSERT/UPDATE and adding the
+  // two self-write policies. What was previously "authenticated cannot write
+  // this table at all" is now "authenticated can write exactly their own row".
 
-  it("gamer cannot insert a minecraft account directly", async () => {
+  it("gamer can update own minecraft account", async () => {
     const { error } = await gamerClient
       .from("minecraft_accounts")
-      .insert({
-        user_id: TEST_IDS.GAMER,
-        minecraft_username: "Hacker",
-      });
+      .update({ minecraft_username: "OwnEdit" })
+      .eq("user_id", TEST_IDS.GAMER);
 
-    expect(error).not.toBeNull();
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from("minecraft_accounts")
+      .select("minecraft_username")
+      .eq("user_id", TEST_IDS.GAMER)
+      .single();
+
+    expect(data!.minecraft_username).toBe("OwnEdit");
+
+    await admin
+      .from("minecraft_accounts")
+      .update({ minecraft_username: SEED.MINECRAFT_USERNAME_GAMER })
+      .eq("user_id", TEST_IDS.GAMER);
   });
 
-  it("gamer cannot update own minecraft account directly", async () => {
-    // RLS would allow reading but the table-level GRANT only has SELECT
-    await gamerClient
+  it("gamer cannot insert a row for another user", async () => {
+    // The INSERT policy's WITH CHECK derives the target from auth.uid(), so a
+    // gamer naming the gedu's id is refused rather than silently re-pointed.
+    const { error } = await gamerClient
+      .from("minecraft_accounts")
+      .insert({ user_id: TEST_IDS.ADMIN, minecraft_username: "Hacker" });
+
+    expect(error).not.toBeNull();
+
+    const { data } = await admin
+      .from("minecraft_accounts")
+      .select("user_id")
+      .eq("user_id", TEST_IDS.ADMIN);
+
+    expect(data).toEqual([]);
+  });
+
+  it("linked parent cannot update their gamer's minecraft account", async () => {
+    // The parent may READ this row (policy above). Write access does not follow
+    // from read access — the parent-facing edit path goes through the gamers
+    // route, not a direct table write.
+    await customerClient
       .from("minecraft_accounts")
       .update({ minecraft_username: "Hacked" })
       .eq("user_id", TEST_IDS.GAMER);
 
-    // Verify it wasn't changed
     const { data } = await admin
       .from("minecraft_accounts")
       .select("minecraft_username")

--- a/tests/db/product-helpers.ts
+++ b/tests/db/product-helpers.ts
@@ -25,6 +25,7 @@ import { TEST_IDS } from "./constants";
  *   5c2            cancel-participation.test.ts
  *   5c3–5c6        get-my-participation-subscription-states.test.ts
  *   5c7            waitlist-admin.test.ts
+ *   5c8–5c9        admin-participation-rpcs.test.ts
  *   5d1–5da        session-credits-cron.test.ts
  *   5e1–5e4        products-gamer-rls.test.ts
  *   5e5–5e8        products-purchaser-rls.test.ts

--- a/tests/db/write-idor.test.ts
+++ b/tests/db/write-idor.test.ts
@@ -42,7 +42,6 @@ const CALENDAR = "00000000-0000-0000-0000-0000000005a7";
 const HOLIDAY = "00000000-0000-0000-0000-0000000005a8";
 const SLOT = "00000000-0000-0000-0000-0000000005a9";
 const WHATSAPP_PHONE = "358900000005";
-const WHATSAPP_MESSAGE_ID = "write-idor-seeded-message";
 
 const tableGrantRows = z.array(
   z.object({ table_name: z.string(), privilege_type: z.string() })
@@ -485,24 +484,51 @@ const CASES: Record<string, IdorCase> = {
       ),
   },
 
-  whatsapp_messages: {
+  // whatsapp_messages has no case: Phase 3 revoked `authenticated`'s dead UPDATE
+  // grant (it had no policy behind it), so message history is now unwritable at
+  // the grant layer — a stronger guarantee than an RLS assertion, and one the
+  // access-control test's grant allowlist already pins. `authenticated` keeps
+  // INSERT, which this loop deliberately does not cover (see the header).
+
+  locations: {
     attacker: "customer2",
-    why: "rewriting someone else's message history",
+    why: "locations are world-readable reference data that only an admin may edit — the classic read/write mismatch, now that authenticated holds the raw grant",
     probe: async (admin) =>
       (
         await admin
-          .from("whatsapp_messages")
+          .from("locations")
           .select("*")
-          .eq("id", WHATSAPP_MESSAGE_ID)
+          .eq("id", TEST_IDS.LOCATION_SITE)
           .maybeSingle()
       ).data,
     update: async (client) =>
       outcomeOf(
         await client
-          .from("whatsapp_messages")
-          .update({ body: "Defaced", status: "failed" })
-          .eq("id", WHATSAPP_MESSAGE_ID)
+          .from("locations")
+          .update({ name: "Defaced" })
+          .eq("id", TEST_IDS.LOCATION_SITE)
           .select("id")
+      ),
+  },
+
+  minecraft_accounts: {
+    attacker: "customer",
+    why: "the linked *parent* may read their gamer's Minecraft row — the self-write policies must still keep them from editing it",
+    probe: async (admin) =>
+      (
+        await admin
+          .from("minecraft_accounts")
+          .select("*")
+          .eq("user_id", TEST_IDS.GAMER)
+          .maybeSingle()
+      ).data,
+    update: async (client) =>
+      outcomeOf(
+        await client
+          .from("minecraft_accounts")
+          .update({ minecraft_username: "Defaced" })
+          .eq("user_id", TEST_IDS.GAMER)
+          .select("user_id")
       ),
   },
 
@@ -553,7 +579,6 @@ describe("write-path IDOR (§3.4 check 3)", () => {
 
     await deleteTestProducts(admin, [PRODUCT]);
     await admin.from("holiday_calendars").delete().eq("id", CALENDAR);
-    await admin.from("whatsapp_messages").delete().eq("id", WHATSAPP_MESSAGE_ID);
     await admin.from("whatsapp_contacts").delete().eq("phone", WHATSAPP_PHONE);
 
     await createTestProduct(admin, { id: PRODUCT, seatCount: null });
@@ -639,19 +664,19 @@ describe("write-path IDOR (§3.4 check 3)", () => {
     await admin
       .from("whatsapp_contacts")
       .insert({ phone: WHATSAPP_PHONE, wa_name: "IDOR fixture" });
-    await admin.from("whatsapp_messages").insert({
-      id: WHATSAPP_MESSAGE_ID,
-      phone: WHATSAPP_PHONE,
-      direction: "inbound",
-      status: "received",
-      body: "Seeded by write-idor.test.ts",
-    });
+
+    // The gamer's Minecraft row: owned by the gamer, readable by their linked
+    // parent, and therefore the sharp attacker's target. Seeded here rather than
+    // relied on from seed.sql because minecraft-accounts.test.ts deletes it.
+    await admin.from("minecraft_accounts").upsert(
+      { user_id: TEST_IDS.GAMER, minecraft_username: "IDOR fixture" },
+      { onConflict: "user_id" },
+    );
   });
 
   afterAll(async () => {
     await deleteTestProducts(admin, [PRODUCT]);
     await admin.from("holiday_calendars").delete().eq("id", CALENDAR);
-    await admin.from("whatsapp_messages").delete().eq("id", WHATSAPP_MESSAGE_ID);
     await admin.from("whatsapp_contacts").delete().eq("phone", WHATSAPP_PHONE);
     await admin
       .from("gedu_locations")

--- a/tests/integration/api/admin-locations.test.ts
+++ b/tests/integration/api/admin-locations.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { POST } from "@/app/api/admin/locations/create/route";
+import { PATCH } from "@/app/api/admin/locations/[id]/route";
+
+/**
+ * The locations CRUD routes moved off the service-role client in Phase 3 of the
+ * DB authorization refactor: `authenticated` gained INSERT/UPDATE on the table
+ * so the pre-existing admin_manage_locations policy could finally be the layer
+ * that decides. These tests cover the four shapes the per-route checklist asks
+ * for — unauthenticated, wrong role, bad input, happy path — plus the case that
+ * only exists because of the conversion: the database refusing the write.
+ */
+
+// --- Mocks ---
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockFrom = vi.fn(() => ({ insert: mockInsert, update: mockUpdate }));
+
+const LOCATION_ID = "00000000-0000-0000-0000-0000000000aa";
+const PARENT_ID = "00000000-0000-0000-0000-0000000000ab";
+
+const ROW = {
+  id: LOCATION_ID,
+  name: "Helsinki",
+  name_i18n: null,
+  type: "municipality",
+  parent_id: PARENT_ID,
+  country_code: null,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+/** `.insert(...).select().single()` / `.update(...).eq(...).select().single()`. */
+function resolvesTo(result: { data: unknown; error: unknown }) {
+  return { select: () => ({ single: () => Promise.resolve(result) }) };
+}
+
+function mockAdmin() {
+  mockRequireRole.mockResolvedValue({
+    user: { id: "admin-user-id" },
+    profile: { role: "admin" },
+    supabase: { from: mockFrom },
+  });
+}
+
+function mockUnauthenticated() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  );
+}
+
+function mockForbidden(message: string) {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: message }, { status: 403 }),
+  );
+}
+
+function createRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/admin/locations/create", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function patchRequest(body: unknown): Request {
+  return new Request(
+    `http://localhost:3000/api/admin/locations/${LOCATION_ID}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const params = Promise.resolve({ id: LOCATION_ID });
+
+const validCreate = {
+  name: "Helsinki",
+  type: "municipality",
+  parent_id: PARENT_ID,
+  country_code: null,
+};
+
+// --- Tests ---
+
+describe("POST /api/admin/locations/create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue({ insert: mockInsert, update: mockUpdate });
+    mockInsert.mockReturnValue(resolvesTo({ data: ROW, error: null }));
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthenticated();
+
+    const res = await POST(createRequest(validCreate));
+
+    expect(res.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-admin", async () => {
+    mockForbidden("Only admins can create locations");
+
+    const res = await POST(createRequest(validCreate));
+    const data = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(data.error).toBe("Only admins can create locations");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the body fails the contract schema", async () => {
+    mockAdmin();
+
+    const res = await POST(createRequest({ name: "", type: "municipality" }));
+
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("creates the location on the user-bound client", async () => {
+    mockAdmin();
+
+    const res = await POST(createRequest(validCreate));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual(ROW);
+    expect(mockFrom).toHaveBeenCalledWith("locations");
+    expect(mockInsert).toHaveBeenCalledWith(validCreate);
+  });
+
+  it("returns 403 when the database refuses the insert", async () => {
+    mockAdmin();
+    mockInsert.mockReturnValue(
+      resolvesTo({
+        data: null,
+        error: { code: "42501", message: "permission denied for table locations" },
+      }),
+    );
+
+    const res = await POST(createRequest(validCreate));
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("PATCH /api/admin/locations/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue({ insert: mockInsert, update: mockUpdate });
+    mockUpdate.mockReturnValue({
+      eq: () => resolvesTo({ data: ROW, error: null }),
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthenticated();
+
+    const res = await PATCH(patchRequest({ name: "Espoo" }), { params });
+
+    expect(res.status).toBe(401);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-admin", async () => {
+    mockForbidden("Only admins can update locations");
+
+    const res = await PATCH(patchRequest({ name: "Espoo" }), { params });
+
+    expect(res.status).toBe(403);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an empty name", async () => {
+    mockAdmin();
+
+    const res = await PATCH(patchRequest({ name: "   " }), { params });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("renames the location on the user-bound client", async () => {
+    mockAdmin();
+
+    const res = await PATCH(patchRequest({ name: "Espoo" }), { params });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual(ROW);
+    expect(mockFrom).toHaveBeenCalledWith("locations");
+    expect(mockUpdate).toHaveBeenCalledWith({ name: "Espoo" });
+  });
+
+  it("returns 403 when the policy refuses the update", async () => {
+    mockAdmin();
+    mockUpdate.mockReturnValue({
+      eq: () =>
+        resolvesTo({
+          data: null,
+          error: { code: "42501", message: "permission denied" },
+        }),
+    });
+
+    const res = await PATCH(patchRequest({ name: "Espoo" }), { params });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/integration/api/feedback.test.ts
+++ b/tests/integration/api/feedback.test.ts
@@ -14,9 +14,12 @@ vi.mock("@/lib/brevo", () => ({
   sendTransactionalEmail: (...args: unknown[]) => mockSendTransactionalEmail(...args),
 }));
 
+// The feedback WRITE now runs on the user-bound client (`submit_my_feedback`);
+// the admin client survives only for the notification fan-out, which reads every
+// admin's email and a gamer's parent's — neither in the submitter's RLS view.
 const mockFrom = vi.fn();
 const mockRpc = vi.fn();
-const mockAdminClient = { from: mockFrom, rpc: mockRpc };
+const mockAdminClient = { from: mockFrom };
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => mockAdminClient,
@@ -48,7 +51,7 @@ function mockAuthenticatedAs(role: string, overrides?: Record<string, unknown>) 
       first_name: `Test ${role}`,
       ...overrides,
     },
-    supabase: {},
+    supabase: { rpc: mockRpc },
   });
 }
 
@@ -301,15 +304,31 @@ describe("POST /api/feedback", () => {
 
   // -- RPC --
 
-  it("should call submit_feedback RPC with correct params", async () => {
+  it("calls submit_my_feedback on the user client, with no user parameter", async () => {
     mockAuthenticatedAs("customer");
     setupHappyPath();
 
     await POST(createRequest(validBody));
 
-    expect(mockRpc).toHaveBeenCalledWith("submit_feedback", {
-      p_user_id: "user-123",
+    // The absence of a user id here is the point: the row is attributed by the
+    // database from auth.uid(), so this handler cannot file feedback as anyone
+    // else even if `user.id` were wrong.
+    expect(mockRpc).toHaveBeenCalledWith("submit_my_feedback", {
       p_message: validBody.message,
     });
+  });
+
+  it("returns 500 and sends no mail when the RPC errors", async () => {
+    mockAuthenticatedAs("customer");
+    setupHappyPath();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: "23514", message: "feedback message must be between..." },
+    });
+
+    const response = await POST(createRequest(validBody));
+
+    expect(response.status).toBe(500);
+    expect(mockSendTransactionalEmail).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/api/minecraft-account.test.ts
+++ b/tests/integration/api/minecraft-account.test.ts
@@ -17,12 +17,10 @@ vi.mock("@/lib/mojang", () => ({
     mockIsValidMinecraftUsername(...args),
 }));
 
-const mockAdminFrom = vi.fn();
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({
-    from: (...args: unknown[]) => mockAdminFrom(...args),
-  })),
-}));
+// The upsert runs on the USER-bound client: the caller may write exactly their
+// own minecraft_accounts row, and the row key comes from the session rather than
+// the request body. The mock therefore hangs off `supabase`.
+const mockFrom = vi.fn();
 
 // --- Helpers ---
 
@@ -38,13 +36,13 @@ function mockAuthenticated(userId = "gamer-123", role = "gamer") {
   mockRequireRole.mockResolvedValue({
     user: { id: userId },
     profile: { role },
-    supabase: {},
+    supabase: { from: (...args: unknown[]) => mockFrom(...args) },
   });
 }
 
 function mockUpsertSuccess() {
   const upsertMock = vi.fn().mockResolvedValue({ data: null, error: null });
-  mockAdminFrom.mockReturnValue({ upsert: upsertMock });
+  mockFrom.mockReturnValue({ upsert: upsertMock });
   return { upsertMock };
 }
 
@@ -186,7 +184,7 @@ describe("PATCH /api/minecraft/account", () => {
         code: "23505",
       },
     });
-    mockAdminFrom.mockReturnValue({ upsert: upsertMock });
+    mockFrom.mockReturnValue({ upsert: upsertMock });
 
     const response = await PATCH(createRequest({ minecraftUsername: "TakenPlayer" }));
     const data = await response.json();

--- a/tests/integration/api/participations-waitlist.test.ts
+++ b/tests/integration/api/participations-waitlist.test.ts
@@ -9,10 +9,10 @@ vi.mock("@/lib/auth", () => ({
   requireRole: (...args: unknown[]) => mockRequireRole(...args),
 }));
 
-const mockAdminRpc = vi.fn();
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({ rpc: mockAdminRpc })),
-}));
+// The route runs on the USER-bound client from `requireRole`, so the RPC mock
+// hangs off the `supabase` handed back by that mock rather than off the admin
+// client — which this route no longer touches at all.
+const mockRpc = vi.fn();
 
 // --- Fixtures ---
 
@@ -52,7 +52,7 @@ function mockForbidden(role: string) {
       return Promise.resolve({
         user: { id: CUSTOMER_ID },
         profile: { role },
-        supabase: {},
+        supabase: { rpc: mockRpc },
       });
     },
   );
@@ -62,7 +62,7 @@ function mockAuthenticatedCustomer() {
   mockRequireRole.mockResolvedValue({
     user: { id: CUSTOMER_ID },
     profile: { role: "customer" },
-    supabase: {},
+    supabase: { rpc: mockRpc },
   });
 }
 
@@ -83,7 +83,7 @@ describe("POST /api/participations/waitlist", () => {
     );
 
     expect(res.status).toBe(401);
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 403 for gamer role", async () => {
@@ -96,7 +96,7 @@ describe("POST /api/participations/waitlist", () => {
 
     expect(res.status).toBe(403);
     expect(data.error).toBe("Only customers can join a waitlist");
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 403 for gedu role", async () => {
@@ -107,7 +107,7 @@ describe("POST /api/participations/waitlist", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 403 for admin role", async () => {
@@ -118,7 +118,7 @@ describe("POST /api/participations/waitlist", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   // -- Validation --
@@ -131,7 +131,7 @@ describe("POST /api/participations/waitlist", () => {
 
     expect(res.status).toBe(400);
     expect(data.error).toBe("Invalid JSON body");
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 400 when productId is missing", async () => {
@@ -142,7 +142,7 @@ describe("POST /api/participations/waitlist", () => {
 
     expect(res.status).toBe(400);
     expect(data.error).toMatch(/(productId|gamerId): Required/);
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 400 when gamerId is missing", async () => {
@@ -153,14 +153,14 @@ describe("POST /api/participations/waitlist", () => {
 
     expect(res.status).toBe(400);
     expect(data.error).toMatch(/(productId|gamerId): Required/);
-    expect(mockAdminRpc).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   // -- Happy path --
 
   it("returns the new waitlist position when join_waitlist succeeds", async () => {
     mockAuthenticatedCustomer();
-    mockAdminRpc.mockResolvedValue({
+    mockRpc.mockResolvedValue({
       data: {
         participation_id: PARTICIPATION_ID,
         waitlist_position: 3,
@@ -180,10 +180,9 @@ describe("POST /api/participations/waitlist", () => {
       waitlistPosition: 3,
       status: "waitlisted",
     });
-    expect(mockAdminRpc).toHaveBeenCalledWith("join_waitlist", {
+    expect(mockRpc).toHaveBeenCalledWith("join_product_waitlist", {
       p_product_id: PRODUCT_ID,
       p_gamer_id: GAMER_ID,
-      p_customer_id: CUSTOMER_ID,
     });
   });
 
@@ -191,7 +190,7 @@ describe("POST /api/participations/waitlist", () => {
     mockAuthenticatedCustomer();
     // The RPC itself short-circuits on existing participation rows; the route
     // just relays whatever shape the RPC returns. This locks in that contract.
-    mockAdminRpc.mockResolvedValue({
+    mockRpc.mockResolvedValue({
       data: {
         participation_id: PARTICIPATION_ID,
         waitlist_position: 1,
@@ -213,7 +212,7 @@ describe("POST /api/participations/waitlist", () => {
 
   it("returns 400 when waitlist is not enabled for the product (RPC raises check_violation)", async () => {
     mockAuthenticatedCustomer();
-    mockAdminRpc.mockResolvedValue({
+    mockRpc.mockResolvedValue({
       data: null,
       error: {
         code: "23514",
@@ -232,7 +231,7 @@ describe("POST /api/participations/waitlist", () => {
 
   it("returns 400 when the customer is not the parent of the gamer (IDOR guard)", async () => {
     mockAuthenticatedCustomer();
-    mockAdminRpc.mockResolvedValue({
+    mockRpc.mockResolvedValue({
       data: null,
       error: {
         code: "23514",
@@ -249,9 +248,25 @@ describe("POST /api/participations/waitlist", () => {
     expect(data.error).toContain("is not the parent of gamer");
   });
 
+  it("returns 403 when the RPC guard refuses the caller (42501)", async () => {
+    // Defense in depth made visible: even if this route's own role check were
+    // bypassed, `join_product_waitlist` refuses a non-customer in the database.
+    mockAuthenticatedCustomer();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: "42501", message: "Forbidden" },
+    });
+
+    const res = await POST(
+      createRequest({ productId: PRODUCT_ID, gamerId: GAMER_ID }),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
   it("returns 400 when the product does not exist", async () => {
     mockAuthenticatedCustomer();
-    mockAdminRpc.mockResolvedValue({
+    mockRpc.mockResolvedValue({
       data: null,
       error: {
         code: "P0002",

--- a/tests/integration/api/products-participations-delete.test.ts
+++ b/tests/integration/api/products-participations-delete.test.ts
@@ -1,32 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
 import { DELETE } from "@/app/api/admin/products/[id]/participations/[participationId]/route";
-import { mockSupabaseError, mockSupabaseSuccess } from "../../mocks/supabase";
 import { getBoolean, getString } from "../../helpers/json";
-import type { ProductType } from "@/types";
 
-// The admin remove-gamer route does two reads and one RPC:
-//   1. SELECT participations (IDOR guard — must belong to this product).
-//   2. SELECT products (type gate — consumer_club blocked, symmetric w/ add).
-//   3. RPC cancel_participation(reason='admin_cancelled') — hard delete, no
-//      refund. cancel_participation is service_role-only, so the admin client.
+// The admin remove-gamer route is now one call: `admin_remove_participation` on
+// the USER-bound client. The product-membership check, the consumer_club gate
+// and the live-subscription refusal moved into that RPC — where the last of them
+// finally shares a transaction with the delete instead of racing it. What this
+// file covers is the handler's remaining job: the role check and the mapping
+// from SQLSTATE to HTTP status. The rules themselves are covered against a real
+// database in tests/db/admin-participation-rpcs.test.ts.
 
 const mockRequireRole = vi.fn();
 vi.mock("@/lib/auth", () => ({
   requireRole: (...args: unknown[]) => mockRequireRole(...args),
 }));
 
-const mockFrom = vi.fn();
 const mockRpc = vi.fn();
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({ from: mockFrom, rpc: mockRpc })),
-}));
 
 function mockAuthenticatedAdmin() {
   mockRequireRole.mockResolvedValue({
     user: { id: "admin-user-id" },
     profile: { role: "admin" },
-    supabase: {},
+    supabase: { rpc: mockRpc },
   });
 }
 
@@ -45,61 +41,8 @@ function mockNonAdmin() {
   );
 }
 
-type SupabaseResult<T> =
-  | { data: T; error: null }
-  | { data: null; error: { message: string; code?: string } };
-
-function ok<T>(data: T): SupabaseResult<T> {
-  return mockSupabaseSuccess(data);
-}
-
-function err(message: string): SupabaseResult<never> {
-  return mockSupabaseError(message) as SupabaseResult<never>;
-}
-
-interface WireOptions {
-  participation?: SupabaseResult<{ id: string; product_id: string } | null>;
-  product?: SupabaseResult<{ product_type: ProductType } | null>;
-  liveSub?: SupabaseResult<{ stripe_subscription_id: string } | null>;
-  rpcResult?: SupabaseResult<unknown>;
-}
-
-// Wires the three from() calls (participations, products, family_subscriptions
-// — all select().eq().maybeSingle()) and the rpc() call. The route calls from()
-// in a fixed order; dispatch by table keeps tests off call-ordering hacks.
-function wireSupabase(opts: WireOptions) {
-  const participationCall = {
-    select: () => ({
-      eq: () => ({
-        maybeSingle: () => Promise.resolve(opts.participation ?? ok(null)),
-      }),
-    }),
-  };
-
-  const productCall = {
-    select: () => ({
-      eq: () => ({
-        maybeSingle: () => Promise.resolve(opts.product ?? ok(null)),
-      }),
-    }),
-  };
-
-  const familySubscriptionCall = {
-    select: () => ({
-      eq: () => ({
-        maybeSingle: () => Promise.resolve(opts.liveSub ?? ok(null)),
-      }),
-    }),
-  };
-
-  mockFrom.mockImplementation((table: string) => {
-    if (table === "participations") return participationCall;
-    if (table === "products") return productCall;
-    if (table === "family_subscriptions") return familySubscriptionCall;
-    throw new Error(`Unexpected from() table: ${table}`);
-  });
-
-  mockRpc.mockResolvedValue(opts.rpcResult ?? ok({ kind: "cancelled" }));
+function rpcFails(code: string, message = "refused") {
+  mockRpc.mockResolvedValue({ data: null, error: { code, message } });
 }
 
 const PRODUCT_ID = "11111111-1111-1111-1111-111111111111";
@@ -119,8 +62,17 @@ const params = Promise.resolve({
 
 beforeEach(() => {
   mockRequireRole.mockReset();
-  mockFrom.mockReset();
   mockRpc.mockReset();
+  mockRpc.mockResolvedValue({
+    data: {
+      kind: "cancelled",
+      product_id: PRODUCT_ID,
+      previous_status: "active",
+      stripe_subscription_id: null,
+      reason: "admin_cancelled",
+    },
+    error: null,
+  });
 });
 
 describe("DELETE /api/admin/products/[id]/participations/[participationId]", () => {
@@ -128,7 +80,6 @@ describe("DELETE /api/admin/products/[id]/participations/[participationId]", () 
     mockUnauthenticated();
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(401);
-    expect(mockFrom).not.toHaveBeenCalled();
     expect(mockRpc).not.toHaveBeenCalled();
   });
 
@@ -136,81 +87,73 @@ describe("DELETE /api/admin/products/[id]/participations/[participationId]", () 
     mockNonAdmin();
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(403);
-    expect(mockFrom).not.toHaveBeenCalled();
     expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when the participation does not exist", async () => {
+  it("returns 403 when the RPC guard refuses the caller", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({ participation: ok(null) });
+    rpcFails("42501", "Forbidden");
     const response = await DELETE(createRequest(), { params });
-    expect(response.status).toBe(404);
-    expect(mockRpc).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
   });
 
-  it("returns 404 when the participation belongs to a different product (IDOR)", async () => {
+  it("returns 404 when the participation is unknown or on another product", async () => {
+    // One refusal covers both: the RPC checks the (product, participation) pair,
+    // so an id from another product is indistinguishable from a missing one —
+    // which is the correct answer to give, not a limitation.
     mockAuthenticatedAdmin();
-    wireSupabase({
-      participation: ok({ id: PARTICIPATION_ID, product_id: "other-product" }),
-    });
+    rpcFails("P0002", "participation is not on product");
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(404);
-    expect(mockRpc).not.toHaveBeenCalled();
+    const error = getString(await response.json(), "error");
+    expect(error).toContain("not found on this product");
   });
 
   it("rejects consumer_club products (removal goes through Stripe, not here)", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({
-      participation: ok({ id: PARTICIPATION_ID, product_id: PRODUCT_ID }),
-      product: ok({ product_type: "consumer_club" }),
-    });
+    rpcFails("23514", "admin removal is not supported for consumer clubs");
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(400);
     const error = getString(await response.json(), "error");
     expect(error).toContain("consumer club");
-    expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  it("refuses (500) and does NOT delete when a live Stripe subscription exists", async () => {
+  it("refuses (500) when a live Stripe subscription is still linked", async () => {
     // Money-path guard: deleting would CASCADE-orphan the subscription, billing
     // the customer forever. Unreachable under current invariants, but must fail
     // loud rather than silently delete if it ever happens.
     mockAuthenticatedAdmin();
-    wireSupabase({
-      participation: ok({ id: PARTICIPATION_ID, product_id: PRODUCT_ID }),
-      product: ok({ product_type: "camp" }),
-      liveSub: ok({ stripe_subscription_id: "sub_live_123" }),
-    });
+    rpcFails("55000", "participation still has live Stripe subscription sub_123");
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(500);
-    expect(mockRpc).not.toHaveBeenCalled();
+    const error = getString(await response.json(), "error");
+    expect(error).toContain("live Stripe subscription");
   });
 
-  it("returns 400 when the RPC errors", async () => {
+  it("returns 400 for any other RPC error", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({
-      participation: ok({ id: PARTICIPATION_ID, product_id: PRODUCT_ID }),
-      product: ok({ product_type: "camp" }),
-      rpcResult: err("boom"),
-    });
+    rpcFails("XX000", "boom");
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(400);
   });
 
-  it("happy path: cancels with admin_cancelled and returns ok", async () => {
+  it("returns 500 when the RPC result does not match its contract", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({
-      participation: ok({ id: PARTICIPATION_ID, product_id: PRODUCT_ID }),
-      product: ok({ product_type: "event" }),
-      rpcResult: ok({ kind: "cancelled" }),
-    });
+    mockRpc.mockResolvedValue({ data: { kind: "who-knows" }, error: null });
     const response = await DELETE(createRequest(), { params });
+    expect(response.status).toBe(500);
+  });
+
+  it("happy path: passes both ids to the RPC and returns ok", async () => {
+    mockAuthenticatedAdmin();
+    const response = await DELETE(createRequest(), { params });
+
     expect(response.status).toBe(200);
     const okFlag = getBoolean(await response.json(), "ok");
     expect(okFlag).toBe(true);
-    expect(mockRpc).toHaveBeenCalledWith("cancel_participation", {
+    expect(mockRpc).toHaveBeenCalledWith("admin_remove_participation", {
+      p_product_id: PRODUCT_ID,
       p_participation_id: PARTICIPATION_ID,
-      p_reason: "admin_cancelled",
     });
   });
 });

--- a/tests/integration/api/products-participations.test.ts
+++ b/tests/integration/api/products-participations.test.ts
@@ -1,33 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
 import { POST } from "@/app/api/admin/products/[id]/participations/route";
-import { mockSupabaseError, mockSupabaseSuccess } from "../../mocks/supabase";
 import { getString } from "../../helpers/json";
-import type { ProductType } from "@/types";
 
-// The admin add-gamer route does three reads and one write:
-//   1. SELECT products (type gate — consumer_club blocked).
-//   2. SELECT parent_gamer (resolves customer_id from the gamer).
-//   3. INSERT participations (status='active', group_id=NULL).
-// Direct insert is permitted by admin_full_access_participations RLS;
-// the route deliberately bypasses create_participation to skip its
-// payment / registration-window / seat-cap gates.
+// The admin add-gamer route is now one call: `admin_enroll_gamer` on the
+// USER-bound client. The product-type gate, the parent resolution and the
+// "already enrolled" constraint all live inside that RPC, behind an admin guard
+// — so what this file covers is the handler's job, which is the role check, the
+// body contract, and the mapping from SQLSTATE to HTTP status. The rules
+// themselves are covered against a real database in
+// tests/db/admin-participation-rpcs.test.ts.
 
 const mockRequireRole = vi.fn();
 vi.mock("@/lib/auth", () => ({
   requireRole: (...args: unknown[]) => mockRequireRole(...args),
 }));
 
-const mockFrom = vi.fn();
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({ from: mockFrom })),
-}));
+const mockRpc = vi.fn();
 
 function mockAuthenticatedAdmin() {
   mockRequireRole.mockResolvedValue({
     user: { id: "admin-user-id" },
     profile: { role: "admin" },
-    supabase: {},
+    supabase: { rpc: mockRpc },
   });
 }
 
@@ -46,70 +41,14 @@ function mockNonAdmin() {
   );
 }
 
-type SupabaseResult<T> =
-  | { data: T; error: null }
-  | { data: null; error: { message: string; code?: string } };
-
-function ok<T>(data: T): SupabaseResult<T> {
-  return mockSupabaseSuccess(data);
-}
-
-function err(message: string, code?: string): SupabaseResult<never> {
-  return mockSupabaseError(message, code) as SupabaseResult<never>;
-}
-
-interface WireOptions {
-  /** product fetch result — undefined means call shouldn't be reached. */
-  product?: SupabaseResult<{ id: string; product_type: ProductType } | null>;
-  /** parent_gamer fetch result — array of links. */
-  parentLink?: SupabaseResult<{ parent_id: string }[]>;
-  /** Insert result. */
-  insertResult?: SupabaseResult<{ id: string }>;
-}
-
-// Wires three from() calls in order: products (maybeSingle), parent_gamer
-// (limit), participations (single from insert+select). The route always
-// calls from() in this fixed order; the dispatch keeps tests from depending
-// on call ordering hacks.
-function wireSupabase(opts: WireOptions) {
-  const productCall = {
-    select: () => ({
-      eq: () => ({
-        maybeSingle: () => Promise.resolve(opts.product ?? ok(null)),
-      }),
-    }),
-  };
-
-  const parentCall = {
-    select: () => ({
-      eq: () => ({
-        order: () => ({
-          limit: () => Promise.resolve(opts.parentLink ?? ok([])),
-        }),
-      }),
-    }),
-  };
-
-  const insertCall = {
-    insert: () => ({
-      select: () => ({
-        single: () =>
-          Promise.resolve(opts.insertResult ?? ok({ id: "new-part-id" })),
-      }),
-    }),
-  };
-
-  mockFrom.mockImplementation((table: string) => {
-    if (table === "products") return productCall;
-    if (table === "parent_gamer") return parentCall;
-    if (table === "participations") return insertCall;
-    throw new Error(`Unexpected from() table: ${table}`);
-  });
+function rpcFails(code: string, message = "refused") {
+  mockRpc.mockResolvedValue({ data: null, error: { code, message } });
 }
 
 const PRODUCT_ID = "11111111-1111-1111-1111-111111111111";
 const GAMER_ID = "22222222-2222-2222-2222-222222222222";
 const PARENT_ID = "33333333-3333-3333-3333-333333333333";
+const PARTICIPATION_ID = "44444444-4444-4444-4444-444444444444";
 
 function createRequest(body: unknown): Request {
   return new Request("http://localhost/api/admin/products/x/participations", {
@@ -123,7 +62,11 @@ const params = Promise.resolve({ id: PRODUCT_ID });
 
 beforeEach(() => {
   mockRequireRole.mockReset();
-  mockFrom.mockReset();
+  mockRpc.mockReset();
+  mockRpc.mockResolvedValue({
+    data: { participation_id: PARTICIPATION_ID, customer_id: PARENT_ID },
+    error: null,
+  });
 });
 
 describe("POST /api/admin/products/[id]/participations", () => {
@@ -131,21 +74,30 @@ describe("POST /api/admin/products/[id]/participations", () => {
     mockUnauthenticated();
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
     expect(response.status).toBe(401);
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 403 when caller is not an admin", async () => {
     mockNonAdmin();
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
     expect(response.status).toBe(403);
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the RPC guard refuses the caller", async () => {
+    // Defense in depth made visible: the admin gate is in the database too, so
+    // a bypass of the handler's own check still gets nothing.
+    mockAuthenticatedAdmin();
+    rpcFails("42501", "Forbidden");
+    const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
+    expect(response.status).toBe(403);
   });
 
   it("returns 400 when body is not JSON", async () => {
     mockAuthenticatedAdmin();
     const response = await POST(createRequest("not-json"), { params });
     expect(response.status).toBe(400);
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
   it("returns 400 when gamerId is missing", async () => {
@@ -154,76 +106,53 @@ describe("POST /api/admin/products/[id]/participations", () => {
     expect(response.status).toBe(400);
     const error = getString(await response.json(), "error");
     expect(error).toContain("gamerId");
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when product does not exist", async () => {
+  it("returns 404 when the product does not exist", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({ product: ok(null) });
+    rpcFails("P0002", "product does not exist");
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
     expect(response.status).toBe(404);
   });
 
-  it("rejects consumer_club products (no comp path for recurring billing)", async () => {
+  it("returns 400 for the RPC's business-rule refusals", async () => {
+    // consumer_club and "no linked parent" both come back as check_violation.
     mockAuthenticatedAdmin();
-    wireSupabase({
-      product: ok({ id: PRODUCT_ID, product_type: "consumer_club" }),
-    });
+    rpcFails("23514", "admin enrollment is not supported for consumer clubs");
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
     expect(response.status).toBe(400);
-    const error = getString(await response.json(), "error");
-    expect(error).toContain("consumer club");
-  });
-
-  it("returns 400 when gamer has no linked parent", async () => {
-    mockAuthenticatedAdmin();
-    wireSupabase({
-      product: ok({ id: PRODUCT_ID, product_type: "camp" }),
-      parentLink: ok([]),
-    });
-    const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
-    expect(response.status).toBe(400);
-    const error = getString(await response.json(), "error");
-    expect(error).toContain("parent");
   });
 
   it("returns 409 when the gamer is already enrolled", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({
-      product: ok({ id: PRODUCT_ID, product_type: "event" }),
-      parentLink: ok([{ parent_id: PARENT_ID }]),
-      insertResult: err(
-        'duplicate key value violates unique constraint "uq_participations_active_or_waitlisted"',
-        "23505",
-      ),
-    });
+    rpcFails(
+      "23505",
+      'duplicate key value violates unique constraint "uq_participations_active_or_waitlisted"',
+    );
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
     expect(response.status).toBe(409);
     const error = getString(await response.json(), "error");
     expect(error).toContain("already enrolled");
   });
 
-  it("happy path: inserts an active participation and returns the id", async () => {
+  it("returns 500 when the RPC result does not match its contract", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({
-      product: ok({ id: PRODUCT_ID, product_type: "municipality_club" }),
-      parentLink: ok([{ parent_id: PARENT_ID }]),
-      insertResult: ok({ id: "new-participation-id" }),
-    });
+    mockRpc.mockResolvedValue({ data: { unexpected: true }, error: null });
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
-    expect(response.status).toBe(200);
-    const participationId = getString(await response.json(), "participation_id");
-    expect(participationId).toBe("new-participation-id");
+    expect(response.status).toBe(500);
   });
 
-  it("happy path works for camps too", async () => {
+  it("happy path: calls the RPC with the URL product and returns the new id", async () => {
     mockAuthenticatedAdmin();
-    wireSupabase({
-      product: ok({ id: PRODUCT_ID, product_type: "camp" }),
-      parentLink: ok([{ parent_id: PARENT_ID }]),
-      insertResult: ok({ id: "camp-part-id" }),
-    });
     const response = await POST(createRequest({ gamerId: GAMER_ID }), { params });
+
     expect(response.status).toBe(200);
+    const participationId = getString(await response.json(), "participation_id");
+    expect(participationId).toBe(PARTICIPATION_ID);
+    expect(mockRpc).toHaveBeenCalledWith("admin_enroll_gamer", {
+      p_product_id: PRODUCT_ID,
+      p_gamer_id: GAMER_ID,
+    });
   });
 });

--- a/tests/integration/api/user-locale.test.ts
+++ b/tests/integration/api/user-locale.test.ts
@@ -3,22 +3,21 @@ import { PATCH } from "@/app/api/user/locale/route";
 
 // --- Mocks ---
 
-const mockGetUser = vi.fn();
+// The route builds one server client and uses it for both halves: `getClaims()`
+// for identity and `.from("profiles").update()` for the write. The write is a
+// Model B write — `profiles.locale` carries a column-level UPDATE grant and the
+// users_update_own_profile policy scopes it to auth.uid() — so there is no admin
+// client in this route to mock any more.
+const mockGetClaims = vi.fn();
+const mockUpdate = vi.fn();
+const mockEq = vi.fn();
 
-// The route reads identity via the getClaims-backed `getUser()` server helper.
 vi.mock("@/lib/supabase/server", () => ({
-  getUser: () => mockGetUser(),
-}));
-
-const mockAdminUpdate = vi.fn();
-const mockAdminEq = vi.fn();
-
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({
-    from: vi.fn(() => ({
-      update: mockAdminUpdate,
-    })),
-  })),
+  createClient: () =>
+    Promise.resolve({
+      auth: { getClaims: () => mockGetClaims() },
+      from: () => ({ update: mockUpdate }),
+    }),
 }));
 
 // --- Helpers ---
@@ -32,11 +31,14 @@ function createRequest(body: Record<string, unknown>): Request {
 }
 
 function mockAuthenticated(userId = "user-123") {
-  mockGetUser.mockResolvedValue({ id: userId, email: "user@example.com" });
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: userId, email: "user@example.com" } },
+    error: null,
+  });
 }
 
 function mockUnauthenticated() {
-  mockGetUser.mockResolvedValue(null);
+  mockGetClaims.mockResolvedValue({ data: null, error: null });
 }
 
 // --- Tests ---
@@ -44,8 +46,8 @@ function mockUnauthenticated() {
 describe("PATCH /api/user/locale", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAdminUpdate.mockReturnValue({ eq: mockAdminEq });
-    mockAdminEq.mockResolvedValue({ data: null, error: null });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockEq.mockResolvedValue({ data: null, error: null });
   });
 
   // -- Auth --
@@ -58,6 +60,19 @@ describe("PATCH /api/user/locale", () => {
 
     expect(response.status).toBe(401);
     expect(data.error).toBe("Unauthorized");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("should return 401 when the token fails verification", async () => {
+    mockGetClaims.mockResolvedValue({
+      data: null,
+      error: { message: "invalid JWT" },
+    });
+
+    const response = await PATCH(createRequest({ locale: "fi" }));
+
+    expect(response.status).toBe(401);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   // -- Validation --
@@ -92,15 +107,15 @@ describe("PATCH /api/user/locale", () => {
 
     expect(response.status).toBe(200);
     expect(data.locale).toBe("fi");
-    expect(mockAdminUpdate).toHaveBeenCalledWith({ locale: "fi" });
-    expect(mockAdminEq).toHaveBeenCalledWith("id", "user-123");
+    expect(mockUpdate).toHaveBeenCalledWith({ locale: "fi" });
+    expect(mockEq).toHaveBeenCalledWith("id", "user-123");
   });
 
   it("should accept all supported locales", async () => {
     for (const locale of ["en", "fi", "sv", "tlh"]) {
       vi.clearAllMocks();
-      mockAdminUpdate.mockReturnValue({ eq: mockAdminEq });
-      mockAdminEq.mockResolvedValue({ data: null, error: null });
+      mockUpdate.mockReturnValue({ eq: mockEq });
+      mockEq.mockResolvedValue({ data: null, error: null });
       mockAuthenticated();
 
       const response = await PATCH(createRequest({ locale }));
@@ -115,7 +130,7 @@ describe("PATCH /api/user/locale", () => {
 
   it("should return 500 when database update fails", async () => {
     mockAuthenticated();
-    mockAdminEq.mockResolvedValue({
+    mockEq.mockResolvedValue({
       data: null,
       error: { message: "connection error", code: "PGRST301" },
     });
@@ -127,6 +142,20 @@ describe("PATCH /api/user/locale", () => {
     expect(data.error).toBe("Failed to update locale");
   });
 
+  it("should return 403 when the database refuses the write", async () => {
+    // Only reachable if the grant or the self-update policy were changed under
+    // the route's feet — but "the DB said no" must not read as "we broke".
+    mockAuthenticated();
+    mockEq.mockResolvedValue({
+      data: null,
+      error: { message: "permission denied", code: "42501" },
+    });
+
+    const response = await PATCH(createRequest({ locale: "sv" }));
+
+    expect(response.status).toBe(403);
+  });
+
   // -- Security: uses authenticated user ID, not request body --
 
   it("should use the authenticated user ID for the update", async () => {
@@ -134,6 +163,6 @@ describe("PATCH /api/user/locale", () => {
 
     await PATCH(createRequest({ locale: "en" }));
 
-    expect(mockAdminEq).toHaveBeenCalledWith("id", "actual-session-user-id");
+    expect(mockEq).toHaveBeenCalledWith("id", "actual-session-user-id");
   });
 });

--- a/tests/integration/api/whatsapp-send.test.ts
+++ b/tests/integration/api/whatsapp-send.test.ts
@@ -14,21 +14,25 @@ vi.mock("@/lib/whatsapp", () => ({
   sendWhatsAppMessage: (...args: unknown[]) => mockSendWhatsAppMessage(...args),
 }));
 
+// Both writes run on the USER-bound client now — the admin-only insert/update
+// policies on whatsapp_contacts and whatsapp_messages are the second check
+// behind requireRole, and the message policy additionally pins direction to
+// outbound. So the mock hangs off `supabase`, not off the admin client, which
+// this route no longer imports.
 const mockContactUpsert = vi.fn().mockResolvedValue({ error: null });
 const mockMessageInsert = vi.fn().mockResolvedValue({ error: null });
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({
-    from: (table: string) => {
-      if (table === "whatsapp_contacts") {
-        return { upsert: mockContactUpsert };
-      }
-      if (table === "whatsapp_messages") {
-        return { insert: mockMessageInsert };
-      }
-      return {};
-    },
-  })),
-}));
+
+const userClient = {
+  from: (table: string) => {
+    if (table === "whatsapp_contacts") {
+      return { upsert: mockContactUpsert };
+    }
+    if (table === "whatsapp_messages") {
+      return { insert: mockMessageInsert };
+    }
+    return {};
+  },
+};
 
 // --- Helpers ---
 
@@ -36,7 +40,7 @@ function mockAdmin() {
   mockRequireRole.mockResolvedValue({
     user: { id: "admin-user-id" },
     profile: { role: "admin" },
-    supabase: {},
+    supabase: userClient,
   });
 }
 
@@ -135,6 +139,23 @@ describe("POST /api/admin/whatsapp/send", () => {
         status: "pending",
       })
     );
+  });
+
+  it("still returns the message id when the DB write is refused", async () => {
+    // The message is already at Meta by then — reporting failure would be a lie.
+    // The refusal is logged, not surfaced.
+    mockAdmin();
+    mockMessageInsert.mockResolvedValueOnce({
+      error: { code: "42501", message: "new row violates row-level security" },
+    });
+
+    const response = await POST(
+      createRequest({ to: "358401234567", body: "Hello!" })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.messageId).toBe("wamid.test123");
   });
 
   it("should not store message in DB when Meta API fails", async () => {

--- a/tests/integration/auth/pin.test.ts
+++ b/tests/integration/auth/pin.test.ts
@@ -22,18 +22,21 @@ vi.mock("next/headers", () => ({
 }));
 
 const mockAdminRpc = vi.fn();
-// The admin client reads customer_profiles.pin_hash (forgot mints / reset
-// verifies the single-use token bound to it). Returns whatever mockPinHash is
-// set to for the current test.
+// customer_profiles.pin_hash is read in two places, and they are deliberately
+// different clients. The RESET route still needs the admin client: it resolves a
+// user id out of a signed token, not out of a session, so there may be no
+// session to read as. The FORGOT route reads the caller's OWN row and now does
+// so on the user-bound client, which its own RLS policy already allows.
 const mockPinHash = vi.fn<() => { data: { pin_hash: string | null } | null; error: unknown }>(
   () => ({ data: { pin_hash: null }, error: null }),
 );
+const pinHashSelect = () => ({
+  select: () => ({ eq: () => ({ single: () => mockPinHash() }) }),
+});
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     rpc: (...args: unknown[]) => mockAdminRpc(...args),
-    from: () => ({
-      select: () => ({ eq: () => ({ single: () => mockPinHash() }) }),
-    }),
+    from: () => pinHashSelect(),
   })),
 }));
 
@@ -79,7 +82,11 @@ function authCustomer(overrides: { email?: string | null } = {}) {
       email: overrides.email === undefined ? "p@test.local" : overrides.email,
       locale: "en",
     },
-    supabase: { rpc: mockRpc, auth: { getClaims: mockGetClaims } },
+    supabase: {
+      rpc: mockRpc,
+      from: () => pinHashSelect(),
+      auth: { getClaims: mockGetClaims },
+    },
   });
   mockGetClaims.mockResolvedValue({
     data: { claims: { sub: "u1", session_id: "s1" } },


### PR DESCRIPTION
Phase 3 of the DB authorization refactor — the route sweep. Stacked on #75 (Phase 2); base is `refactor/db-auth-phase2`.

Twelve of the twenty-nine modules that held the service-role client at triage time no longer do; three more keep it for a narrowed, documented purpose. Every conversion is covered by the Phase 2 spine — each new function is classified in the role × RPC matrix or the self-scoping allowlist, each new write grant has an IDOR case, and the completeness checks fail the build if either is forgotten.

## Batch 1 — grant-plus-guard (`00122`)

`POST /api/participations/waitlist` and `POST /api/feedback` moved to the user-bound client against guarded entry points that read the caller from `auth.uid()` instead of taking it as a parameter:

- `join_product_waitlist(uuid, uuid)` — role-gated, customer
- `submit_my_feedback(text)` — self-scoping, with the route's length bounds moved into the body (they were decoration once the RPC became browser-reachable)

## Batch 2 — Model B client swaps (`00123`)

Six routes that touch only ordinary tables now run on the caller's own client, so the grant layer and RLS stand behind `requireRole` instead of the route being the only check: admin outbound-WhatsApp, PIN-forgot, Minecraft account link, locale update, and both locations CRUD routes. Adds the grants and policies that made those reachable, and revokes `authenticated`'s dead `UPDATE` on `whatsapp_messages` (the Phase 2 finding).

## Batch 3 — new RPCs (`00124`)

`participations` is grant-locked, so the two admin participation routes became Model C:

- `admin_enroll_gamer(uuid, uuid)` — comp-enroll, admin-gated
- `admin_remove_participation(uuid, uuid)` — un-enroll, admin-gated

## Judgment calls

- **Additive rather than in-place guards.** Migrations hit shared staging on push, but staging's *code* only changes when this stack merges. Guarding an existing RPC would refuse the currently-deployed routes' service-role calls and break staging for that whole window. The alternative — an `auth.uid() IS NULL` escape hatch in the guard — reopens the roleless-caller hole Phase 2 closed, in the one place every guarded function shares. So the guarded entry points are new functions beside untouched engines: nothing is weakened for even one request, and there is no allowance to remember to remove. The two now-redundant signatures are recorded as a Phase 4 item, droppable any time after this deploys.
- **The admin cancel route was not grant-plus-guard.** The plan expected it to be; the cancel RPC is also called by the Stripe webhook, which has no session by definition and must keep calling it as `service_role` *permanently*. Guarding it would break that path for good. It stays an engine; the admin entry point wraps it.
- **One conversion closed a real race.** The live-Stripe-subscription refusal on admin un-enroll now shares a transaction and the product lock with the delete, instead of being a separate statement before it.
- **The locale route's admin client was never a typing bug.** The comment blamed a `@supabase/ssr` version two majors old; the actual blocker was a missing column grant. Root-caused, not carried forward.
- **`/api/voice/token` stays Model A, on purpose.** Its reads would convert, but the same handler prunes stale private-zone occupancy from prior session windows — a cross-user maintenance DELETE no participant is authorized to make. Converting only the reads leaves the handler holding the service-role client anyway, so the trust boundary would not move; it would only add a way for an RLS subtlety to lock a gamer out of a live voice session. A member-scoped prune RPC is recorded as the Phase 4 way to finish it.
- **`/api/feedback` is a partial conversion.** Its write is Model C; the notification fan-out (every admin's email, a gamer's parent's) stays service-role. Folding that into the RPC would make admin emails readable by any authenticated caller who invoked it directly.

## Docs

`docs/db-authorization-architecture.md` marks Phase 3 landed and carries the full triage as a machine-readable block — module → write model → conversion shape → justification — which is the classification step the playbook's route-layer instance is waiting on. Phase 4's inherited items are listed at the end of the Phase 3 section.

## Note on branch drift

This stack is based on `dev` as of Phase 1. `dev` has since gained four commits, one of which adds a parent-facing "leave the waitlist" feature — worth a look when the stack merges down, since it touches the same area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
