### PR TITLE
refactor(routes): Phase 1 — posture registry + spine + defineRoute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,12 @@ work under `tests/`). Two things worth knowing from anywhere:
   branch, not locally.
 - **Shared mock factories live in `tests/mocks/`** — add new mocks there rather than
   duplicating across files.
+- **A new API route has to be classified in the integration suite's route posture
+  registry** — its auth posture (with a written reason for anything that is not
+  role-gated), how it takes its body, and the test that exercises it. The registry's
+  completeness checks fail the build otherwise, and they also fail on an undeclared
+  handler method, an unjustified service-role import, and a named test that does not
+  exist or does not reference the route.
 
 ## Code Style
 

--- a/docs/route-boundary-architecture.md
+++ b/docs/route-boundary-architecture.md
@@ -222,15 +222,85 @@ hand-roll silently.
 
 ## 5. Implementation plan
 
-### Phase 1 — registry + spine + primitive
+### Phase 1 — registry + spine + primitive — **LANDED**
 
-Build `defineRoute`, write the registry seeding **reality as-is** (every current
-handler classified with today's posture, warts recorded as warts — including the
-hand-rolled locale auth, the plain-compare webhook challenge, and `test: null` for the
-untested nine), and land the four spine checks green against that honest seed. Convert
-two or three exemplar routes (one role-gated JSON route, one public carve-out, one
-webhook left off-wrapper but classified) to prove the primitive's shape. From this
-phase on, a new route cannot ship unclassified.
+`defineRoute` lives in `src/lib/api/`; the posture registry and the four spine checks
+live together in the route-registry integration test, mirroring the DB spine's
+in-test annotations. The registry seeds reality as-is: all 39 route files and 41
+handlers classified, warts recorded as warts. From this phase on, a new route cannot
+ship unclassified — an unregistered route file, an undeclared handler method, an
+unjustified service-role import and a stale test link each fail CI.
+
+**Registry seed.** 27 role-gated handlers (6 skipping the PIN gate, 2 requiring a
+verified educator, 1 naming all four roles), 1 any-authenticated, 4 public, 2
+session-mutating-public, 1 signed-token, 1 optional-auth, 4 webhook across four
+verifier strategies, 1 api-key. Body discipline: 17 JSON with a schema (7 through a
+feature contract, 10 through a schema declared inline in the route), 7 JSON with no
+schema at all, 2 multipart, 3 raw, 12 with no body. 16 route files justify a
+service-role import; 4 non-route modules are pinned separately. 9 handlers carry no
+test.
+
+**The primitive's shape, as built.** It covers the three postures that authenticate
+through shared code — role-gated, any-authenticated and public — and deliberately
+covers none of the others: a webhook, an api-key or a signed-token route stays
+hand-written, and the spine's static check is what keeps it honest. Two properties
+worth knowing before writing against it:
+
+- **The body is read only when a body schema is declared.** That is the structural
+  guarantee that a raw-body verifier can coexist with the wrapper rather than being
+  quietly broken by it, and it is pinned by a test that asserts an unconsumed stream.
+- **A declared response schema is an allowlist, not just a check.** The payload sent
+  is the schema's parse output, so an undeclared field is dropped rather than
+  delivered; only a genuine shape mismatch becomes a logged 500.
+
+**Exemplars.** One role-gated JSON route moved onto `defineRoute` — its 13 existing
+integration tests pass unchanged, which is the evidence that the wrapper preserves
+behaviour. The public and webhook exemplars are classifications, not conversions:
+they demonstrate the reasoned carve-out shape, which is the other half of the design.
+
+### What Phase 2 inherits
+
+Findings and judgment calls from Phase 1 that the sweep should carry forward:
+
+- **Two error-mapping divergences resolved deliberately in the exemplar**, and the
+  same two questions recur in every conversion. First, an unrecognized database code
+  now becomes a 500 rather than being folded into a 400 — an error nobody anticipated
+  is a server error, and pretending otherwise hides it. Second, a route whose
+  underlying messages are genuinely the user-facing explanation must opt into
+  disclosure explicitly, and the opt-in carries its reason as its value.
+- **Per-route overrides are how a deliberate divergence survives conversion.** The
+  exemplar keeps one code on a non-default status because the client treats that
+  failure as bad input rather than a missing resource. Prefer an override with a
+  written reason over silently normalizing a route's observable behaviour.
+- **`no-data-found` is the code most likely to need a per-route decision** — some
+  routes mean "you asked for something that isn't there" (404), others mean "your
+  input names something that doesn't exist" (400). Decide it per route, not globally.
+- **The taxonomy needed no new posture**, but two entries needed a note rather than a
+  category: the all-four-roles route is recorded as role-gated rather than
+  any-authenticated because that is what the code does (it loads the profile and
+  applies the PIN gate along the way), and the two webhook handlers in one file carry
+  different verifier strategies, which is why verifier is a per-handler field.
+- **Body discipline needed a "declared but unschema'd" state.** Seven handlers parse
+  JSON with hand-rolled checks or none; recording them as JSON-with-no-schema keeps
+  them countable, and zero of them is a Phase 2 exit condition alongside zero
+  untested handlers.
+- **The recorded off-primitive exception expires by itself.** The spine fails if a
+  file carrying that exception later gains the shared gate, so converting the
+  hand-rolled session route forces the exception's removal in the same change.
+- **The architecture still has no permanent home.** Phase 1 put the tripwire in the
+  root and the registry conventions with the test suite, and deliberately left the
+  route shape here rather than duplicating a mid-flight design into a colocated doc.
+  When the sweep finishes, decide that home — the primitive and the routes live in
+  different directories, so the doc that a route author auto-loads is not the one
+  beside the primitive.
+
+**Snapshot corrections found while re-verifying §2.** The surface, the posture counts
+and the service-role import set were all exact. Coverage was not: "26 of 39 route
+files" counts the integration *test files*, not the routes they cover. The real
+figures are 31 of 39 files covered, with 8 files plus one handler in a ninth
+untested — which is what §2's untested list already named, so only the ratio was
+wrong. The WhatsApp webhook is covered by a test that imports it dynamically, so any
+linkage check has to match both the static and the dynamic import form.
 
 ### Phase 2 — the sweep
 

