### PR TITLE
refactor(db-auth): Phase 4 — RLS completeness

### DIFF
--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -13,10 +13,13 @@ how authorization is enforced in the database.
 Before touching anything it describes:
 
 1. **Re-verify current state.** Snapshots in this doc were verified against the live
-   schema in 2026-06 and will drift. Current state lives in `supabase/schema.sql`
-   (function bodies, grants, policies) and the DB access-control test's allowlists —
-   never in migration history. Regenerate the route list with
-   `git grep -l createAdminClient src/`.
+   schema in 2026-07 and will drift. Current state lives in `supabase/schema.sql`
+   (function bodies, grants, policies) and the DB test suite's classifications — never
+   in migration history. Regenerate the route list with
+   `git grep -l createAdminClient src/`. Note the corollary the Phase 4 drift repair
+   made concrete: `schema.sql` is a dump of a *hosted* database, so an object created
+   outside a migration lands in it and is invisible to every check we run, all of which
+   build their database from migrations alone.
 2. **Follow the migration workflow in CLAUDE.md** (push migration → regenerate types →
    dump `schema.sql` → check type aliases → commit together).
 3. **DB tests run in CI** against a local Supabase stack started by the workflow. Do
@@ -74,7 +77,7 @@ the next instance of that class fails a test before it ships.
 
 ---
 
-## 2. Current state (verified 2026-06 — re-verify per the execution contract)
+## 2. Current state (verified 2026-07 — re-verify per the execution contract)
 
 **Platform regime change (2026-06):** Supabase no longer auto-grants Data API privileges
 (`anon`/`authenticated`/`service_role`) to new `public`-schema objects — on local stacks
@@ -192,11 +195,12 @@ write path. The access-control test now audits `anon` grants alongside
 `authenticated` and pins the write surface at zero; `anon` keeps `SELECT` for the
 public catalog policies.
 
-**Column-level grants are already in use on `profiles`**: `authenticated` holds
-`UPDATE` on exactly the safe columns (name, phone, spoken languages) — `role` is not
-grantable — and the self-update policy's `WITH CHECK` additionally pins `role` to its
-current value. The §3.4 column-grant audit asserts this state holds; it does not need
-to construct it.
+**Column-level grants are in use on `profiles`**, and it is the only table where they
+are: `authenticated` holds `UPDATE` on exactly the safe columns (name, phone, spoken
+languages, locale) — `role` is not grantable — and the self-update policy's `WITH CHECK`
+additionally pins `role` to its current value. The §3.4 column-grant audit asserts this
+state holds, and asserts that `profiles` is still the only member; it does not need to
+construct either.
 
 ### Existing verification
 
@@ -590,49 +594,187 @@ src/lib/supabase/admin.ts,-,-,the client factory itself
   leave the handler holding the service-role client anyway, so the trust boundary would
   not move; it would only add a way for an RLS subtlety to lock a gamer out of a live
   voice session. A member-scoped prune RPC is the obvious way to finish this and is
-  recorded as a Phase 4 candidate rather than forced here.
+  recorded as a Phase 4 candidate rather than forced here. (Phase 4 designed it and did
+  not ship it either — for a sharper reason than this one; see its design note.)
 - **The feedback route is a partial conversion and is recorded as such.** Its write is
   Model C; its notification fan-out stays Model A. Folding the recipient lookup into the
   RPC would make every admin's email address readable by any authenticated caller who
   invoked that RPC directly, which is worse than the thing it would fix.
 
-What Phase 4 inherits:
+Phase 4 cleared the backlog Phase 3 left: the two participation predicates went into
+policies, the product-read predicate became total, and the redundant engine signatures
+were sequenced behind the deploy (see the post-deploy list at the end of §5).
 
-- **Two now-redundant function signatures.** The engines behind the waitlist-join and
-  feedback-submission entry points still carry their pre-Phase-3 signatures, which take
-  the caller's identity as a parameter. They are unreferenced by application code once
-  this stack deploys; drop them then, and drop their `service_role` grants with them.
-  Nothing depends on the timing beyond "after the deploy".
-- **A member-scoped voice-occupancy prune** would let the voice-token route convert; see
-  the judgment call above for why it was not forced into this phase.
-- **The parent-writes-linked-gamer policy** is the last thing keeping the gamer-update
-  route's data writes on the admin client (its Auth Admin calls keep it Model A
-  regardless). Phase 4 already plans this policy; landing it shrinks that route's
-  service-role surface to the auth work alone.
-- **`can_read_product` answers `NULL`, not `false`,** for a caller with no profiles row
-  — carried forward from Phase 2, still worth a total-boolean fix when that predicate is
-  next touched.
-- **The Phase 1 grant asymmetry still stands** for the self-assertion primitive and the
-  two §3.2 participation predicates: nothing composes from them yet, so they remain
-  `service_role`-only. Phase 4 is the phase that puts them in a policy.
+### Phase 4 — RLS completeness — **landed**
 
-### Phase 4 — RLS completeness
+Every policy in the database now expresses its admin half as one named predicate, and no
+policy re-derives an ownership question a predicate already answers.
 