--- a/src/app/api/participations/waitlist/route.ts
+++ b/src/app/api/participations/waitlist/route.ts
@@ -1,6 +1,5 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import {
   joinWaitlistBody,
   joinWaitlistRpcResult,
@@ -15,46 +14,46 @@ import {
  * else, and the RPC's own guard refuses a non-customer even if this route's
  * role check were bypassed.
  */
-export async function POST(request: Request) {
-  const result = await requireRole("customer", {
-    forbiddenMessage: "Only customers can join a waitlist",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  forbiddenMessage: "Only customers can join a waitlist",
+  body: joinWaitlistBody,
 
-  const body = await parseJsonBody(request, joinWaitlistBody);
-  if (body instanceof NextResponse) return body;
-  const { productId, gamerId } = body;
+  // The RPC raises the canonical forbidden code when the caller is not a
+  // customer, and a check violation for a request the customer may make but
+  // that this data refuses (waitlist disabled, not the gamer's parent) — both
+  // already land on the shared table. `no_data_found` is the exception: the
+  // RPC raises it for a product that does not exist, which the client treats
+  // as bad input rather than a missing endpoint, so it stays a 400 here.
+  errorStatus: { P0002: 400 },
 
-  const { data, error } = await supabase.rpc("join_product_waitlist", {
-    p_product_id: productId,
-    p_gamer_id: gamerId,
-  });
+  // The RPC's messages are written for the parent to read — "waitlist is not
+  // enabled for this product", "product … does not exist" — and the UI shows
+  // them verbatim. They name no row the caller was not already holding.
+  discloseErrorMessages:
+    "the guarded RPC's messages are the user-facing explanation of a refused join",
 
-  if (error) {
-    // The RPC raises the canonical forbidden code when the caller is not a
-    // customer; everything else it raises (missing product, not the gamer's
-    // parent, waitlist disabled) is a request the customer may make but that
-    // this data refuses.
-    const status = error.code === "42501" ? 403 : 400;
-    return NextResponse.json({ error: error.message }, { status });
-  }
+  handler: async ({ supabase, body }) => {
+    const { data, error } = await supabase.rpc("join_product_waitlist", {
+      p_product_id: body.productId,
+      p_gamer_id: body.gamerId,
+    });
 
-  const parsed = joinWaitlistRpcResult.safeParse(data);
-  if (!parsed.success) {
-    console.error(
-      "join_product_waitlist returned an unexpected shape:",
-      parsed.error.message,
-    );
-    return NextResponse.json(
-      { error: "Failed to join waitlist" },
-      { status: 500 },
-    );
-  }
+    if (error) throw error;
 
-  return NextResponse.json({
-    participationId: parsed.data.participation_id,
-    waitlistPosition: parsed.data.waitlist_position,
-    status: parsed.data.status,
-  });
-}
+    const parsed = joinWaitlistRpcResult.safeParse(data);
+    if (!parsed.success) {
+      throw new ApiError(
+        `join_product_waitlist returned an unexpected shape: ${parsed.error.message}`,
+        500,
+      );
+    }
+
+    return {
+      participationId: parsed.data.participation_id,
+      waitlistPosition: parsed.data.waitlist_position,
+      status: parsed.data.status,
+    };
+  },
+});

--- a/src/lib/api/define-route.ts
+++ b/src/lib/api/define-route.ts
@@ -1,0 +1,479 @@
+import { NextResponse } from "next/server";
+import type { z } from "zod";
+import { requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { ApiError } from "@/lib/api/api-error";
+import { parseBodyValue, parseJsonBody } from "@/lib/api/json-body.server";
+import type { AuthenticatedUser, Profile, UserRole } from "@/types";
+
+/**
+ * `defineRoute` — the HTTP route boundary primitive.
+ *
+ * See docs/route-boundary-architecture.md. It composes the existing boundary
+ * primitives (the role gate, the contract-schema body parse, the ApiError
+ * carrier) into one declaration so the conforming route is the shortest route
+ * to write: declare the posture and the schemas, receive an already-narrowed
+ * and already-validated context, return data.
+ *
+ * What it owns, and why each part is centralized here rather than per route:
+ *
+ *  - **Auth**, from the declared posture. A route cannot accidentally omit its
+ *    gate, because the gate is a required field of the declaration.
+ *  - **Parsing slots** for body, query and dynamic params. The body is read
+ *    ONLY when a body schema is declared — a posture whose verifier needs the
+ *    untouched raw text (any webhook) must not be wrapped, and this wrapper
+ *    gives it no way to be consumed behind the handler's back.
+ *  - **One error-code → HTTP status table**, overridable per route, so the same
+ *    database error cannot mean 403 in one route and 500 in the next.
+ *  - **One message-disclosure point.** By default the client gets a generic
+ *    message for the status and the real one goes to the log. Forwarding the
+ *    underlying message is a per-route opt-in that must carry its reason.
+ *  - **An optional response schema**, validated on the way out (mismatch is a
+ *    logged 500, never a malformed payload delivered to a client).
+ *  - **A non-JSON escape hatch**: a handler that returns a `Response` has it
+ *    passed through untouched — redirects, 204s and raw text stay possible.
+ *
+ * Postures the wrapper does NOT cover — webhook, api-key, signed-token and
+ * optional-auth — are hand-written by design. They still must be classified in
+ * the route posture registry, which is what keeps them honest.
+ */
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * The default PostgreSQL / PostgREST error-code → HTTP status table. A route
+ * that needs a different answer for one code overrides just that code; it does
+ * not re-implement the table.
+ */
+const DEFAULT_ERROR_STATUS: Readonly<Partial<Record<string, number>>> = {
+  // insufficient_privilege — a guard or an RLS policy refused the caller.
+  "42501": 403,
+  // unique_violation — the row already exists.
+  "23505": 409,
+  // no_data_found (raised by our guarded RPCs) and PostgREST's zero-row result.
+  P0002: 404,
+  PGRST116: 404,
+  // foreign_key_violation / check_violation — the request itself is invalid.
+  "23503": 400,
+  "23514": 400,
+  // assert_failure — an invariant the database expected to hold did not. Never
+  // the caller's fault, so it is a logged server error.
+  P0004: 500,
+};
+
+/**
+ * What the client is told when the route has not opted into disclosure. Keyed
+ * by status so the message never depends on the underlying failure.
+ */
+const GENERIC_ERROR_MESSAGE: Readonly<Partial<Record<number, string>>> = {
+  400: "Invalid request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not found",
+  409: "Conflict",
+};
+
+const FALLBACK_ERROR_MESSAGE = "Internal server error";
+
+function genericMessageFor(status: number): string {
+  return GENERIC_ERROR_MESSAGE[status] ?? FALLBACK_ERROR_MESSAGE;
+}
+
+/** Read a string `code` off an unknown thrown value without asserting a type. */
+function errorCodeOf(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || !("code" in value)) {
+    return null;
+  }
+  return typeof value.code === "string" ? value.code : null;
+}
+
+/** Read a string `message` off an unknown thrown value. */
+function errorMessageOf(value: unknown): string | null {
+  if (value instanceof Error) return value.message;
+  if (typeof value !== "object" || value === null || !("message" in value)) {
+    return null;
+  }
+  return typeof value.message === "string" ? value.message : null;
+}
+
+// ---------------------------------------------------------------------------
+// Posture declarations
+// ---------------------------------------------------------------------------
+
+/** The Supabase client the gate hands back, bound to the calling user. */
+type UserBoundClient = Awaited<ReturnType<typeof createClient>>;
+
+/** A profile whose `role` is narrowed to the roles the posture allows. */
+type NarrowedProfile<R extends UserRole> = Omit<Profile, "role"> & { role: R };
+
+interface RoleGatedPosture<R extends UserRole> {
+  posture: "role-gated";
+  /** Roles allowed past the gate. Narrows `profile.role` at the type level. */
+  roles: R | readonly R[];
+  /** Message returned with the 403. Defaults to a bare "Forbidden". */
+  forbiddenMessage?: string;
+  /** Skip the parent-PIN gate — for routes a locked customer must reach. */
+  allowUnverified?: boolean;
+  /** Refuse an unverified gedu — for gedu actions that are a trust boundary. */
+  requireVerifiedGedu?: boolean;
+}
+
+interface AnyAuthenticatedPosture {
+  posture: "any-authenticated";
+  /**
+   * Why role is irrelevant here. Any signed-in caller is allowed, so the usual
+   * "which roles" question has no answer and the intent has to be written down.
+   */
+  reason: string;
+}
+
+interface PublicPosture {
+  posture: "public";
+  /** Why this route is reachable with no session at all. Mandatory. */
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler context
+// ---------------------------------------------------------------------------
+
+interface ParsedInput<TBody, TQuery, TParams> {
+  /** The raw request. Present for header reads and origin resolution. */
+  request: Request;
+  /** The validated JSON body, or `undefined` when no body schema is declared. */
+  body: TBody;
+  /** The validated query string, or `undefined` when no query schema is declared. */
+  query: TQuery;
+  /** The validated dynamic route params, or `undefined` when none is declared. */
+  params: TParams;
+}
+
+type RoleGatedContext<R extends UserRole, TBody, TQuery, TParams> = ParsedInput<
+  TBody,
+  TQuery,
+  TParams
+> & {
+  user: AuthenticatedUser;
+  profile: NarrowedProfile<R>;
+  supabase: UserBoundClient;
+};
+
+type AnyAuthenticatedContext<TBody, TQuery, TParams> = ParsedInput<
+  TBody,
+  TQuery,
+  TParams
+> & {
+  user: AuthenticatedUser;
+  supabase: UserBoundClient;
+};
+
+type PublicContext<TBody, TQuery, TParams> = ParsedInput<TBody, TQuery, TParams>;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * What a handler may return: a value the wrapper serializes as JSON, a
+ * `Response` it passes through untouched, or `undefined` for a 204.
+ */
+type HandlerResult<TResult> =
+  | TResult
+  | Response
+  | undefined
+  | Promise<TResult | Response | undefined>;
+
+interface SharedRouteConfig<TBody, TQuery, TParams, TResult> {
+  /**
+   * Schema for the JSON request body. Declaring it is the ONLY thing that makes
+   * the wrapper read the body — omit it and the request stream is untouched.
+   */
+  body?: z.ZodType<TBody>;
+  /** Schema for the query string, read as a flat string record. */
+  query?: z.ZodType<TQuery>;
+  /** Schema for the dynamic route params (Next.js's second handler argument). */
+  params?: z.ZodType<TParams>;
+  /** Schema the outgoing payload is validated against. Mismatch is a 500. */
+  response?: z.ZodType<TResult>;
+  /**
+   * Per-route deviations from the default error-code table. Only the codes
+   * listed here differ; everything else keeps the shared answer.
+   */
+  errorStatus?: Readonly<Partial<Record<string, number>>>;
+  /**
+   * Opt in to forwarding the underlying error message to the client, with the
+   * reason as the value. Without this the client gets a generic message for
+   * the status and the real one is logged — which is the default because an
+   * underlying message can name rows, columns and identifiers the caller was
+   * never shown.
+   */
+  discloseErrorMessages?: string;
+}
+
+type RouteConfig<
+  R extends UserRole,
+  TBody,
+  TQuery,
+  TParams,
+  TResult,
+> =
+  | (SharedRouteConfig<TBody, TQuery, TParams, TResult> &
+      RoleGatedPosture<R> & {
+        handler: (
+          context: RoleGatedContext<R, TBody, TQuery, TParams>,
+        ) => HandlerResult<TResult>;
+      })
+  | (SharedRouteConfig<TBody, TQuery, TParams, TResult> &
+      AnyAuthenticatedPosture & {
+        handler: (
+          context: AnyAuthenticatedContext<TBody, TQuery, TParams>,
+        ) => HandlerResult<TResult>;
+      })
+  | (SharedRouteConfig<TBody, TQuery, TParams, TResult> &
+      PublicPosture & {
+        handler: (
+          context: PublicContext<TBody, TQuery, TParams>,
+        ) => HandlerResult<TResult>;
+      });
+
+/**
+ * Next.js hands dynamic route handlers a second argument carrying the params
+ * promise. It is optional here so integration tests can call a handler for a
+ * static route with the request alone.
+ */
+interface RouteContextArgument {
+  params: Promise<unknown>;
+}
+
+export type DefinedRouteHandler = (
+  request: Request,
+  context?: RouteContextArgument,
+) => Promise<Response>;
+
+// ---------------------------------------------------------------------------
+// The wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * The internal view of a config, with the per-route generics erased. The public
+ * overload above is what route authors see; this is what the single engine
+ * below operates on. `handler` is declared with method syntax deliberately —
+ * the erased context has to accept every concrete context shape.
+ */
+interface ErasedRouteConfig {
+  posture: "role-gated" | "any-authenticated" | "public";
+  roles?: UserRole | readonly UserRole[];
+  forbiddenMessage?: string;
+  allowUnverified?: boolean;
+  requireVerifiedGedu?: boolean;
+  reason?: string;
+  body?: z.ZodType<unknown>;
+  query?: z.ZodType<unknown>;
+  params?: z.ZodType<unknown>;
+  response?: z.ZodType<unknown>;
+  errorStatus?: Readonly<Partial<Record<string, number>>>;
+  discloseErrorMessages?: string;
+  handler(context: {
+    request: Request;
+    body: unknown;
+    query: unknown;
+    params: unknown;
+    // Optional because a public route has none. The typed overload is what
+    // decides whether a given handler may read them.
+    user?: AuthenticatedUser;
+    profile?: Profile;
+    supabase?: UserBoundClient;
+  }): unknown;
+}
+
+export function defineRoute<
+  const R extends UserRole,
+  TBody = undefined,
+  TQuery = undefined,
+  TParams = undefined,
+  TResult = unknown,
+>(config: RouteConfig<R, TBody, TQuery, TParams, TResult>): DefinedRouteHandler;
+export function defineRoute(config: ErasedRouteConfig): DefinedRouteHandler {
+  return async (request, context) => {
+    try {
+      return await runRoute(config, request, context);
+    } catch (error) {
+      return toErrorResponse(error, config, request);
+    }
+  };
+}
+
+async function runRoute(
+  config: ErasedRouteConfig,
+  request: Request,
+  context: RouteContextArgument | undefined,
+): Promise<Response> {
+  // --- Auth, from the declared posture -------------------------------------
+  //
+  // Runs before any parsing so an unauthorized caller is refused without the
+  // route revealing which inputs it would have accepted.
+  let identity: {
+    user: AuthenticatedUser;
+    profile?: Profile;
+    supabase: UserBoundClient;
+  } | null = null;
+
+  if (config.posture === "role-gated") {
+    const gate = await requireRole(config.roles ?? [], {
+      forbiddenMessage: config.forbiddenMessage,
+      allowUnverified: config.allowUnverified,
+      requireVerifiedGedu: config.requireVerifiedGedu,
+    });
+    if (gate instanceof NextResponse) return gate;
+    identity = gate;
+  } else if (config.posture === "any-authenticated") {
+    const session = await requireSession();
+    if (session instanceof NextResponse) return session;
+    identity = session;
+  }
+
+  // --- Parsing slots -------------------------------------------------------
+  const parsed = await parseInputs(config, request, context);
+  if (parsed instanceof NextResponse) return parsed;
+
+  // --- The handler ---------------------------------------------------------
+  //
+  // A public route has no identity; the erased context declares the auth
+  // fields, and the typed overload is what stops a public handler from
+  // reading them.
+  const result = await config.handler({
+    request,
+    body: parsed.body,
+    query: parsed.query,
+    params: parsed.params,
+    ...identity,
+  });
+
+  // --- Response ------------------------------------------------------------
+  //
+  // The escape hatch: anything the handler already shaped as a Response —
+  // a redirect, a 204, raw text — is delivered untouched.
+  if (result instanceof Response) return result;
+  if (result === undefined) return new NextResponse(null, { status: 204 });
+
+  if (config.response) {
+    const validated = config.response.safeParse(result);
+    if (!validated.success) {
+      console.error(
+        `[${routeLabel(request)}] response failed its schema:`,
+        validated.error.message,
+      );
+      return NextResponse.json(
+        { error: FALLBACK_ERROR_MESSAGE },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json(validated.data);
+  }
+
+  return NextResponse.json(result);
+}
+
+/**
+ * The any-authenticated gate: verify the session and hand back the caller's id
+ * and their user-bound client. Deliberately does NOT load the profile — a
+ * route that needs a role is role-gated, not any-authenticated.
+ */
+async function requireSession(): Promise<
+  { user: AuthenticatedUser; supabase: UserBoundClient } | NextResponse
+> {
+  const supabase = await createClient();
+  // Verifies the JWT locally against the project's JWKS — no auth round-trip,
+  // and no profile read, because a route that needs a role is role-gated.
+  const { data, error } = await supabase.auth.getClaims();
+  const claims = data?.claims;
+  if (error || !claims?.sub) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return { user: { id: claims.sub, email: claims.email }, supabase };
+}
+
+async function parseInputs(
+  config: ErasedRouteConfig,
+  request: Request,
+  context: RouteContextArgument | undefined,
+): Promise<
+  { body: unknown; query: unknown; params: unknown } | NextResponse
+> {
+  let params: unknown;
+  if (config.params) {
+    const raw = context ? await context.params : undefined;
+    const validated = parseBodyValue(raw, config.params);
+    if (validated instanceof NextResponse) return validated;
+    params = validated;
+  }
+
+  let query: unknown;
+  if (config.query) {
+    // Flat string record. A repeated key collapses to its last value; a route
+    // that needs list-valued query params declares a Response-returning handler
+    // and reads the URL itself.
+    const search = new URL(request.url).searchParams;
+    const validated = parseBodyValue(
+      Object.fromEntries(search.entries()),
+      config.query,
+    );
+    if (validated instanceof NextResponse) return validated;
+    query = validated;
+  }
+
+  let body: unknown;
+  if (config.body) {
+    const validated = await parseJsonBody(request, config.body);
+    if (validated instanceof NextResponse) return validated;
+    body = validated;
+  }
+
+  return { body, query, params };
+}
+
+/** The single point where a failure becomes a status and a client message. */
+function toErrorResponse(
+  error: unknown,
+  config: ErasedRouteConfig,
+  request: Request,
+): Response {
+  // A handler may throw a ready Response to short-circuit; honour it.
+  if (error instanceof Response) return error;
+
+  const label = routeLabel(request);
+  const disclose = config.discloseErrorMessages !== undefined;
+
+  if (error instanceof ApiError) {
+    console.error(`[${label}] ${error.message}`);
+    const message = disclose ? error.message : genericMessageFor(error.status);
+    return NextResponse.json(
+      error.code ? { error: message, code: error.code } : { error: message },
+      { status: error.status },
+    );
+  }
+
+  const code = errorCodeOf(error);
+  if (code !== null) {
+    const status =
+      config.errorStatus?.[code] ?? DEFAULT_ERROR_STATUS[code] ?? 500;
+    console.error(`[${label}] ${code}:`, errorMessageOf(error) ?? error);
+    const message = disclose
+      ? (errorMessageOf(error) ?? genericMessageFor(status))
+      : genericMessageFor(status);
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  console.error(`[${label}] unhandled failure:`, error);
+  return NextResponse.json({ error: FALLBACK_ERROR_MESSAGE }, { status: 500 });
+}
+
+function routeLabel(request: Request): string {
+  try {
+    return new URL(request.url).pathname;
+  } catch {
+    return "route";
+  }
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -65,6 +65,27 @@ or a `NextResponse` error for unauthorized. Mock Supabase clients
 import Next.js's `server-only` marker work because `vitest.config.mts` aliases it to a
 stub in `tests/mocks/server-only.ts`.
 
+A route that goes through `defineRoute` still runs the same role gate underneath, so
+the same `requireRole` mock drives it and an existing test needs no rewrite. The per-
+route bar is unchanged: unauthenticated, wrong role, bad input, happy path.
+
+### The route posture registry
+
+The integration suite carries a registry classifying every API route handler — auth
+posture, body discipline, and the test that exercises it — beside the four checks that
+consume it. **Adding an API route means adding its registry entry in the same change**,
+or the build fails. Three things about maintaining it:
+
+- **A posture that is not role-gated needs a written reason.** Reasons are the whole
+  point: a deliberately public route and a route missing its gate look identical
+  without one. Write the sentence you would want to read in a security review.
+- **Warts are recorded, not excused.** A route standing off the shared primitive, a
+  handler with no test, a body parsed without a schema — each has a slot in the
+  registry. Recording one keeps it countable; hiding it is how it survives.
+- **A recorded exception expires on its own.** The checks fail when a file that claims
+  to stand off the primitive starts using it, so fixing the code forces the annotation
+  to be deleted in the same change instead of rotting into a rubber stamp.
+
 ## Unit test setup
 
 `tests/setup.ts` (the jsdom config's setup file) globally mocks `next/navigation` and the

--- a/tests/integration/api-route-registry.test.ts
+++ b/tests/integration/api-route-registry.test.ts
@@ -1,0 +1,1043 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import type { UserRole } from "@/types";
+
+/**
+ * The route verification spine — docs/route-boundary-architecture.md §3.3.
+ *
+ * The HTTP route boundary has the same shape of problem the database
+ * authorization layer had: the right way to write a route exists and is mostly
+ * followed, but a deviation fails no automated check. Nothing distinguishes a
+ * deliberately public route from a route whose author forgot the gate.
+ *
+ * The fix is the same shape too. Every handler on the surface carries exactly
+ * one machine-readable classification in the registry below, and four checks
+ * keep that registry honest:
+ *
+ *   1. Completeness — the route files on disk and the registry agree in both
+ *      directions, and each file's declared handlers are the methods it really
+ *      exports. A new unclassified route fails CI.
+ *   2. Static conformance — a handler that authenticates its caller must
+ *      contain the boundary primitive. A file containing neither the primitive
+ *      nor the role gate has to be a reasoned carve-out.
+ *   3. Admin-client pinning — the set of files reaching for the service-role
+ *      client equals the set that justified it. A new import site without a
+ *      written justification fails CI.
+ *   4. Test linkage — every classified handler names an integration test, and
+ *      that test really exists and really exercises the route.
+ *
+ * They interlock: 1 forces a classification to exist, 2 and 3 force the
+ * classification to match what the file actually does, 4 forces something to be
+ * verifying the behaviour. Allowlist growth is the failure mode of every
+ * allowlist design, and check 1 is what polices it — so the registry is
+ * deliberately verbose, and every carve-out costs its author a sentence.
+ *
+ * The registry seeds REALITY AS IT IS, warts included: the route that hand-rolls
+ * its session check instead of using the shared gate, the webhook challenge that
+ * compares its secret with a plain `===`, and the handlers with no integration
+ * test at all are all recorded as what they are rather than quietly excused.
+ * Recording a wart is what makes it a tracked item instead of an invisible one.
+ */
+
+// ---------------------------------------------------------------------------
+// Classification vocabulary
+// ---------------------------------------------------------------------------
+
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+
+const METHODS: readonly Method[] = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+];
+
+/**
+ * The auth posture taxonomy. It is exhaustive over the current surface by
+ * construction — a route that fits none of these is the first finding, not a
+ * reason to widen a case silently.
+ *
+ * Every posture except `role-gated` carries a mandatory `reason`: role-gated is
+ * the default and needs no defence, and everything else is a decision someone
+ * made that the next reader deserves to see.
+ */
+type Posture =
+  /** The shared role gate: a named set of roles, plus its two extra gates. */
+  | {
+      kind: "role-gated";
+      roles: readonly UserRole[];
+      /** Skips the parent-PIN gate, for routes a locked customer must reach. */
+      allowUnverified?: true;
+      /** Refuses an unverified educator, for gedu actions that are a boundary. */
+      requireVerifiedGedu?: true;
+    }
+  /** Any signed-in caller, no role check. */
+  | { kind: "any-authenticated"; reason: string }
+  /** Reachable with no session at all. */
+  | { kind: "public"; reason: string }
+  /** Public, and its whole purpose is to change the session cookies. */
+  | { kind: "session-mutating-public"; reason: string }
+  /** A signed token in the request IS the authorization; session-agnostic. */
+  | { kind: "signed-token"; reason: string }
+  /** Public, but silently elevates a recognized caller. Must fail closed. */
+  | { kind: "optional-auth"; reason: string }
+  /** A third party's signature over the raw body is the authorization. */
+  | { kind: "webhook"; verifier: WebhookVerifier; reason: string }
+  /** Server-to-server, authorized by a shared secret rather than a session. */
+  | { kind: "api-key"; reason: string };
+
+/**
+ * Webhook verifier strategies, recorded per handler because their error
+ * contracts diverge and the divergence is load-bearing: Stripe wants a 5xx so
+ * it retries, and Meta disables an endpoint that answers 5xx persistently.
+ */
+type WebhookVerifier =
+  | "stripe-signature"
+  | "meta-hmac-sha256"
+  | "meta-challenge-plain-compare"
+  | "discord-ed25519";
+
+/**
+ * How the handler takes its request payload. `schema: null` on a `json` entry
+ * records a body parsed without a schema — a hand-rolled shape check, or none
+ * at all. Those are the sweep's targets; recording them is how they stay
+ * countable.
+ */
+type BodyDiscipline =
+  | { kind: "json"; schema: string | null }
+  | { kind: "multipart"; schema: string }
+  | { kind: "raw"; reason: string }
+  | { kind: "none" };
+
+interface HandlerEntry {
+  posture: Posture;
+  body: BodyDiscipline;
+  /**
+   * The integration test that exercises this handler, repo-relative. `null`
+   * records a handler with no test at all — allowed only while the registry is
+   * seeding reality; the sweep ends with none left.
+   */
+  test: string | null;
+}
+
+interface RouteEntry {
+  handlers: Partial<Record<Method, HandlerEntry>>;
+  /**
+   * Why this file may construct the service-role client. Seeded from the
+   * database-authorization refactor's triage, which classified every module
+   * that used that client with a one-clause justification.
+   */
+  adminClient?: string;
+  /**
+   * Why this file contains neither the boundary primitive nor the shared role
+   * gate despite authenticating its caller. A recorded exception, not a
+   * permanent allowance — check 2 fails if the file later gains the primitive
+   * and the exception is left behind.
+   */
+  offPrimitive?: string;
+}
+
+// ---------------------------------------------------------------------------
+// The registry
+// ---------------------------------------------------------------------------
+
+const API_DIR = join("src", "app", "api");
+
+const TESTS = {
+  adminLocations: "tests/integration/api/admin-locations.test.ts",
+  callback: "tests/integration/auth/callback.test.ts",
+  checkout: "tests/integration/api/checkout-products-create.test.ts",
+  feedback: "tests/integration/api/feedback.test.ts",
+  forgotPassword: "tests/integration/auth/forgot-password.test.ts",
+  gamersCreate: "tests/integration/api/gamers-create.test.ts",
+  gamersUpdate: "tests/integration/api/gamers-update.test.ts",
+  minecraftAccount: "tests/integration/api/minecraft-account.test.ts",
+  minecraftJoinCheck: "tests/integration/api/minecraft-join-check.test.ts",
+  minecraftVerify: "tests/integration/api/minecraft-verify.test.ts",
+  pin: "tests/integration/auth/pin.test.ts",
+  productsCreate: "tests/integration/api/products-create.test.ts",
+  productsGroupsApply: "tests/integration/api/products-groups-apply.test.ts",
+  productsParticipations: "tests/integration/api/products-participations.test.ts",
+  productsParticipationsDelete:
+    "tests/integration/api/products-participations-delete.test.ts",
+  sendTestEmail: "tests/integration/api/send-test-email.test.ts",
+  stripeWebhook: "tests/integration/api/stripe-webhook-products.test.ts",
+  switchAccount: "tests/integration/auth/switch-account.test.ts",
+  userLocale: "tests/integration/api/user-locale.test.ts",
+  voiceInstantCreate: "tests/integration/api/voice-instant-create.test.ts",
+  voiceInstantEnd: "tests/integration/api/voice-instant-end.test.ts",
+  voiceInstantToken: "tests/integration/api/voice-instant-token.test.ts",
+  voiceToken: "tests/integration/api/voice-token.test.ts",
+  waitlist: "tests/integration/api/participations-waitlist.test.ts",
+  whatsappSend: "tests/integration/api/whatsapp-send.test.ts",
+  whatsappWebhook: "tests/integration/api/whatsapp-webhook.test.ts",
+} as const;
+
+const ADMIN_ONLY: Posture = { kind: "role-gated", roles: ["admin"] };
+
+const ROUTE_REGISTRY: Record<string, RouteEntry> = {
+  // --- Admin surfaces ------------------------------------------------------
+
+  "src/app/api/admin/locations/[id]/route.ts": {
+    handlers: {
+      PATCH: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "updateLocationBody" },
+        test: TESTS.adminLocations,
+      },
+    },
+  },
+
+  "src/app/api/admin/locations/create/route.ts": {
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "createLocationBody" },
+        test: TESTS.adminLocations,
+      },
+    },
+  },
+
+  "src/app/api/admin/products/[id]/groups/apply/route.ts": {
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "groupChangeSet" },
+        test: TESTS.productsGroupsApply,
+      },
+    },
+  },
+
+  "src/app/api/admin/products/[id]/participations/[participationId]/route.ts": {
+    handlers: {
+      DELETE: {
+        posture: ADMIN_ONLY,
+        body: { kind: "none" },
+        test: TESTS.productsParticipationsDelete,
+      },
+      PATCH: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "waitlistTransitionBody" },
+        // The one untested handler in an otherwise-tested file — the shape the
+        // per-file view of coverage hides, and the reason check 4 is per
+        // handler rather than per file.
+        test: null,
+      },
+    },
+  },
+
+  "src/app/api/admin/products/[id]/participations/route.ts": {
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "inline: { gamerId }" },
+        test: TESTS.productsParticipations,
+      },
+    },
+  },
+
+  "src/app/api/admin/products/[id]/update/route.ts": {
+    adminClient:
+      "privileged-bucket storage writes only (image upload plus deletes of superseded images); the data writes run on the user client",
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "multipart", schema: "updateProductData" },
+        test: null,
+      },
+    },
+  },
+
+  "src/app/api/admin/products/create/route.ts": {
+    adminClient:
+      "privileged-bucket storage upload only; the data writes run on the user client",
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "multipart", schema: "createProductData" },
+        test: TESTS.productsCreate,
+      },
+    },
+  },
+
+  "src/app/api/admin/send-test-email/route.ts": {
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "inline: requestSchema" },
+        test: TESTS.sendTestEmail,
+      },
+    },
+  },
+
+  "src/app/api/admin/site-notes/route.ts": {
+    handlers: {
+      PATCH: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "updateSiteNotesBody" },
+        test: null,
+      },
+    },
+  },
+
+  "src/app/api/admin/whatsapp/send/route.ts": {
+    handlers: {
+      POST: {
+        posture: ADMIN_ONLY,
+        body: { kind: "json", schema: "inline: requestSchema" },
+        test: TESTS.whatsappSend,
+      },
+    },
+  },
+
+  // --- Auth ----------------------------------------------------------------
+
+  "src/app/api/auth/callback/route.ts": {
+    handlers: {
+      GET: {
+        posture: {
+          kind: "session-mutating-public",
+          reason:
+            "the OAuth redirect target: it exchanges the provider's code for a session, so it must be reachable before one exists. Returns only redirects, and its caller-supplied `next` is resolved to an internal path before use",
+        },
+        body: { kind: "none" },
+        test: TESTS.callback,
+      },
+    },
+  },
+
+  "src/app/api/auth/forgot-password/route.ts": {
+    adminClient: "Auth Admin API (recovery link generation)",
+    handlers: {
+      POST: {
+        posture: {
+          kind: "public",
+          reason:
+            "a password reset is requested by someone who cannot sign in. Always answers 200 regardless of whether the address exists, which is the enumeration defence",
+        },
+        body: { kind: "json", schema: "inline: requestSchema" },
+        test: TESTS.forgotPassword,
+      },
+    },
+  },
+
+  "src/app/api/auth/pin/forgot/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["customer"],
+          allowUnverified: true,
+        },
+        body: { kind: "none" },
+        test: TESTS.pin,
+      },
+    },
+  },
+
+  "src/app/api/auth/pin/reset/route.ts": {
+    adminClient:
+      "resolves its user from a signed token rather than a session, so there is no caller to act as",
+    handlers: {
+      POST: {
+        posture: {
+          kind: "signed-token",
+          reason:
+            "completes a PIN reset from an emailed link. The signed, single-use token delivered to the parent's inbox IS the authorization; a session cannot be required because the parent is locked out of the one they have",
+        },
+        body: { kind: "json", schema: "inline: { token, pin }" },
+        test: TESTS.pin,
+      },
+    },
+  },
+
+  "src/app/api/auth/pin/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["customer"],
+          allowUnverified: true,
+        },
+        body: { kind: "json", schema: "inline: { pin, currentPin? }" },
+        test: TESTS.pin,
+      },
+    },
+  },
+
+  "src/app/api/auth/pin/status/route.ts": {
+    handlers: {
+      GET: {
+        posture: {
+          kind: "role-gated",
+          roles: ["customer"],
+          allowUnverified: true,
+        },
+        body: { kind: "none" },
+        test: TESTS.pin,
+      },
+    },
+  },
+
+  "src/app/api/auth/pin/verify/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["customer"],
+          allowUnverified: true,
+        },
+        body: { kind: "json", schema: "inline: { pin }" },
+        test: TESTS.pin,
+      },
+    },
+  },
+
+  "src/app/api/auth/signout/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "session-mutating-public",
+          reason:
+            "clearing a session must work even when the session is already unusable, so requiring a valid one would strand exactly the callers who need it. POST-only is the CSRF control: a cross-origin top-level POST carries no SameSite=Lax cookie, so a hostile page cannot force a sign-out. Answers a 303 the browser follows as a full-page GET",
+        },
+        body: { kind: "none" },
+        test: null,
+      },
+    },
+  },
+
+  "src/app/api/auth/switch-account/route.ts": {
+    adminClient: "Auth Admin API (user lookup and magic-link generation)",
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["customer", "gamer"],
+          allowUnverified: true,
+        },
+        body: { kind: "json", schema: null },
+        test: TESTS.switchAccount,
+      },
+    },
+  },
+
+  // --- Checkout and billing ------------------------------------------------
+
+  "src/app/api/checkout/products/create/route.ts": {
+    adminClient:
+      "caches a Stripe customer id onto the grant-locked billing table; an authenticated write path there would let a user point their billing row at someone else's Stripe customer",
+    handlers: {
+      POST: {
+        posture: { kind: "role-gated", roles: ["customer"] },
+        body: { kind: "json", schema: null },
+        test: TESTS.checkout,
+      },
+    },
+  },
+
+  "src/app/api/parent/billing-portal/route.ts": {
+    adminClient: "same Stripe-customer helper as checkout",
+    handlers: {
+      POST: {
+        posture: { kind: "role-gated", roles: ["customer"] },
+        body: { kind: "none" },
+        test: null,
+      },
+    },
+  },
+
+  // --- Discord -------------------------------------------------------------
+
+  "src/app/api/discord/interactions/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "webhook",
+          verifier: "discord-ed25519",
+          reason:
+            "Discord's interaction endpoint. There is no session — the Ed25519 signature over the timestamp and raw body is the authorization, and Discord de-registers an endpoint that fails its verification handshake",
+        },
+        body: {
+          kind: "raw",
+          reason: "the signature is computed over the exact bytes sent",
+        },
+        test: null,
+      },
+    },
+  },
+
+  // --- Family and feedback -------------------------------------------------
+
+  "src/app/api/family/list/route.ts": {
+    adminClient:
+      "a gamer legitimately reads siblings beyond their own row-level view; the resolver is scoped to the verified caller's family",
+    handlers: {
+      GET: {
+        posture: {
+          kind: "role-gated",
+          roles: ["customer", "gamer"],
+          allowUnverified: true,
+        },
+        body: { kind: "none" },
+        test: null,
+      },
+    },
+  },
+
+  "src/app/api/feedback/route.ts": {
+    adminClient:
+      "the submission write runs on the user client; the admin client survives only for the notification fan-out (every admin's address, a gamer's parent's) which is not in the submitter's view and must not be returnable",
+    handlers: {
+      POST: {
+        // Every role, which is the shared gate's way of spelling "any
+        // authenticated caller". Recorded as role-gated rather than
+        // any-authenticated because that is what the code does — it loads the
+        // profile and applies the parent-PIN gate along the way.
+        posture: {
+          kind: "role-gated",
+          roles: ["admin", "customer", "gamer", "gedu"],
+        },
+        body: { kind: "json", schema: "inline: feedbackSchema" },
+        test: TESTS.feedback,
+      },
+    },
+  },
+
+  // --- Gamer accounts ------------------------------------------------------
+
+  "src/app/api/gamers/[id]/route.ts": {
+    adminClient:
+      "Auth Admin API (metadata and password updates) interleaved with writes to a LINKED user's rows",
+    handlers: {
+      PATCH: {
+        posture: { kind: "role-gated", roles: ["customer"] },
+        body: { kind: "json", schema: null },
+        test: TESTS.gamersUpdate,
+      },
+    },
+  },
+
+  "src/app/api/gamers/create/route.ts": {
+    adminClient:
+      "Auth Admin API (user creation, with delete-on-failure compensation)",
+    handlers: {
+      POST: {
+        posture: { kind: "role-gated", roles: ["customer"] },
+        body: { kind: "json", schema: null },
+        test: TESTS.gamersCreate,
+      },
+    },
+  },
+
+  // --- Educator self-registration ------------------------------------------
+
+  "src/app/api/gedu/register/route.ts": {
+    adminClient:
+      "Auth Admin API (self-registration creates the auth user before any session exists)",
+    handlers: {
+      POST: {
+        posture: {
+          kind: "public",
+          reason:
+            "educators self-register, so no session can exist yet. The highest-value public route on the surface: it creates an account, and the account it creates is unverified until an admin approves it",
+        },
+        body: { kind: "json", schema: "registerGeduBody" },
+        test: null,
+      },
+    },
+  },
+
+  // --- Minecraft -----------------------------------------------------------
+
+  "src/app/api/minecraft/account/route.ts": {
+    handlers: {
+      PATCH: {
+        posture: { kind: "role-gated", roles: ["gamer", "gedu"] },
+        body: { kind: "json", schema: null },
+        test: TESTS.minecraftAccount,
+      },
+    },
+  },
+
+  "src/app/api/minecraft/join-check/route.ts": {
+    adminClient:
+      "server-to-server, authenticated by a shared API key rather than a user session",
+    handlers: {
+      GET: {
+        posture: {
+          kind: "api-key",
+          reason:
+            "the game server calls this on player join; it has no user session to present. A bearer token compared in constant time is the authorization, and an unported role fails closed rather than being admitted",
+        },
+        body: { kind: "none" },
+        test: TESTS.minecraftJoinCheck,
+      },
+    },
+  },
+
+  "src/app/api/minecraft/verify/route.ts": {
+    handlers: {
+      GET: {
+        posture: {
+          kind: "public",
+          reason:
+            "a read-only passthrough to Mojang's public username lookup — no database access and no secrets. The public educator registration page checks a username before any account exists, so it cannot require a session",
+        },
+        body: { kind: "none" },
+        test: TESTS.minecraftVerify,
+      },
+    },
+  },
+
+  // --- Participations ------------------------------------------------------
+
+  "src/app/api/participations/waitlist/route.ts": {
+    handlers: {
+      POST: {
+        posture: { kind: "role-gated", roles: ["customer"] },
+        body: { kind: "json", schema: "joinWaitlistBody" },
+        test: TESTS.waitlist,
+      },
+    },
+  },
+
+  // --- User settings -------------------------------------------------------
+
+  "src/app/api/user/locale/route.ts": {
+    offPrimitive:
+      "the one route that re-implements the session check inline — it verifies the token and reads the subject itself instead of calling the shared gate. Recorded as nonconforming from day one; the sweep moves it onto the standard primitive",
+    handlers: {
+      PATCH: {
+        posture: {
+          kind: "any-authenticated",
+          reason:
+            "every role sets their own interface language, and the write is scoped to the caller's own row by a column grant plus a self-update policy, so the role is genuinely irrelevant here",
+        },
+        body: { kind: "json", schema: null },
+        test: TESTS.userLocale,
+      },
+    },
+  },
+
+  // --- Voice ---------------------------------------------------------------
+
+  "src/app/api/voice/instant/create/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["admin", "gedu"],
+          requireVerifiedGedu: true,
+        },
+        body: { kind: "none" },
+        test: TESTS.voiceInstantCreate,
+      },
+    },
+  },
+
+  "src/app/api/voice/instant/end/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["admin", "gedu"],
+          requireVerifiedGedu: true,
+        },
+        body: { kind: "json", schema: "inline: { code }" },
+        test: TESTS.voiceInstantEnd,
+      },
+    },
+  },
+
+  "src/app/api/voice/instant/exists/route.ts": {
+    handlers: {
+      GET: {
+        posture: {
+          kind: "public",
+          reason:
+            "the lobby checks whether a room code resolves before asking for camera and microphone permission, and a guest joining by link has no session. Reveals only that a code exists, which anyone holding the code could learn by joining",
+        },
+        body: { kind: "none" },
+        test: null,
+      },
+    },
+  },
+
+  "src/app/api/voice/instant/token/route.ts": {
+    handlers: {
+      POST: {
+        posture: {
+          kind: "optional-auth",
+          reason:
+            "anyone holding the room code may join as a guest, and a recognized admin or verified educator is silently elevated to room owner. A public-or-gated binary cannot express it. Ownership is derived only from the server-side session lookup — never from the request body — and every ambiguous outcome falls through to guest",
+        },
+        body: { kind: "json", schema: null },
+        test: TESTS.voiceInstantToken,
+      },
+    },
+  },
+
+  "src/app/api/voice/token/route.ts": {
+    adminClient:
+      "the self-healing occupancy prune is a cross-user system write no participant is authorized to make",
+    handlers: {
+      POST: {
+        posture: {
+          kind: "role-gated",
+          roles: ["gedu", "gamer", "admin"],
+        },
+        body: { kind: "json", schema: "inline: { groupId }" },
+        test: TESTS.voiceToken,
+      },
+    },
+  },
+
+  // --- Webhooks ------------------------------------------------------------
+
+  "src/app/api/webhooks/stripe/products/route.ts": {
+    adminClient: "webhook; no session by construction",
+    handlers: {
+      POST: {
+        posture: {
+          kind: "webhook",
+          verifier: "stripe-signature",
+          reason:
+            "Stripe posts payment events with no session. The signature over the raw body is the authorization. Its error contract is the inverse of Meta's: a failed write answers 5xx ON PURPOSE so Stripe retries the delivery",
+        },
+        body: {
+          kind: "raw",
+          reason: "the signature is computed over the exact bytes sent",
+        },
+        test: TESTS.stripeWebhook,
+      },
+    },
+  },
+
+  "src/app/api/webhooks/whatsapp/route.ts": {
+    adminClient: "webhook; no session by construction",
+    handlers: {
+      GET: {
+        posture: {
+          kind: "webhook",
+          verifier: "meta-challenge-plain-compare",
+          reason:
+            "Meta's subscription handshake: it echoes a challenge back when the shared verify token matches. RECORDED WART — the token comparison is a plain equality check rather than a constant-time one, unlike every other secret comparison on this surface. The sweep gives it a timing-safe compare",
+        },
+        body: { kind: "none" },
+        test: TESTS.whatsappWebhook,
+      },
+      POST: {
+        posture: {
+          kind: "webhook",
+          verifier: "meta-hmac-sha256",
+          reason:
+            "Meta posts inbound messages and delivery receipts with no session; an HMAC over the raw body, compared in constant time, is the authorization. Its error contract is the inverse of Stripe's: it must answer 200 even for an envelope it cannot parse, because Meta disables an endpoint that errors persistently",
+        },
+        body: {
+          kind: "raw",
+          reason: "the HMAC is computed over the exact bytes sent",
+        },
+        test: TESTS.whatsappWebhook,
+      },
+    },
+  },
+};
+
+/**
+ * Modules OUTSIDE the route surface that construct the service-role client.
+ * Pinned here for the same reason the route entries are: the dangerous thing is
+ * not any one use, it is a new use appearing without anyone weighing it.
+ */
+const NON_ROUTE_ADMIN_CLIENT_SITES: Record<string, string> = {
+  "src/lib/supabase/admin.ts": "the client factory itself",
+  "src/lib/pin-session-server.ts":
+    "resolves a PIN-reset token to a user id with no session in hand; shared by the reset page and the reset route",
+  "src/services/family/family.server.ts":
+    "the shared family resolver — a gamer legitimately reads siblings beyond their own view",
+  "src/app/select-profile/page.tsx":
+    "the profile chooser prefetch, through the same family resolver as the family-list route",
+};
+
+// ---------------------------------------------------------------------------
+// Surface enumeration
+// ---------------------------------------------------------------------------
+
+/** Repo-relative, forward-slashed, so registry keys read the same everywhere. */
+function repoPath(absolute: string): string {
+  return relative(process.cwd(), absolute).split("\\").join("/");
+}
+
+function walk(dir: string, matches: (name: string) => boolean): string[] {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- walks fixed in-repo directories (the API route tree and src/), no external input
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full, matches);
+    return matches(entry.name) ? [full] : [];
+  });
+}
+
+function readSource(path: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- reads a file discovered by the fixed in-repo walk above
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+/** Handler exports really present in a route file's source. */
+function exportedMethods(source: string): Method[] {
+  const pattern =
+    /^export\s+(?:async\s+function|function|const|let|var)\s+([A-Z]+)\b/gm;
+  const found = new Set<Method>();
+  for (const match of source.matchAll(pattern)) {
+    const name = match[1];
+    const method = METHODS.find((candidate) => candidate === name);
+    if (method) found.add(method);
+  }
+  return METHODS.filter((method) => found.has(method));
+}
+
+const ROUTE_FILES = walk(join(process.cwd(), API_DIR), (name) => name === "route.ts")
+  .map(repoPath)
+  .sort();
+
+const REGISTRY_PATHS = Object.keys(ROUTE_REGISTRY).sort();
+
+/** Every (file, method, entry) triple, which is the real unit of classification. */
+const REGISTERED_HANDLERS = Object.entries(ROUTE_REGISTRY).flatMap(
+  ([path, entry]) =>
+    Object.entries(entry.handlers).map(([method, handler]) => ({
+      path,
+      method,
+      handler,
+      label: `${method} ${path}`,
+    })),
+);
+
+// ---------------------------------------------------------------------------
+// Check 1 — completeness
+// ---------------------------------------------------------------------------
+
+describe("check 1 — completeness: the surface and the registry agree", () => {
+  // Anti-vacuity. Every check below iterates a discovered or declared list; if
+  // either list were empty the whole suite would pass while verifying nothing,
+  // which is the failure mode a spine must not have.
+  it("found route files on disk", () => {
+    expect(ROUTE_FILES.length).toBeGreaterThan(0);
+  });
+
+  it("found classified handlers in the registry", () => {
+    expect(REGISTERED_HANDLERS.length).toBeGreaterThan(0);
+  });
+
+  it("classifies every route file on disk", () => {
+    const unclassified = ROUTE_FILES.filter(
+      (path) => !REGISTRY_PATHS.includes(path),
+    );
+    expect(unclassified).toEqual([]);
+  });
+
+  it("has no registry entry for a file that no longer exists", () => {
+    const stale = REGISTRY_PATHS.filter((path) => !ROUTE_FILES.includes(path));
+    expect(stale).toEqual([]);
+  });
+
+  it.each(REGISTRY_PATHS)(
+    "%s declares exactly the handlers it exports",
+    (path) => {
+      const declared = Object.keys(ROUTE_REGISTRY[path].handlers).sort();
+      const actual = exportedMethods(readSource(path)).sort();
+      expect(declared).toEqual(actual);
+    },
+  );
+
+  it.each(REGISTERED_HANDLERS.map((h) => [h.label, h.handler] as const))(
+    "%s carries a reason for any posture that is not role-gated",
+    (_label, handler) => {
+      if (handler.posture.kind === "role-gated") {
+        expect(handler.posture.roles.length).toBeGreaterThan(0);
+        return;
+      }
+      expect(handler.posture.reason.trim().length).toBeGreaterThan(0);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Check 2 — static conformance
+// ---------------------------------------------------------------------------
+
+/**
+ * A handler that authenticates its caller has to do it through shared code, so
+ * that fixing the gate once fixes it everywhere. `defineRoute` is the primitive;
+ * the bare role gate is the pre-primitive shape and still counts while the sweep
+ * runs. A file that contains neither, yet claims to authenticate, must say why —
+ * and that exception expires automatically, because a file that later gains the
+ * primitive while keeping its exception fails the same test.
+ */
+describe("check 2 — static conformance: gated routes contain the primitive", () => {
+  const GATED_KINDS = new Set(["role-gated", "any-authenticated"]);
+
+  const gatedPaths = REGISTRY_PATHS.filter((path) =>
+    Object.values(ROUTE_REGISTRY[path].handlers).some((handler) =>
+      GATED_KINDS.has(handler.posture.kind),
+    ),
+  );
+
+  it("found gated routes to check", () => {
+    expect(gatedPaths.length).toBeGreaterThan(0);
+  });
+
+  it.each(gatedPaths)("%s calls defineRoute or the shared role gate", (path) => {
+    const source = readSource(path);
+    const usesPrimitive = /\bdefineRoute\b/.test(source);
+    const usesRoleGate = /\brequireRole\b/.test(source);
+    const exception = ROUTE_REGISTRY[path].offPrimitive;
+
+    if (exception === undefined) {
+      expect(
+        usesPrimitive || usesRoleGate,
+        `${path} authenticates its caller but contains neither defineRoute nor requireRole. Either use the primitive, or record an offPrimitive reason in the registry.`,
+      ).toBe(true);
+      return;
+    }
+
+    // The exception is recorded — assert it is still true, so a converted route
+    // cannot keep a stale excuse.
+    expect(
+      usesPrimitive || usesRoleGate,
+      `${path} carries an offPrimitive exception but now uses the shared gate. Delete the exception.`,
+    ).toBe(false);
+  });
+
+  it.each(
+    REGISTRY_PATHS.filter((path) => ROUTE_REGISTRY[path].offPrimitive !== undefined),
+  )("%s gives a reason for standing off the primitive", (path) => {
+    expect(ROUTE_REGISTRY[path].offPrimitive?.trim().length).toBeGreaterThan(0);
+  });
+
+  // The wrapper reads the request body only when a body schema is declared, so
+  // a raw-body posture must never be wrapped: a consumed stream cannot be
+  // re-read, and the signature is over the bytes.
+  it.each(
+    REGISTERED_HANDLERS.filter((h) => h.handler.body.kind === "raw").map(
+      (h) => [h.label, h.path] as const,
+    ),
+  )("%s verifies a raw body and stays off the wrapper", (_label, path) => {
+    expect(/\bdefineRoute\b/.test(readSource(path))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Check 3 — admin-client pinning
+// ---------------------------------------------------------------------------
+
+/**
+ * The service-role client bypasses every row-level policy, so its import sites
+ * are the shortest list of places where a handler bug becomes a database-wide
+ * capability. Pinning the set to a justified registry is the same move that
+ * pinned anonymous write grants at zero: growth is possible, but only
+ * deliberately.
+ */
+describe("check 3 — admin-client pinning", () => {
+  const ADMIN_CLIENT = /\bcreateAdminClient\b/;
+
+  const importers = walk(join(process.cwd(), "src"), (name) =>
+    /\.tsx?$/.test(name),
+  )
+    .map(repoPath)
+    .filter((path) => ADMIN_CLIENT.test(readSource(path)))
+    .sort();
+
+  const routeImporters = importers.filter((path) =>
+    path.startsWith("src/app/api/"),
+  );
+  const nonRouteImporters = importers.filter(
+    (path) => !path.startsWith("src/app/api/"),
+  );
+
+  const justifiedRoutes = REGISTRY_PATHS.filter(
+    (path) => ROUTE_REGISTRY[path].adminClient !== undefined,
+  );
+
+  it("found service-role client import sites", () => {
+    expect(importers.length).toBeGreaterThan(0);
+  });
+
+  it("has a justification for every route that uses the service-role client", () => {
+    const unjustified = routeImporters.filter(
+      (path) => !justifiedRoutes.includes(path),
+    );
+    expect(unjustified).toEqual([]);
+  });
+
+  it("has no justification left behind by a route that dropped the client", () => {
+    const obsolete = justifiedRoutes.filter(
+      (path) => !routeImporters.includes(path),
+    );
+    expect(obsolete).toEqual([]);
+  });
+
+  it.each(justifiedRoutes)("%s justifies its use in a full clause", (path) => {
+    expect(ROUTE_REGISTRY[path].adminClient?.trim().length).toBeGreaterThan(0);
+  });
+
+  it("pins the non-route import sites too", () => {
+    expect(nonRouteImporters).toEqual(
+      Object.keys(NON_ROUTE_ADMIN_CLIENT_SITES).sort(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Check 4 — test linkage
+// ---------------------------------------------------------------------------
+
+/**
+ * The spine guarantees a test EXISTS to review, not that it is a good one —
+ * test quality stays a review concern. What it removes is the silent case: a
+ * route shipping with nothing exercising it and nobody noticing.
+ */
+describe("check 4 — test linkage", () => {
+  const linked = REGISTERED_HANDLERS.flatMap((h) =>
+    h.handler.test === null ? [] : [{ ...h, test: h.handler.test }],
+  );
+  const untested = REGISTERED_HANDLERS.filter((h) => h.handler.test === null);
+
+  it("found linked handlers", () => {
+    expect(linked.length).toBeGreaterThan(0);
+  });
+
+  it.each(
+    linked.map((h) => [h.label, h.test, h.path] as const),
+  )("%s names a test file that exists and exercises it", (_label, test, path) => {
+    const testPath = join(process.cwd(), test);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- the path comes from the registry literal in this file, not from input
+    expect(existsSync(testPath), `${test} does not exist`).toBe(true);
+
+    // Matches both the static import and the dynamic `await import(...)` form.
+    const specifier = `@/${path.replace(/^src\//, "").replace(/\.ts$/, "")}`;
+    expect(
+      readSource(test).includes(specifier),
+      `${test} does not reference ${specifier}`,
+    ).toBe(true);
+  });
+
+  // Untested handlers are recorded rather than excused. This assertion is the
+  // counter: it can only go down, and the sweep ends when it reaches zero.
+  it("records the handlers that still have no test", () => {
+    expect(untested.map((h) => h.label).sort()).toEqual([
+      "GET src/app/api/family/list/route.ts",
+      "GET src/app/api/voice/instant/exists/route.ts",
+      "PATCH src/app/api/admin/products/[id]/participations/[participationId]/route.ts",
+      "PATCH src/app/api/admin/site-notes/route.ts",
+      "POST src/app/api/admin/products/[id]/update/route.ts",
+      "POST src/app/api/auth/signout/route.ts",
+      "POST src/app/api/discord/interactions/route.ts",
+      "POST src/app/api/gedu/register/route.ts",
+      "POST src/app/api/parent/billing-portal/route.ts",
+    ]);
+  });
+});

--- a/tests/unit/lib/api/define-route.test.ts
+++ b/tests/unit/lib/api/define-route.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockGetClaims = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ auth: { getClaims: mockGetClaims } }),
+}));
+
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
+
+const URL_BASE = "http://localhost:3000/api/probe";
+
+function jsonRequest(body: unknown, url = URL_BASE): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+function authenticated(role = "customer") {
+  const supabase = { rpc: vi.fn() };
+  mockRequireRole.mockResolvedValue({
+    user: { id: "user-1", email: "a@b.test" },
+    profile: { id: "user-1", role },
+    supabase,
+  });
+  return supabase;
+}
+
+describe("defineRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  // -- Auth ----------------------------------------------------------------
+
+  describe("posture: role-gated", () => {
+    it("passes the declared roles and gate options to the shared role gate", async () => {
+      authenticated("gedu");
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: ["admin", "gedu"],
+        forbiddenMessage: "nope",
+        allowUnverified: true,
+        requireVerifiedGedu: true,
+        handler: () => ({ ok: true }),
+      });
+
+      await POST(jsonRequest({}));
+
+      expect(mockRequireRole).toHaveBeenCalledWith(["admin", "gedu"], {
+        forbiddenMessage: "nope",
+        allowUnverified: true,
+        requireVerifiedGedu: true,
+      });
+    });
+
+    it("returns the gate's refusal untouched and never runs the handler", async () => {
+      mockRequireRole.mockResolvedValue(
+        NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      );
+      const handler = vi.fn();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        handler,
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(response.status).toBe(401);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("hands the handler the caller's identity and user-bound client", async () => {
+      const supabase = authenticated("admin");
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "admin",
+        handler: async (context) => {
+          // Calling through the context proves it is the gate's client, not a
+          // fresh one the wrapper built behind the handler's back.
+          await context.supabase.rpc("pin_is_set");
+          return { id: context.user.id, role: context.profile.role };
+        },
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(await response.json()).toEqual({ id: "user-1", role: "admin" });
+      expect(supabase.rpc).toHaveBeenCalledWith("pin_is_set");
+    });
+
+    it("refuses before parsing, so an unauthorized caller learns nothing about the input", async () => {
+      mockRequireRole.mockResolvedValue(
+        NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      );
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        body: z.object({ needed: z.string() }),
+        handler: () => ({ ok: true }),
+      });
+
+      const response = await POST(jsonRequest({ wrong: 1 }));
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("posture: any-authenticated", () => {
+    it("accepts any signed-in caller without consulting the role gate", async () => {
+      mockGetClaims.mockResolvedValue({
+        data: { claims: { sub: "user-9", email: "x@y.test" } },
+        error: null,
+      });
+      const POST = defineRoute({
+        posture: "any-authenticated",
+        reason: "test",
+        handler: (context) => ({ id: context.user.id }),
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(await response.json()).toEqual({ id: "user-9" });
+      expect(mockRequireRole).not.toHaveBeenCalled();
+    });
+
+    it("answers 401 when there is no verified session", async () => {
+      mockGetClaims.mockResolvedValue({ data: null, error: null });
+      const handler = vi.fn();
+      const POST = defineRoute({
+        posture: "any-authenticated",
+        reason: "test",
+        handler,
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(response.status).toBe(401);
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("posture: public", () => {
+    it("runs the handler with no authentication at all", async () => {
+      const GET = defineRoute({
+        posture: "public",
+        reason: "test",
+        handler: () => ({ ok: true }),
+      });
+
+      const response = await GET(new Request(URL_BASE));
+
+      expect(await response.json()).toEqual({ ok: true });
+      expect(mockRequireRole).not.toHaveBeenCalled();
+      expect(mockGetClaims).not.toHaveBeenCalled();
+    });
+  });
+
+  // -- Parsing slots -------------------------------------------------------
+
+  describe("parsing slots", () => {
+    it("validates the body against its schema and hands over the typed value", async () => {
+      authenticated();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        body: z.object({ count: z.number() }),
+        handler: ({ body }) => ({ doubled: body.count * 2 }),
+      });
+
+      const response = await POST(jsonRequest({ count: 21 }));
+
+      expect(await response.json()).toEqual({ doubled: 42 });
+    });
+
+    it("answers 400 with the first issue when the body fails its schema", async () => {
+      authenticated();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        body: z.object({ count: z.number() }),
+        handler: () => ({ ok: true }),
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toContain("count");
+    });
+
+    it("answers 400 for malformed JSON", async () => {
+      authenticated();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        body: z.object({ count: z.number() }),
+        handler: () => ({ ok: true }),
+      });
+
+      const response = await POST(jsonRequest("{not-json"));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe("Invalid JSON body");
+    });
+
+    // The invariant that lets a raw-body verifier coexist with the wrapper:
+    // no body schema means the request stream is never touched, so a handler
+    // (or a hand-written route beside it) can still read the exact bytes.
+    it("never reads the request body when no body schema is declared", async () => {
+      authenticated();
+      let rawSeen: string | null = null;
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        handler: async ({ request }) => {
+          rawSeen = await request.text();
+          return { ok: true };
+        },
+      });
+
+      const request = jsonRequest({ signed: "payload" });
+      expect(request.bodyUsed).toBe(false);
+
+      await POST(request);
+
+      expect(rawSeen).toBe(JSON.stringify({ signed: "payload" }));
+    });
+
+    it("validates the query string", async () => {
+      const GET = defineRoute({
+        posture: "public",
+        reason: "test",
+        query: z.object({ code: z.string().min(3) }),
+        handler: ({ query }) => ({ code: query.code }),
+      });
+
+      const ok = await GET(new Request(`${URL_BASE}?code=abcd`));
+      expect(await ok.json()).toEqual({ code: "abcd" });
+
+      const bad = await GET(new Request(`${URL_BASE}?code=a`));
+      expect(bad.status).toBe(400);
+    });
+
+    it("validates the dynamic route params", async () => {
+      authenticated();
+      const PATCH = defineRoute({
+        posture: "role-gated",
+        roles: "admin",
+        params: z.object({ id: z.string().uuid() }),
+        handler: ({ params }) => ({ id: params.id }),
+      });
+
+      const id = "11111111-1111-1111-1111-111111111111";
+      const ok = await PATCH(new Request(URL_BASE), {
+        params: Promise.resolve({ id }),
+      });
+      expect(await ok.json()).toEqual({ id });
+
+      const bad = await PATCH(new Request(URL_BASE), {
+        params: Promise.resolve({ id: "not-a-uuid" }),
+      });
+      expect(bad.status).toBe(400);
+    });
+  });
+
+  // -- Error mapping -------------------------------------------------------
+
+  describe("error mapping", () => {
+    async function respondToThrown(
+      thrown: unknown,
+      extra: { errorStatus?: Record<string, number>; disclose?: string } = {},
+    ) {
+      authenticated();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        errorStatus: extra.errorStatus,
+        discloseErrorMessages: extra.disclose,
+        handler: () => {
+          throw thrown;
+        },
+      });
+      return POST(jsonRequest({}));
+    }
+
+    it.each([
+      ["42501", 403],
+      ["23505", 409],
+      ["P0002", 404],
+      ["PGRST116", 404],
+      ["23503", 400],
+      ["23514", 400],
+      ["P0004", 500],
+    ])("maps database code %s to HTTP %i", async (code, status) => {
+      const response = await respondToThrown({ code, message: "raw detail" });
+      expect(response.status).toBe(status);
+    });
+
+    it("maps an unrecognized database code to 500 rather than guessing", async () => {
+      const response = await respondToThrown({ code: "40001", message: "x" });
+      expect(response.status).toBe(500);
+    });
+
+    it("lets a route override one code without re-implementing the table", async () => {
+      const overridden = await respondToThrown(
+        { code: "P0002", message: "x" },
+        { errorStatus: { P0002: 400 } },
+      );
+      expect(overridden.status).toBe(400);
+
+      const untouched = await respondToThrown(
+        { code: "23505", message: "x" },
+        { errorStatus: { P0002: 400 } },
+      );
+      expect(untouched.status).toBe(409);
+    });
+
+    it("returns a generic message by default and logs the real one", async () => {
+      const response = await respondToThrown({
+        code: "23505",
+        message: "duplicate key value violates unique constraint pk_secret",
+      });
+
+      expect(await response.json()).toEqual({ error: "Conflict" });
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("forwards the underlying message only when the route opts in", async () => {
+      const response = await respondToThrown(
+        { code: "23514", message: "waitlist is not enabled" },
+        { disclose: "the message is the user-facing explanation" },
+      );
+
+      expect(await response.json()).toEqual({
+        error: "waitlist is not enabled",
+      });
+    });
+
+    it("uses an ApiError's status and stable code, keeping its message for the log", async () => {
+      const response = await respondToThrown(
+        new ApiError("internal detail", 403, "PIN_REQUIRED"),
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: "Forbidden",
+        code: "PIN_REQUIRED",
+      });
+    });
+
+    it("answers a generic 500 for a failure it cannot classify", async () => {
+      const response = await respondToThrown(new Error("boom"));
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "Internal server error" });
+    });
+
+    it("honours a Response thrown by the handler as a short-circuit", async () => {
+      const response = await respondToThrown(
+        NextResponse.json({ error: "teapot" }, { status: 418 }),
+      );
+
+      expect(response.status).toBe(418);
+    });
+  });
+
+  // -- Responses -----------------------------------------------------------
+
+  describe("responses", () => {
+    it("validates the outgoing payload when a response schema is declared", async () => {
+      authenticated();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        response: z.object({ id: z.string() }),
+        handler: () => ({ id: "abc" }),
+      });
+
+      const response = await POST(jsonRequest({}));
+      expect(await response.json()).toEqual({ id: "abc" });
+    });
+
+    it("answers a logged 500 rather than delivering a payload that fails its schema", async () => {
+      authenticated();
+      // Modelled the way a real mismatch arrives: a value that entered the
+      // process untyped (an RPC result, a third-party payload) and does not
+      // actually match the shape the route promised.
+      const fromOutside: { id: string } = JSON.parse('{"id":42}');
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        response: z.object({ id: z.string() }),
+        handler: () => fromOutside,
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "Internal server error" });
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    // The response slot doubles as an allowlist: the payload sent is the
+    // schema's parse output, so a field the contract never declared is dropped
+    // rather than quietly delivered.
+    it("sends the schema's output, dropping fields the contract does not declare", async () => {
+      authenticated();
+      const POST = defineRoute({
+        posture: "role-gated",
+        roles: "customer",
+        response: z.object({ id: z.string() }),
+        handler: () => ({ id: "abc", internalNote: "not for the client" }),
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(await response.json()).toEqual({ id: "abc" });
+    });
+
+    it("passes a handler-built Response through untouched (redirects, raw text)", async () => {
+      const GET = defineRoute({
+        posture: "public",
+        reason: "test",
+        handler: () => new Response("challenge-token", { status: 200 }),
+      });
+
+      const response = await GET(new Request(URL_BASE));
+
+      expect(await response.text()).toBe("challenge-token");
+    });
+
+    it("passes a redirect through untouched", async () => {
+      const POST = defineRoute({
+        posture: "public",
+        reason: "test",
+        handler: () => NextResponse.redirect("http://localhost:3000/", { status: 303 }),
+      });
+
+      const response = await POST(jsonRequest({}));
+
+      expect(response.status).toBe(303);
+      expect(response.headers.get("location")).toBe("http://localhost:3000/");
+    });
+
+    it("answers 204 with no body when the handler returns nothing", async () => {
+      const GET = defineRoute({
+        posture: "public",
+        reason: "test",
+        handler: () => undefined,
+      });
+
+      const response = await GET(new Request(URL_BASE));
+
+      expect(response.status).toBe(204);
+      expect(await response.text()).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
Phase 1 of `docs/route-boundary-architecture.md` — instance 2 of the hindsight-refactor playbook. The registry, the spine and the primitive land together; the sweep (Phase 2) does not start here.

CI green at the end of this phase means **every route is classified even though almost none are converted** — which is the point: from here a new route cannot ship unclassified.

## The taxonomy

The §2 snapshot was re-verified against a fresh glob and a fresh service-role import list before anything was written. The surface, the posture counts and the import set were exact; only one prose figure was wrong (see *Deviations*).

| Posture | Handlers | Notes |
|---|---|---|
| `role-gated` | 27 | 6 skip the parent-PIN gate, 2 require a verified educator, 1 names all four roles |
| `any-authenticated` | 1 | the route that re-implements the session check inline — recorded as nonconforming from day one |
| `public` | 4 | Mojang lookup, instant-room existence, educator self-registration, forgot-password |
| `session-mutating-public` | 2 | OAuth callback, sign-out |
| `signed-token` | 1 | PIN reset — the emailed token *is* the authorization |
| `optional-auth` | 1 | instant-room token: public, silently elevates a recognized moderator, fails closed to guest |
| `webhook` | 4 | four verifier strategies with divergent error contracts (Stripe wants 5xx, Meta must never 5xx) |
| `api-key` | 1 | Minecraft join-check, constant-time bearer compare |

Every non-`role-gated` entry carries a mandatory `reason`. Body discipline: **17** JSON with a schema (7 through a feature contract, 10 inline), **7** JSON with no schema at all, **2** multipart, **3** raw, **12** with no body. **16** route files justify a service-role import (seeded from the DB-auth triage CSV, re-derived not edited); **4** non-route modules are pinned separately. **9** handlers carry `test: null`.

Warts are recorded as warts, not excused: the hand-rolled session check, the webhook challenge that compares its shared secret with a plain `===`, the bodies parsed with no schema, and the untested nine each have a slot.

## The four checks

`tests/integration/api-route-registry.test.ts` — 170 assertions, sibling of the proxy test and built on its page-walk shape (fixed-dir recursion, carve-outs-with-reason, anti-vacuity guard, `it.each`).

1. **Completeness** — glob ↔ registry in both directions, plus each file's declared handlers must equal the methods it really exports, plus a reason present on every non-role-gated posture. Two anti-vacuity guards.
2. **Static conformance** — a handler that authenticates its caller must contain `defineRoute` or the shared role gate, or carry a recorded `offPrimitive` reason. The exception **expires by itself**: a file that later gains the gate while keeping its excuse fails. A raw-body handler is additionally asserted to stay off the wrapper.
3. **Admin-client pinning** — the set of route files importing the service-role client equals the justified registry, in both directions; the non-route import sites are pinned to their own reasoned list.
4. **Test linkage** — every non-`null` entry names a file that exists and references the route (matching both the static and the dynamic import form). The nine untested handlers are asserted as an explicit list that can only shrink.

Each check was verified to **fail on a deliberate mutation** before being trusted — an unclassified route file, an unjustified service-role import, a gated route losing its gate, and a stale test link each produced the expected failure.

## Exemplars

- **Role-gated JSON conversion** — the waitlist join route moves onto `defineRoute`. Its **13 existing integration tests pass unchanged**, which is the evidence the wrapper preserves behaviour; no mock needed updating, because the wrapper runs the same role gate underneath.
- **Public carve-out, classified without wrapping** — the Mojang username lookup: reasoned in the registry, untouched in code.
- **Webhook, classified off-wrapper** — the Stripe products webhook and both WhatsApp handlers: raw-body verifiers stay hand-written, and check 2 now *enforces* that they do.

`defineRoute` itself gets 33 unit tests covering every slot it owns, including the structural invariant that makes the webhook carve-out safe: **it never reads the request body unless a body schema is declared**.

## Deviations from the doc

- **The primitive covers three postures, not all eight.** `role-gated`, `any-authenticated` and `public` go through the wrapper; webhook, api-key, signed-token and optional-auth stay hand-written by design, exactly as §3.2 allows. Classification is what is mandatory.
- **Two error-mapping divergences resolved deliberately** in the exemplar, both recorded in the doc: an unrecognized database code now becomes a **500** rather than being folded into a 400 (an error nobody anticipated is a server error), and `no_data_found` keeps its **400** through an explicit per-route override rather than silently becoming the table's 404.
- **A declared response schema is an allowlist, not just a check** — the payload sent is the schema's parse output, so an undeclared field is dropped rather than delivered. Only a genuine shape mismatch becomes a logged 500.
- **§2 snapshot correction.** "26 of 39 route files" counted the integration *test files*, not the routes they cover. The real figures are 31 of 39 covered, with 8 files plus one handler in a ninth untested — which is exactly the list §2 already named, so only the ratio was wrong. The WhatsApp webhook is covered by a test that imports it dynamically, which is why the linkage check matches both import forms.

## Docs

`docs/route-boundary-architecture.md` marks Phase 1 landed and records what Phase 2 inherits (the two error-mapping questions that recur per conversion, why `no_data_found` needs a per-route decision, why the taxonomy needed a note rather than a new category twice, and the still-undecided permanent home for the architecture). The tripwire goes in the root `CLAUDE.md` beside its DB twin; the registry conventions go in `tests/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