-Refactor existing write policies to compose from the §3.2 predicates so the write-IDOR
-loop passes everywhere; migrate inline `(SELECT get_user_role()) = 'admin'` policy
-comparisons to `is_admin()` opportunistically as policies are touched. Ship pending
-features that add write policies (e.g. a parent updating their linked gamer's profile
-fields) on the same predicates. Start from the inherited-items list at the end of
-Phase 3 — it is the backlog this phase clears.
+- **The admin idiom is now singular.** Twenty-eight policies migrated to the named admin
+  predicate, InitPlan-wrapped. They had been written three different ways — an inline
+  comparison against the role accessor, a bare call to the predicate, and a hand-rolled
+  `EXISTS` over the profiles table — and the three were scattered across tables with no
+  pattern to which table got which. Each swap is a rename of an identical expression,
+  including the NULL answer for a caller with no profiles row, which a `USING` /
+  `WITH CHECK` clause denies either way. Three of them carried a bare call and were
+  paying a function call per row; the wrapper fixed that as a side effect.
+- **The three party-to policies compose from the §3.2 predicates**, which took their
+  `authenticated` grant at that point (a policy expression is evaluated as the querying
+  role) and their spine classification with fixture-bearing scope tests. The equivalence
+  argument is below — it is the interesting part of this phase.
+- **The product-read predicate became a total boolean.** Its admin disjunct is NULL for a
+  caller with no profiles row and `NULL OR false` is NULL, so it answered SQL NULL. The
+  deny was never in doubt; the fix is about not handing the next consumer a
+  three-valued answer. Wrapped in `COALESCE(…, false)`, and moved to the canonical empty
+  search_path while it was open.
+- **`ALTER POLICY`, not `DROP` + `CREATE`.** No statement ever observes a table without
+  its policy, and the change is one catalog update rather than a window.
+
+#### Judgment calls
+
+- **The party-to swap was argued from its *direction*, not from a data snapshot.** The
+  predicates unify the two participation columns into one question; the policies they
+  replaced each keyed on one column under a role gate. So the rewrite can only ever
+  *admit* a row the old form refused, never refuse one it admitted — which is what makes
+  it safe to apply to a shared database whose deployed code has not changed yet. A
+  snapshot showing zero affected rows would have been weaker: it says nothing about the
+  next row inserted.
+- **The row it could additionally admit is the policies' own intent.** That row is a
+  caller holding one party's role who occupies the *other* party's column — a
+  customer-role account that is the gamer on an active participation, or the reverse.
+  It does not exist on the shared database (checked in both directions before writing
+  the migration) and is unreachable through the application's own creation paths:
+  participation parties are resolved from parent/gamer links, gamer accounts are created
+  with the gamer role by the atomic creation RPC, which refuses to promote an existing
+  account, and the role column carries no write grant for `authenticated` at all, so only
+  an admin could ever produce one. And if one existed, the effect would be to show a
+  party to a participation the group or assignment row they are themselves party to —
+  the thing these policies exist to do. Making it *structurally* impossible would mean a
+  cross-table role invariant enforced by triggers on both tables, which buys nothing here
+  and would refuse an admin's legitimate role correction.
+- **A drift between the hosted databases and migration history surfaced here and was
+  repaired.** Two admin full-access policies — on the tables holding the parent PIN hash
+  and a child's date of birth — existed on the hosted databases but had never been
+  written into a migration, so a database built from migrations alone did not have them.
+  CI builds exactly such a database, which means the DB suite had been verifying a
+  different RLS surface from the one that runs in production on those two tables. The
+  migration creates them when absent and alters them when present. Worth remembering as
+  a class: **a policy created outside a migration is invisible to every check we have**,
+  because every check runs against a database built from migrations.
+- **The voice-token route stays Model A, and this is now a decision rather than a
+  deferral** — see the design note below.
+
+#### The voice-occupancy prune: designed, not shipped
+
+Phase 3 recorded a member-scoped prune RPC as the obvious way to finish the voice-token
+route's conversion. Designing it surfaced two blockers, and the first is a genuine
+privacy hole rather than an inconvenience:
+
+1. **No caller may supply the cutoff.** The prune deletes private-zone occupancy rows
+   from *previous* session windows, so it needs to know where the current window starts.
+   If that boundary is a parameter, any group member can pass a value that sweeps the
+   *current* window's rows — and those rows are the privacy ledger the SFU permission
+   projection is rebuilt from, so deleting them un-blocks the very people they confine.
+   A confined participant could free themselves, which is precisely the guarantee the
+   write-IDOR loop pins for that table. Bounding the parameter to the past does not help:
+   the current window opened in the past too.
+2. **A gedu's cross-group voice mobility has no matching read policy.** The voice model
+   treats a gedu as a member and moderator of every group of a product they are assigned
+   to, and the token route's membership gate follows that. But the policy letting a gedu
+   *read a group row* is assignment-scoped, not product-scoped — so converting the
+   route's group read to the user client would lock a gedu out of a sibling group's room
+   that they are entitled to join. Widening that policy would fix it, but widening is not
+   behaviour-equivalent, which the deployment-window rule forbids in the same change.
+
+The three ways out of the first blocker, for whoever picks this up:
+
+- **Compute the window in the database.** Correct and parameterless, but it means a
+  second implementation of the session-window arithmetic — weekday, product timezone,
+  duration, and the open/close grace margins — in SQL, where it would silently drift from
+  the application's copy. The margins are application constants, not schema.
+- **Prune on a fixed retention** (delete occupancy older than a day) rather than on the
+  window boundary. Parameterless, safe by construction because a current window's start
+  is always within hours of now, and it still serves every purpose the prune has: freeing
+  the uniqueness constraint for re-occupancy, reaping a participant who never left, and
+  bounding growth. It is not equivalent — rows survive longer — but nothing reads them:
+  every consumer filters occupancy to an exact window already.
+- **Restrict the prune to moderators**, who are authorized to delete occupancy anyway.
+  Simplest, but it stops being self-healing on a session no moderator joins.
+
+The second blocker wants the route to stop reading the group row directly at all: a
+single self-scoping RPC that answers "may I join this room, and what are its schedule and
+timezone", bounded by the existing voice-membership predicate — which already encodes
+exactly the route's three-way membership gate. That collapses two of the route's gates
+and its group read into one call, and leaves only the prune, the occupancy read and the
+caller's own Minecraft row, all of which convert cleanly. Until both parts land, the
+route holds the service-role client, so converting its reads piecemeal would move no
+trust boundary — the same reasoning Phase 3 applied.
+
+#### Post-deploy cleanup
+
+The only work this refactor leaves. Both items are blocked on the deploy of this stack,
+not on design:
+
+- **Revoke `service_role` EXECUTE from the two participation engines** — the three-argument
+  waitlist-join and the two-argument feedback-submission functions, which take the
+  caller's identity as a parameter. Phase 3 put guarded entry points in front of them and
+  no application code calls them directly any more, but staging's *deployed* code still
+  does until this stack ships. Note they cannot be dropped, as Phase 3's note assumed:
+  the guarded entry points call them. Revoking the grant is the stronger outcome anyway —
+  it makes the engines reachable only through their guarded wrappers, which is the §2
+  grant-lockdown posture applied to a function instead of a table:
+
+  ```sql
+  REVOKE EXECUTE ON FUNCTION public.join_waitlist(uuid, uuid, uuid) FROM service_role;
+  REVOKE EXECUTE ON FUNCTION public.submit_feedback(uuid, text) FROM service_role;
+  ```
+
+  Verify first that nothing outside the wrappers still calls them, then push the revoke
+  as a normal migration; the wrappers are `SECURITY DEFINER` and reach the engines through
+  ownership, not through a role grant.
+- **Confirm the two repaired admin policies exist on production.** The drift repair above
+  is conditional, so production takes the ALTER branch — but the drift is evidence that
+  the hosted schemas were edited outside migrations at least once, and the cheapest time
+  to notice another instance is right after this stack lands. Compare the production
+  policy catalog against `supabase/schema.sql`.
+
+The self-assertion primitive remains `service_role`-only: nothing composes from it yet,
+because no `SECURITY INVOKER` body or policy has needed a raising self-check. That is the
+Phase 1 asymmetry working as designed, not an omission — the phase that needs it grants
+it, and the spine will require its classification at that point.
 
 ---
 
 ## 6. Explicitly out of scope
 
-Adjacent but *different* refactors — folding them in would bloat this one:
+Adjacent but *different* refactors — folding either into this one would have bloated it,
+and both are still open:
 
 - **Data-validity constraints** — CHECK constraints on free-text columns, NOT NULL
   tightening. Same layer, different property (validity, not authorization).
-- **Browser-level auth E2E** — Playwright against a local Supabase stack. Shares the
-  role-switching substrate and would accelerate Phase 2, but the DB-test helpers
-  already cover what the spine needs.
+- **Browser-level auth E2E** — Playwright against a local Supabase stack. It shares the
+  role-switching substrate, but the DB-test helpers cover what the spine needs, so this
+  buys coverage of the *browser* half of an auth flow rather than more of the database
+  half.
+
+---
+
+## 7. Feature work this refactor makes cheap
+
+Not part of the refactor, and not blocking anything. Recorded here because the refactor
+is what put the pieces in place, and because each one is a *product* decision wearing an
+authorization costume — none should be slipped in as a cleanup.
+
+- **A parent writing their linked gamer's profile fields.** The predicate for it exists
+  and has since Phase 1, so the policy itself is a few lines. What makes it a product
+  decision is what it costs: the write-IDOR loop currently pins the opposite guarantee —
+  a parent may *read* their child's profile row and may not write it — with the linked
+  parent deliberately chosen as the sharpest attacker for that table. Landing the feature
+  means rewriting that case to a narrower one (which columns, and which are still the
+  child's alone), and that column list is the actual decision. The payoff is that the
+  gamer-update route's data writes leave the service-role client; its Auth Admin calls
+  keep it Model A regardless, so the win is a smaller Model A surface, not one fewer
+  Model A route.
+- **Finishing the voice-token conversion**, per the design note in §5 Phase 4. Both parts
+  of it change behaviour — one changes when stale occupancy is reaped, the other widens
+  what a gedu may read — so both want a deploy boundary of their own.

--- a/docs/db-authorization-architecture.md
+++ b/docs/db-authorization-architecture.md
@@ -1,13 +1,16 @@
 # Database Authorization Architecture
 
-**Status:** target architecture + migration plan. The conventions in §2–§3 are how new
-code is written today; §5 Phase 1 (guard primitives + ownership predicates), Phase 2 (the
-§3.4 verification spine) and Phase 3 (the route sweep) have landed; RLS completeness
-(Phase 4) is not yet built. This is the single source of truth for the refactor — when
-someone says "let's do the DB authorization refactor," this is the doc to read and act on.
+**Status: built.** All four phases of §5 have landed — the guard primitives and ownership
+predicates, the §3.4 verification spine, the route sweep, and RLS completeness. §2–§3
+describe the system that exists, not a target: every privileged function body opens with a
+guard primitive or is classified self-scoping with a named scope test, every policy
+expresses its admin half as one named predicate, and the spine fails the build when
+anything escapes that. What remains is the post-deploy cleanup listed at the end of §5 and
+the feature work in §7 — no structural work. This doc stays the single source of truth for
+how authorization is enforced in the database.
 
-**Execution contract.** This doc is written so a fresh Claude Code session can execute
-the refactor from it. Before acting on any phase:
+**Execution contract.** This doc is written so a fresh Claude Code session can act on it.
+Before touching anything it describes:
 
 1. **Re-verify current state.** Snapshots in this doc were verified against the live
    schema in 2026-06 and will drift. Current state lives in `supabase/schema.sql`
@@ -18,8 +21,13 @@ the refactor from it. Before acting on any phase:
    dump `schema.sql` → check type aliases → commit together).
 3. **DB tests run in CI** against a local Supabase stack started by the workflow. Do
    not run them locally or against the remote DB — push the branch and let CI run them.
-4. **One phase per PR batch**, in order. A phase's checks must be green before the
-   next phase starts, because later phases lean on them.
+4. **A migration reaches the shared database the moment it is pushed; the code running
+   against that database does not change until the PR merges and deploys.** So any
+   change to a policy, a grant, or a guard has to be behaviour-equivalent for the
+   *currently deployed* code, or it breaks the shared environment for the whole window.
+   The reliable shapes are: add a new object beside the old one, or rewrite a policy so
+   it can only ever admit more than before, never less. A rewrite that cannot be argued
+   to one of those does not ship — it gets recorded and sequenced behind a deploy.
 
 ---
 
@@ -128,9 +136,15 @@ the verification spine treats each kind differently:
   for `42501` (which also finds the assertions themselves).
 - **Self-scoping helpers** (the majority): every read/write keyed to `auth.uid()`;
   no raise block, by design. The `get_my_*` family, the PIN functions.
-- **Boolean predicates consumed by RLS policies**: `is_admin()`,
-  `can_read_product()`, `is_parent_of()` — `STABLE SECURITY DEFINER`, return a
-  boolean, never raise. `can_read_product` is the only function granted to `anon`.
+- **Boolean predicates consumed by RLS policies**: the admin predicate, the product-read
+  predicate, parent-of-gamer, the two party-to-a-participation predicates, and the two
+  voice-room ones — `STABLE SECURITY DEFINER`, return a boolean, never raise. Each is
+  granted to `authenticated` because a policy expression is evaluated as the *querying*
+  role, so a predicate a policy composes from must be executable by that role. The
+  product-read predicate is the only function granted to `anon`. **A predicate returns a
+  total boolean** — never NULL. A `USING` clause treats NULL as deny, so a NULL-capable
+  predicate is not a hole *there*, but it is a trap for any consumer that is not a policy;
+  wrap a disjunction whose first term can be NULL in `COALESCE(…, false)`.
 - **The participation state machine** (the waitlist-join, participation-create,
   participation-cancel and reservation-confirm functions): granted to **service_role
   only** — not callable by `authenticated` at all. Phase 3 put guarded,
@@ -150,6 +164,16 @@ that subquery form makes it an InitPlan evaluated once per statement. **The Init
 wrapping, not `STABLE` itself, is what makes it cheap** — `STABLE` permits
 optimization but guarantees no caching. Keep the wrapped form in every policy; a bare
 call in a policy predicate is a per-row function call.
+
+**The wrapping rule applies to argument-free predicates.** A predicate that takes the
+row's own column as an argument cannot be an InitPlan — it depends on the row, so
+`(SELECT p(col))` is a correlated subplan re-executed per row, exactly like the bare
+call. Wrap it anyway for one shape across every policy, but do not expect the InitPlan
+payoff there, and be aware of the trade the wrapping rule cannot hide: replacing an
+uncorrelated `col IN (SELECT …)` — which PostgreSQL evaluates once and hashes — with a
+per-row predicate call buys auditability at the cost of a function call per row. That is
+the right trade on the small tables the party-to predicates guard; it would not be on a
+large one.
 
 ### Sensitive tables (grant-locked today)
 
@@ -234,22 +258,30 @@ is for *policies*, which evaluate per row.)
 
 **Keep `is_admin()`.** Assertions and predicates are two primitives for two contexts,
 not duplicates: function bodies need a raising assertion; RLS policies need a boolean
-expression. `is_admin()` is the named admin predicate for policies (20+ policies use
-it today) and the first member of the §3.2 predicate family. The thing to migrate away
-from is the *other* policy idiom — the inline `(SELECT get_user_role()) = 'admin'`
-comparison some policies carry — folded into Phase 4 opportunistically, not as a
-big-bang rewrite.
+expression. `is_admin()` is the named admin predicate for policies and the first member
+of the §3.2 predicate family. **It is now the only way a policy asks "is the caller an
+admin"** — the inline `(SELECT get_user_role()) = 'admin'` comparison and the
+hand-rolled `EXISTS` over `profiles` are both gone from every policy in the database
+(Phase 4). A new policy that reintroduces either is doing by hand what a named,
+audited, single-definition predicate already does.
 
 ### 3.2 Ownership predicates (for policies)
 
 The "target half" of RLS — "is this caller allowed to reference *this specific
 row*?" — expressed as a small set of reusable `STABLE` predicate functions rather than
-re-derived as an inline `EXISTS` subquery inside each policy. The concrete duplication
-today: the "caller has an active participation on this product/group" subquery appears
-inline in at least three policies (customer- and gamer-side group visibility), each a
-chance to get it half-right. Policies then *compose* from audited predicates:
-`is_admin()`, parent-of-gamer, has-active-participation-on, and the like. The IDOR
-class of bug exists precisely because the inline subquery is easy to write half-right.
+re-derived as an inline `EXISTS` subquery inside each policy. Policies *compose* from
+audited predicates: `is_admin()`, parent-of-gamer, has-active-participation-on, and the
+like. The IDOR class of bug exists precisely because the inline subquery is easy to
+write half-right, and the duplication that motivated this — the same "caller has an
+active participation on this product/group" subquery written out in three separate
+policies — is gone as of Phase 4.
+
+**A predicate asks about the caller's *relationship* to a row, not about their role.**
+The party-to predicates deliberately treat the purchasing parent and the enrolled gamer
+as one question ("am I a party to this participation") rather than one predicate per
+column. That unification is what makes a predicate reusable across the customer-side
+and gamer-side policies; the role gate, where a policy still wants one, stays in the
+policy where it is visible.
 
 ### 3.3 Grant lockdown as the default for sensitive tables
 

--- a/supabase/migrations/00125_phase4_rls_completeness.sql
+++ b/supabase/migrations/00125_phase4_rls_completeness.sql
@@ -217,12 +217,46 @@ ALTER POLICY admin_manage_spoken_languages ON public.spoken_languages
 -- 4b. FOR ALL policies carrying only USING. A FOR ALL policy with no WITH CHECK
 --     reuses its USING clause for writes, so leaving WITH CHECK unset preserves
 --     the existing shape exactly.
+--
+--     These two are create-or-alter rather than a plain ALTER, because they are
+--     the one place where the hosted databases and migration history disagree:
+--     both policies exist on the hosted databases but were never written into a
+--     migration, so a database built from migrations alone has no admin policy
+--     on either table. That drift meant CI was verifying a *different* RLS
+--     surface from the one that runs in production on exactly the two tables
+--     holding the parent PIN hash and a child's date of birth. Creating them
+--     when absent repairs it; the hosted databases take the ALTER branch and
+--     are unaffected.
 
-ALTER POLICY "Admins can do everything on customer_profiles" ON public.customer_profiles
-  USING ((SELECT public.is_admin()));
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename = 'customer_profiles'
+       AND policyname = 'Admins can do everything on customer_profiles'
+  ) THEN
+    ALTER POLICY "Admins can do everything on customer_profiles" ON public.customer_profiles
+      USING ((SELECT public.is_admin()));
+  ELSE
+    CREATE POLICY "Admins can do everything on customer_profiles" ON public.customer_profiles
+      TO authenticated USING ((SELECT public.is_admin()));
+  END IF;
 
-ALTER POLICY "Admins can do everything on gamer_profiles" ON public.gamer_profiles
-  USING ((SELECT public.is_admin()));
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename = 'gamer_profiles'
+       AND policyname = 'Admins can do everything on gamer_profiles'
+  ) THEN
+    ALTER POLICY "Admins can do everything on gamer_profiles" ON public.gamer_profiles
+      USING ((SELECT public.is_admin()));
+  ELSE
+    CREATE POLICY "Admins can do everything on gamer_profiles" ON public.gamer_profiles
+      TO authenticated USING ((SELECT public.is_admin()));
+  END IF;
+END;
+$$;
 
 -- 4c. The WhatsApp policies, which hand-rolled the EXISTS over profiles rather
 --     than calling the role accessor at all — the last copies of that idiom.

--- a/supabase/migrations/00125_phase4_rls_completeness.sql
+++ b/supabase/migrations/00125_phase4_rls_completeness.sql
@@ -1,0 +1,245 @@
+-- Phase 4 of the DB authorization refactor (docs/db-authorization-architecture.md
+-- §5 Phase 4): RLS completeness.
+--
+-- WHAT THIS CHANGES
+--
+-- 1. can_read_product() becomes a TOTAL boolean. Its first disjunct compares the
+--    caller's role to 'admin', which is NULL for a caller with no profiles row,
+--    and `NULL OR false` is NULL under three-valued logic — so a roleless caller
+--    got SQL NULL rather than false. Harmless where it is used (a USING clause
+--    treats NULL as deny) but a predicate that can answer NULL is a trap for the
+--    next consumer. COALESCE(…, false) closes it. Behaviour under RLS is
+--    unchanged; the function is also moved to the canonical empty search_path.
+--
+-- 2. The two §3.2 participation predicates gain their `authenticated` EXECUTE
+--    grant, because three policies now compose from them (item 3). They were
+--    service_role-only while nothing consumed them.
+--
+-- 3. Three SELECT policies stop inlining the "caller has an active participation
+--    on this product / in this group" subquery and call the audited predicate
+--    instead. See the equivalence note below.
+--
+-- 4. Every policy that compared the caller's role to 'admin' inline — either as
+--    `(SELECT get_user_role()) = 'admin'` or as a hand-rolled EXISTS over
+--    profiles — now calls the named admin predicate, InitPlan-wrapped as
+--    `(SELECT public.is_admin())`. The four policies that already called
+--    is_admin() bare are wrapped too, so the admin half of every policy in the
+--    database is one shape.
+--
+-- EQUIVALENCE (item 3) — why this is safe to apply ahead of any code deploy
+--
+-- The inlined subqueries key on ONE participation column each (customer_id for
+-- the two customer policies, gamer_id for the gamer one) under a role gate. The
+-- predicates key on EITHER column ("is the caller a party to this
+-- participation"). So the rewrite can only ever ADMIT a row the old form
+-- refused, never refuse one it admitted — no existing read can break, which is
+-- what makes it safe to push to a shared database whose deployed code has not
+-- changed yet.
+--
+-- The one row it could additionally admit is a caller holding role 'customer'
+-- who is the gamer_id of an active participation (or role 'gamer' who is the
+-- customer_id). Verified as non-existent on the shared database at write time:
+-- zero rows in either direction, every gamer_id resolving to a 'gamer' profile
+-- and every customer_id to a 'customer' one. It is also unreachable through the
+-- application's own creation paths — participation parties are resolved from
+-- parent/gamer links, gamer profiles are created with the gamer role by the
+-- atomic creation RPC (which refuses to promote an existing account), and the
+-- role column carries no write grant for `authenticated` at all. And were such a
+-- row ever created, the effect would be to show a party to a participation the
+-- group/assignment row they are themselves party to — the policies' own intent,
+-- not a widening of it.
+--
+-- The `group_id IS NOT NULL` clause in the two group policies is dropped as
+-- redundant: the predicate compares group_id to product_groups.id, which is a
+-- NOT NULL primary key, so a NULL group_id can never match.
+--
+-- ALTER POLICY (rather than DROP + CREATE) is used throughout so no statement
+-- ever observes the table without its policy.
+
+-- ---------------------------------------------------------------------------
+-- 1. can_read_product — total boolean, canonical search_path
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.can_read_product(p_product_id uuid) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO ''
+    AS $$
+  SELECT COALESCE(
+    -- admin sees everything (mirrors admin_full_access_* FOR ALL)
+    (SELECT public.get_user_role()) = 'admin'::public.user_role
+    -- public: published and visible
+    OR EXISTS (
+      SELECT 1 FROM public.products pr
+      WHERE pr.id = p_product_id
+        AND pr.status IN ('pending'::public.product_status, 'running'::public.product_status)
+        AND pr.is_visible = true
+    )
+    -- enrolled gamer (child's own login) OR purchaser (parent), active/waitlisted
+    OR EXISTS (
+      SELECT 1 FROM public.participations p
+      WHERE p.product_id = p_product_id
+        AND (p.gamer_id = (SELECT auth.uid()) OR p.customer_id = (SELECT auth.uid()))
+        AND p.status IN ('active'::public.participation_status, 'waitlisted'::public.participation_status)
+    )
+    -- assigned gedu
+    OR EXISTS (
+      SELECT 1 FROM public.gedu_group_assignments a
+      WHERE a.product_id = p_product_id
+        AND a.gedu_id = (SELECT auth.uid())
+    ),
+    false
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_read_product(p_product_id uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.can_read_product(p_product_id uuid) TO anon;
+GRANT EXECUTE ON FUNCTION public.can_read_product(p_product_id uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.can_read_product(p_product_id uuid) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. The §3.2 participation predicates become policy-callable
+-- ---------------------------------------------------------------------------
+-- A policy expression is evaluated as the querying role, so a predicate a
+-- policy composes from must be executable by that role.
+
+GRANT EXECUTE ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. The three policies that inlined the party-to subquery
+-- ---------------------------------------------------------------------------
+
+ALTER POLICY customers_read_assignments_via_gamers ON public.gedu_group_assignments
+  USING (
+    (SELECT public.get_user_role()) = 'customer'::public.user_role
+    AND (SELECT public.has_active_participation_on_product(product_id))
+  );
+
+ALTER POLICY customers_read_groups_via_gamers ON public.product_groups
+  USING (
+    (SELECT public.get_user_role()) = 'customer'::public.user_role
+    AND (SELECT public.has_active_participation_in_group(id))
+  );
+
+ALTER POLICY gamers_read_own_group ON public.product_groups
+  USING (
+    (SELECT public.get_user_role()) = 'gamer'::public.user_role
+    AND (SELECT public.has_active_participation_in_group(id))
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. Every inline admin comparison becomes (SELECT public.is_admin())
+-- ---------------------------------------------------------------------------
+-- `(SELECT get_user_role()) = 'admin'` and `is_admin()` are the same expression
+-- — is_admin()'s entire body is that comparison — so each of these is a
+-- rename, not a semantic change, including the NULL answer for a caller with no
+-- profiles row (which a USING/WITH CHECK clause treats as deny either way).
+--
+-- The subquery wrapper is what makes it an InitPlan: one evaluation per
+-- statement instead of one per row. Three of the policies below carried a bare
+-- call and were paying per row; the four that already called is_admin() bare
+-- were too.
+
+-- 4a. FOR ALL policies — USING and WITH CHECK.
+
+ALTER POLICY admin_full_access_calendar_holidays ON public.calendar_holidays
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_family_subscriptions ON public.family_subscriptions
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_feedback ON public.feedback_submissions
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_gedu_assignments ON public.gedu_group_assignments
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_gedu_profiles ON public.gedu_profiles
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_holiday_calendars ON public.holiday_calendars
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_minecraft_accounts ON public.minecraft_accounts
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_parent_gamer ON public.parent_gamer
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_participations ON public.participations
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_payments ON public.payments
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_product_groups ON public.product_groups
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_product_holiday_calendars ON public.product_holiday_calendars
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_product_prices ON public.product_prices
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_product_subscription_prices ON public.product_subscription_prices
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_product_translations ON public.product_translations
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_products ON public.products
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_profiles ON public.profiles
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_refunds ON public.refunds
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_schedule_slots ON public.schedule_slots
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_site_details ON public.site_details
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_full_access_site_staff_details ON public.site_staff_details
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_manage_gedu_locations ON public.gedu_locations
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_manage_locations ON public.locations
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY admin_manage_spoken_languages ON public.spoken_languages
+  USING ((SELECT public.is_admin())) WITH CHECK ((SELECT public.is_admin()));
+
+-- 4b. FOR ALL policies carrying only USING. A FOR ALL policy with no WITH CHECK
+--     reuses its USING clause for writes, so leaving WITH CHECK unset preserves
+--     the existing shape exactly.
+
+ALTER POLICY "Admins can do everything on customer_profiles" ON public.customer_profiles
+  USING ((SELECT public.is_admin()));
+
+ALTER POLICY "Admins can do everything on gamer_profiles" ON public.gamer_profiles
+  USING ((SELECT public.is_admin()));
+
+-- 4c. The WhatsApp policies, which hand-rolled the EXISTS over profiles rather
+--     than calling the role accessor at all — the last copies of that idiom.
+
+ALTER POLICY "Admins can read whatsapp_contacts" ON public.whatsapp_contacts
+  USING ((SELECT public.is_admin()));
+
+ALTER POLICY "Admins can update whatsapp_contacts" ON public.whatsapp_contacts
+  USING ((SELECT public.is_admin()));
+
+ALTER POLICY "Admins can insert whatsapp_contacts" ON public.whatsapp_contacts
+  WITH CHECK ((SELECT public.is_admin()));
+
+ALTER POLICY "Admins can read whatsapp_messages" ON public.whatsapp_messages
+  USING ((SELECT public.is_admin()));
+
+-- The direction pin stays: an admin may write outbound messages only, so an
+-- inbound row can never be forged through the API.
+ALTER POLICY "Admins can insert whatsapp_messages" ON public.whatsapp_messages
+  WITH CHECK ((SELECT public.is_admin()) AND direction = 'outbound');

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -559,31 +559,33 @@ $$;
 
 CREATE FUNCTION public.can_read_product(p_product_id uuid) RETURNS boolean
     LANGUAGE sql STABLE SECURITY DEFINER
-    SET search_path TO 'public'
+    SET search_path TO ''
     AS $$
-  SELECT
+  SELECT COALESCE(
     -- admin sees everything (mirrors admin_full_access_* FOR ALL)
-    (SELECT get_user_role()) = 'admin'
+    (SELECT public.get_user_role()) = 'admin'::public.user_role
     -- public: published and visible
     OR EXISTS (
-      SELECT 1 FROM products pr
+      SELECT 1 FROM public.products pr
       WHERE pr.id = p_product_id
-        AND pr.status IN ('pending', 'running')
+        AND pr.status IN ('pending'::public.product_status, 'running'::public.product_status)
         AND pr.is_visible = true
     )
     -- enrolled gamer (child's own login) OR purchaser (parent), active/waitlisted
     OR EXISTS (
-      SELECT 1 FROM participations p
+      SELECT 1 FROM public.participations p
       WHERE p.product_id = p_product_id
         AND (p.gamer_id = (SELECT auth.uid()) OR p.customer_id = (SELECT auth.uid()))
-        AND p.status IN ('active', 'waitlisted')
+        AND p.status IN ('active'::public.participation_status, 'waitlisted'::public.participation_status)
     )
     -- assigned gedu
     OR EXISTS (
-      SELECT 1 FROM gedu_group_assignments a
+      SELECT 1 FROM public.gedu_group_assignments a
       WHERE a.product_id = p_product_id
         AND a.gedu_id = (SELECT auth.uid())
-    );
+    ),
+    false
+  );
 $$;
 
 
@@ -4424,59 +4426,49 @@ ALTER TABLE ONLY public.whatsapp_messages
 -- Name: customer_profiles Admins can do everything on customer_profiles; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can do everything on customer_profiles" ON public.customer_profiles TO authenticated USING (public.is_admin());
+CREATE POLICY "Admins can do everything on customer_profiles" ON public.customer_profiles TO authenticated USING (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: gamer_profiles Admins can do everything on gamer_profiles; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can do everything on gamer_profiles" ON public.gamer_profiles TO authenticated USING (public.is_admin());
+CREATE POLICY "Admins can do everything on gamer_profiles" ON public.gamer_profiles TO authenticated USING (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: whatsapp_contacts Admins can insert whatsapp_contacts; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can insert whatsapp_contacts" ON public.whatsapp_contacts FOR INSERT TO authenticated WITH CHECK ((EXISTS ( SELECT 1
-   FROM public.profiles
-  WHERE ((profiles.id = auth.uid()) AND (profiles.role = 'admin'::public.user_role)))));
+CREATE POLICY "Admins can insert whatsapp_contacts" ON public.whatsapp_contacts FOR INSERT TO authenticated WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: whatsapp_messages Admins can insert whatsapp_messages; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can insert whatsapp_messages" ON public.whatsapp_messages FOR INSERT TO authenticated WITH CHECK (((EXISTS ( SELECT 1
-   FROM public.profiles
-  WHERE ((profiles.id = auth.uid()) AND (profiles.role = 'admin'::public.user_role)))) AND (direction = 'outbound'::text)));
+CREATE POLICY "Admins can insert whatsapp_messages" ON public.whatsapp_messages FOR INSERT TO authenticated WITH CHECK ((( SELECT public.is_admin() AS is_admin) AND (direction = 'outbound'::text)));
 
 
 --
 -- Name: whatsapp_contacts Admins can read whatsapp_contacts; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can read whatsapp_contacts" ON public.whatsapp_contacts FOR SELECT TO authenticated USING ((EXISTS ( SELECT 1
-   FROM public.profiles
-  WHERE ((profiles.id = auth.uid()) AND (profiles.role = 'admin'::public.user_role)))));
+CREATE POLICY "Admins can read whatsapp_contacts" ON public.whatsapp_contacts FOR SELECT TO authenticated USING (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: whatsapp_messages Admins can read whatsapp_messages; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can read whatsapp_messages" ON public.whatsapp_messages FOR SELECT TO authenticated USING ((EXISTS ( SELECT 1
-   FROM public.profiles
-  WHERE ((profiles.id = auth.uid()) AND (profiles.role = 'admin'::public.user_role)))));
+CREATE POLICY "Admins can read whatsapp_messages" ON public.whatsapp_messages FOR SELECT TO authenticated USING (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: whatsapp_contacts Admins can update whatsapp_contacts; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY "Admins can update whatsapp_contacts" ON public.whatsapp_contacts FOR UPDATE TO authenticated USING ((EXISTS ( SELECT 1
-   FROM public.profiles
-  WHERE ((profiles.id = auth.uid()) AND (profiles.role = 'admin'::public.user_role)))));
+CREATE POLICY "Admins can update whatsapp_contacts" ON public.whatsapp_contacts FOR UPDATE TO authenticated USING (( SELECT public.is_admin() AS is_admin));
 
 
 --
@@ -4511,168 +4503,168 @@ CREATE POLICY "Parents can read linked gamer profiles" ON public.gamer_profiles 
 -- Name: calendar_holidays admin_full_access_calendar_holidays; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_calendar_holidays ON public.calendar_holidays TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_calendar_holidays ON public.calendar_holidays TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: family_subscriptions admin_full_access_family_subscriptions; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_family_subscriptions ON public.family_subscriptions TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_family_subscriptions ON public.family_subscriptions TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: feedback_submissions admin_full_access_feedback; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_feedback ON public.feedback_submissions TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_feedback ON public.feedback_submissions TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: gedu_group_assignments admin_full_access_gedu_assignments; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_gedu_assignments ON public.gedu_group_assignments TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_gedu_assignments ON public.gedu_group_assignments TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: gedu_profiles admin_full_access_gedu_profiles; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_gedu_profiles ON public.gedu_profiles TO authenticated USING (public.is_admin()) WITH CHECK (public.is_admin());
+CREATE POLICY admin_full_access_gedu_profiles ON public.gedu_profiles TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: holiday_calendars admin_full_access_holiday_calendars; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_holiday_calendars ON public.holiday_calendars TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_holiday_calendars ON public.holiday_calendars TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: minecraft_accounts admin_full_access_minecraft_accounts; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_minecraft_accounts ON public.minecraft_accounts TO authenticated USING (public.is_admin()) WITH CHECK (public.is_admin());
+CREATE POLICY admin_full_access_minecraft_accounts ON public.minecraft_accounts TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: parent_gamer admin_full_access_parent_gamer; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_parent_gamer ON public.parent_gamer TO authenticated USING ((public.get_user_role() = 'admin'::public.user_role)) WITH CHECK ((public.get_user_role() = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_parent_gamer ON public.parent_gamer TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: participations admin_full_access_participations; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_participations ON public.participations TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_participations ON public.participations TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: payments admin_full_access_payments; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_payments ON public.payments TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_payments ON public.payments TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: product_groups admin_full_access_product_groups; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_product_groups ON public.product_groups TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_product_groups ON public.product_groups TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: product_holiday_calendars admin_full_access_product_holiday_calendars; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_product_holiday_calendars ON public.product_holiday_calendars TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_product_holiday_calendars ON public.product_holiday_calendars TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: product_prices admin_full_access_product_prices; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_product_prices ON public.product_prices TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_product_prices ON public.product_prices TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: product_subscription_prices admin_full_access_product_subscription_prices; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_product_subscription_prices ON public.product_subscription_prices TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_product_subscription_prices ON public.product_subscription_prices TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: product_translations admin_full_access_product_translations; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_product_translations ON public.product_translations TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_product_translations ON public.product_translations TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: products admin_full_access_products; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_products ON public.products TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_products ON public.products TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: profiles admin_full_access_profiles; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_profiles ON public.profiles TO authenticated USING ((public.get_user_role() = 'admin'::public.user_role)) WITH CHECK ((public.get_user_role() = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_profiles ON public.profiles TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: refunds admin_full_access_refunds; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_refunds ON public.refunds TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_refunds ON public.refunds TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: schedule_slots admin_full_access_schedule_slots; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_schedule_slots ON public.schedule_slots TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_schedule_slots ON public.schedule_slots TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: site_details admin_full_access_site_details; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_site_details ON public.site_details TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_site_details ON public.site_details TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: site_staff_details admin_full_access_site_staff_details; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_full_access_site_staff_details ON public.site_staff_details TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_full_access_site_staff_details ON public.site_staff_details TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: gedu_locations admin_manage_gedu_locations; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_manage_gedu_locations ON public.gedu_locations TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_manage_gedu_locations ON public.gedu_locations TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: locations admin_manage_locations; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_manage_locations ON public.locations TO authenticated USING ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role)) WITH CHECK ((( SELECT public.get_user_role() AS get_user_role) = 'admin'::public.user_role));
+CREATE POLICY admin_manage_locations ON public.locations TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
 -- Name: spoken_languages admin_manage_spoken_languages; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY admin_manage_spoken_languages ON public.spoken_languages TO authenticated USING ((public.get_user_role() = 'admin'::public.user_role)) WITH CHECK ((public.get_user_role() = 'admin'::public.user_role));
+CREATE POLICY admin_manage_spoken_languages ON public.spoken_languages TO authenticated USING (( SELECT public.is_admin() AS is_admin)) WITH CHECK (( SELECT public.is_admin() AS is_admin));
 
 
 --
@@ -4749,18 +4741,14 @@ CREATE POLICY customers_delete_own_links ON public.parent_gamer FOR DELETE TO au
 -- Name: gedu_group_assignments customers_read_assignments_via_gamers; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY customers_read_assignments_via_gamers ON public.gedu_group_assignments FOR SELECT TO authenticated USING (((( SELECT public.get_user_role() AS get_user_role) = 'customer'::public.user_role) AND (product_id IN ( SELECT participations.product_id
-   FROM public.participations
-  WHERE ((participations.customer_id = auth.uid()) AND (participations.status = 'active'::public.participation_status))))));
+CREATE POLICY customers_read_assignments_via_gamers ON public.gedu_group_assignments FOR SELECT TO authenticated USING (((( SELECT public.get_user_role() AS get_user_role) = 'customer'::public.user_role) AND ( SELECT public.has_active_participation_on_product(gedu_group_assignments.product_id) AS has_active_participation_on_product)));
 
 
 --
 -- Name: product_groups customers_read_groups_via_gamers; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY customers_read_groups_via_gamers ON public.product_groups FOR SELECT TO authenticated USING (((( SELECT public.get_user_role() AS get_user_role) = 'customer'::public.user_role) AND (id IN ( SELECT participations.group_id
-   FROM public.participations
-  WHERE ((participations.customer_id = auth.uid()) AND (participations.group_id IS NOT NULL) AND (participations.status = 'active'::public.participation_status))))));
+CREATE POLICY customers_read_groups_via_gamers ON public.product_groups FOR SELECT TO authenticated USING (((( SELECT public.get_user_role() AS get_user_role) = 'customer'::public.user_role) AND ( SELECT public.has_active_participation_in_group(product_groups.id) AS has_active_participation_in_group)));
 
 
 --
@@ -4799,9 +4787,7 @@ CREATE POLICY gamer_select_own_participations ON public.participations FOR SELEC
 -- Name: product_groups gamers_read_own_group; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY gamers_read_own_group ON public.product_groups FOR SELECT TO authenticated USING (((( SELECT public.get_user_role() AS get_user_role) = 'gamer'::public.user_role) AND (id IN ( SELECT participations.group_id
-   FROM public.participations
-  WHERE ((participations.gamer_id = auth.uid()) AND (participations.group_id IS NOT NULL) AND (participations.status = 'active'::public.participation_status))))));
+CREATE POLICY gamers_read_own_group ON public.product_groups FOR SELECT TO authenticated USING (((( SELECT public.get_user_role() AS get_user_role) = 'gamer'::public.user_role) AND ( SELECT public.has_active_participation_in_group(product_groups.id) AS has_active_participation_in_group)));
 
 
 --
@@ -5527,6 +5513,7 @@ GRANT ALL ON FUNCTION public.handle_orphaned_gamer() TO service_role;
 
 REVOKE ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) FROM PUBLIC;
 GRANT ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) TO service_role;
+GRANT ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) TO authenticated;
 
 
 --
@@ -5535,6 +5522,7 @@ GRANT ALL ON FUNCTION public.has_active_participation_in_group(p_group_id uuid) 
 
 REVOKE ALL ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) FROM PUBLIC;
 GRANT ALL ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) TO service_role;
+GRANT ALL ON FUNCTION public.has_active_participation_on_product(p_product_id uuid) TO authenticated;
 
 
 --

--- a/tests/db/authorization-spine.test.ts
+++ b/tests/db/authorization-spine.test.ts
@@ -135,6 +135,14 @@ const SELF_SCOPING: Record<string, { scopeTest: string; why: string }> = {
     scopeTest: "tests/db/exposed-function-scope.test.ts",
     why: "read predicate behind the product policies; anon-reachable on purpose, and its anon branch returns true only for published+visible products",
   },
+  has_active_participation_on_product: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "answers only 'am I a party to an active participation on X', bounded to the caller's uid; consumed by the customer-side assignment policy",
+  },
+  has_active_participation_in_group: {
+    scopeTest: "tests/db/exposed-function-scope.test.ts",
+    why: "the group-level sibling of the above; consumed by the customer- and gamer-side group policies",
+  },
   get_my_gamers: {
     scopeTest: "tests/db/exposed-function-scope.test.ts",
     why: "the caller's own linked gamers",

--- a/tests/db/exposed-function-scope.test.ts
+++ b/tests/db/exposed-function-scope.test.ts
@@ -222,22 +222,77 @@ describe("self-scoping exposed functions", () => {
       });
       expect(asCustomer2.data).toBe(false);
 
-      // anon answers NULL, not false, and that is worth pinning rather than
-      // hiding behind a truthiness check: anon has no profiles row, so
-      // `get_user_role() = 'admin'` is NULL, and `NULL OR false OR false` is
-      // NULL under SQL's three-valued logic. It is not a leak — a policy's
-      // USING clause treats NULL as deny, which is exactly what read_products
-      // relies on, and the read below proves it.
+      // anon answers a real `false`, and that is worth pinning: anon has no
+      // profiles row, so `get_user_role() = 'admin'` is NULL and the whole OR
+      // chain evaluates to NULL under SQL's three-valued logic. Phase 4 wrapped
+      // the chain in COALESCE(…, false) so the predicate is a total boolean.
+      // The deny was never in doubt — a policy's USING clause treats NULL as
+      // deny too, which is what read_products relied on and what the read below
+      // proves — but a predicate that can answer NULL is a trap for the next
+      // consumer, which may not be a USING clause.
       const asAnon = await anon.rpc("can_read_product", {
         p_product_id: PRIVATE_PRODUCT,
       });
-      expect(asAnon.data).toBeNull();
+      expect(asAnon.data).toBe(false);
 
       const visible = await anon
         .from("products")
         .select("id")
         .eq("id", PRIVATE_PRODUCT);
       expect(visible.data).toEqual([]);
+    });
+  });
+
+  /**
+   * The two §3.2 party-to predicates. They unify the customer and gamer columns
+   * into one question — "am I a party to an active participation here" — which
+   * is what makes them reusable across the customer-side and gamer-side
+   * policies that used to inline the subquery separately. So the scoping claim
+   * has two halves: both parties get `true`, and nobody else does.
+   */
+  describe("has_active_participation_on_product", () => {
+    it("is true for both parties to the participation and no one else", async () => {
+      for (const client of [customer, gamer]) {
+        const { data } = await client.rpc("has_active_participation_on_product", {
+          p_product_id: PRIVATE_PRODUCT,
+        });
+        expect(data).toBe(true);
+      }
+
+      // The assigned gedu and the admin are not *parties* — they reach the
+      // product by other routes, which is precisely why this predicate is not
+      // the same question as can_read_product.
+      for (const client of [customer2, gedu, adminAuth]) {
+        const { data } = await client.rpc("has_active_participation_on_product", {
+          p_product_id: PRIVATE_PRODUCT,
+        });
+        expect(data).toBe(false);
+      }
+    });
+
+    it("is false for a product the caller is a party to nothing on", async () => {
+      const { data } = await customer.rpc("has_active_participation_on_product", {
+        p_product_id: PUBLIC_PRODUCT,
+      });
+      expect(data).toBe(false);
+    });
+  });
+
+  describe("has_active_participation_in_group", () => {
+    it("is true for both parties to the participation and no one else", async () => {
+      for (const client of [customer, gamer]) {
+        const { data } = await client.rpc("has_active_participation_in_group", {
+          p_group_id: GROUP_ID,
+        });
+        expect(data).toBe(true);
+      }
+
+      for (const client of [customer2, gedu, adminAuth]) {
+        const { data } = await client.rpc("has_active_participation_in_group", {
+          p_group_id: GROUP_ID,
+        });
+        expect(data).toBe(false);
+      }
     });
   });
 

--- a/tests/db/guard-primitives.test.ts
+++ b/tests/db/guard-primitives.test.ts
@@ -119,8 +119,9 @@ describe("guard primitives", () => {
   describe("ownership predicates", () => {
     it("answer false for a caller with no participation context", async () => {
       // service_role has no auth.uid(), so the predicates can only answer
-      // false. Enough to pin the signature, the grant and the fail-closed
-      // default until Phase 4 wires them into policies with real fixtures.
+      // false. That fail-closed default is what this pins; the fixture-bearing
+      // scope tests (exposed-function-scope.test.ts) cover the true answers now
+      // that three policies compose from them.
       const admin = createAdminTestClient();
 
       const onProduct = await admin.rpc("has_active_participation_on_product", {


### PR DESCRIPTION
Final phase of the DB authorization refactor (`docs/db-authorization-architecture.md` §5 Phase 4). Stacked on `refactor/db-auth-phase3` — review that first.

## What lands

**Every policy's admin half is now one named predicate.** Twenty-eight policies migrate their inline comparison to `(SELECT public.is_admin())`: nineteen `admin_full_access_*`, three `admin_manage_*`, five WhatsApp policies that were still hand-rolling an `EXISTS` over `profiles`, and the four that already called `is_admin()` bare. Three of them carried a bare call and were paying a function call per row; the subquery wrapper makes it an InitPlan evaluated once per statement. `is_admin()`'s body *is* the comparison it replaces, so each swap is a rename — including the NULL answer for a caller with no `profiles` row, which a `USING`/`WITH CHECK` clause denies either way.

**The three policies that inlined the party-to subquery now compose from the §3.2 predicates**, which get their `authenticated` EXECUTE grant (a policy expression is evaluated as the querying role) and their spine classification with fixture-bearing scope tests.

**`can_read_product` becomes a total boolean.** Its admin disjunct is NULL for a roleless caller and `NULL OR false` is NULL, so it answered SQL NULL rather than `false`. Harmless inside a `USING` clause; a trap for a consumer that is not one. `COALESCE(…, false)` closes it, and the scope test flips from pinning the NULL to pinning the `false`.

## Why this is safe to push to staging ahead of the deploy

A migration reaches the shared database immediately; the code running against it does not change until this stack merges. So every rewrite here had to be behaviour-equivalent for staging's *current* traffic:

- The admin migrations are renames of an identical expression.
- The party-to swap can only ever **admit** a row the old form refused, never refuse one it admitted — the predicates check *either* participation column where the policies checked one each. Nothing that reads today stops reading.
- The one row the swap could additionally admit is a caller holding role `customer` who is the `gamer_id` of an active participation (or the reverse). Verified as non-existent on the shared database before writing the migration — zero rows in either direction, all 95 participations correctly roled on both columns. It is also unreachable through the app's own creation paths, and were such a row ever created the effect would be to show a party to a participation the group/assignment row they are themselves party to: the policies' own intent, not a widening of it.

`ALTER POLICY` throughout, so no statement ever observes a table without its policy.

## One finding worth calling out

CI builds its database from migrations alone, which is how this branch surfaced a drift nobody had noticed: the admin full-access policies on `customer_profiles` and `gamer_profiles` exist on the hosted databases but were **never written into a migration**. So the DB suite has been verifying a different RLS surface from the one that runs in production, on exactly the two tables holding the parent PIN hash and a child's date of birth. The migration creates them when absent and alters them when present, so the hosted databases are unaffected and CI now matches them.

The general lesson is in the doc's execution contract: `schema.sql` is a dump of a *hosted* database, so an object created outside a migration lands in it and is invisible to every check we run — all of which build their database from migrations.

## Deliberately not here

- **The voice-token route stays Model A.** The member-scoped prune RPC turns out to need a session-window cutoff, and any cutoff the *caller* supplies lets a confined gamer delete their own current-window occupancy row — which is exactly the "a gamer cannot free themselves" guarantee the write-IDOR loop pins. The full design, the three ways out, and the second blocker (a gedu's cross-group voice mobility has no matching group-read policy) are written up in the doc.
- **The redundant service_role engine signatures** stay until this stack deploys — staging's running code still calls them. Recorded in the doc with the exact revoke steps. Note they cannot be *dropped* as Phase 3 assumed: the guarded entry points call them, so the cleanup is revoking `service_role`'s grant, which leaves them reachable only through their wrappers.
- **The parent-writes-linked-gamer policy** is a feature, not a refactor: shipping it means rewriting the IDOR case that currently pins a parent *out* of their gamer's profile row. Recorded in the doc's new §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
