### PR TITLE
refactor(routes): Phase 2 — the sweep

### DIFF
--- a/docs/refactor-playbook.md
+++ b/docs/refactor-playbook.md
@@ -64,7 +64,7 @@ without the last two is an audit, not a fix.
 |---|---|---|
 | DB grants + RLS presence | Done (2026-03) | `docs/SECURITY_REPORT.md`; enforced by the DB access-control test |
 | DB function bodies + RLS behavior | Done (2026-07) | `docs/db-authorization-architecture.md`; enforced by the verification-spine DB tests |
-| HTTP route layer | In flight | `docs/route-boundary-architecture.md` |
+| HTTP route layer | Done (2026-07) | `docs/route-boundary-architecture.md`; enforced by the route posture registry's integration tests |
 | Data validity (constraints) | Future | Deferred by the db-auth doc's out-of-scope list; instances accumulate in `TODO.md` |
 
 ## Next instance stub: the HTTP route layer

--- a/docs/route-boundary-architecture.md
+++ b/docs/route-boundary-architecture.md
@@ -1,29 +1,37 @@
 # HTTP Route Boundary Architecture
 
-**Status:** target architecture + migration plan. This is the second instance of the
+**Status: built.** Both phases of §5 have landed — the primitive, the posture registry
+and its four spine checks, then the sweep. §2–§3 describe the system that exists, not a
+target: every handler on the surface carries one machine-readable classification, every
+handler that authenticates its caller does so through shared code, every JSON body is
+validated against a schema, every handler has an integration test, and the spine fails
+the build when any of that stops being true. This is the second instance of the
 hindsight-refactor loop (`docs/refactor-playbook.md`); the first was
 `docs/db-authorization-architecture.md`, whose §1 problem statement this doc repeats one
-layer up. When someone says "let's do the route-layer refactor," this is the doc to read
-and act on.
+layer up. This doc stays the source of truth for how the HTTP boundary is enforced.
 
-**Execution contract.** Written so a fresh session can execute the refactor from it:
+**Execution contract.** Written so a fresh session can act on it:
 
 1. **Re-verify current state.** The §2 snapshot was verified 2026-07-27 and will drift.
    Regenerate the surface with a glob over `src/app/api/**/route.ts`; regenerate the
-   admin-client import list with `git grep -l createAdminClient src/`. The Model-A
-   justifications live in the triage CSV in `docs/db-authorization-architecture.md` §5
-   Phase 3 — re-derive against it, don't edit it.
-2. **No database involvement.** This refactor is app-layer only: no migrations, no
-   staging side effects, no deploy-window hazards. The spine tests are plain jsdom
-   integration tests and run locally (`npx vitest run <file>`) and in CI.
-3. **One phase per PR**, CI green before the next starts.
-4. **No authorization semantics change silently.** Every posture in §2 is recorded as it
-   *is*, warts included. A wart fixed during the sweep is a deliberate, recorded change
-   in the PR description — never a side effect of mechanical conversion.
+   admin-client import list with `git grep -l createAdminClient src/`. The registry
+   itself is the live classification and is checked against the filesystem on every CI
+   run, so it cannot silently disagree with the surface the way a doc snapshot can.
+2. **No database involvement.** This work is app-layer only: no migrations, no staging
+   side effects, no deploy-window hazards. The spine tests are plain jsdom integration
+   tests and run locally (`npx vitest run <file>`) and in CI.
+3. **No authorization semantics change silently.** Every posture in §2 was recorded as
+   it *was*, warts included, before anything moved. A wart fixed during the sweep was a
+   deliberate, recorded change in its PR description — never a side effect of mechanical
+   conversion. The same rule applies to any future change here.
 
 ---
 
 ## 1. The problem
+
+*Stated as it stood before the work, and kept in that tense: it is the record of why
+the machinery in §3 exists, and the thing to re-read if anyone proposes removing a
+piece of it.*
 
 The route layer's conventions — `requireRole` gating, contract-schema body parsing,
 error-code→HTTP mapping, the `{ error: string }` wire shape — are enforced by
@@ -54,7 +62,11 @@ refactor builds the mechanical first layer in front of it.
 
 ---
 
-## 2. Current state (verified 2026-07-27 — re-verify per the execution contract)
+## 2. The surface (snapshot 2026-07-27 — re-verify per the execution contract)
+
+*The posture taxonomy and the per-posture counts below still describe the surface: the
+sweep changed no route's posture, by design. What the sweep did change is recorded at
+the end of §5 — how bodies are parsed, how errors map, and what is tested.*
 
 ### The surface
 
@@ -258,9 +270,11 @@ integration tests pass unchanged, which is the evidence that the wrapper preserv
 behaviour. The public and webhook exemplars are classifications, not conversions:
 they demonstrate the reasoned carve-out shape, which is the other half of the design.
 
-### What Phase 2 inherits
+### What Phase 1 handed the sweep
 
-Findings and judgment calls from Phase 1 that the sweep should carry forward:
+Findings and judgment calls from Phase 1, kept because they are the reasoning behind
+choices the sweep then applied surface-wide — the "why" the Phase 2 record below
+assumes:
 
 - **Two error-mapping divergences resolved deliberately in the exemplar**, and the
   same two questions recur in every conversion. First, an unrecognized database code
@@ -287,12 +301,10 @@ Findings and judgment calls from Phase 1 that the sweep should carry forward:
 - **The recorded off-primitive exception expires by itself.** The spine fails if a
   file carrying that exception later gains the shared gate, so converting the
   hand-rolled session route forces the exception's removal in the same change.
-- **The architecture still has no permanent home.** Phase 1 put the tripwire in the
+- **The architecture had no permanent home yet.** Phase 1 put the tripwire in the
   root and the registry conventions with the test suite, and deliberately left the
   route shape here rather than duplicating a mid-flight design into a colocated doc.
-  When the sweep finishes, decide that home — the primitive and the routes live in
-  different directories, so the doc that a route author auto-loads is not the one
-  beside the primitive.
+  The sweep's answer is at the end of this section.
 
 **Snapshot corrections found while re-verifying §2.** The surface, the posture counts
 and the service-role import set were all exact. Coverage was not: "26 of 39 route
@@ -302,18 +314,84 @@ untested — which is what §2's untested list already named, so only the ratio 
 wrong. The WhatsApp webhook is covered by a test that imports it dynamically, so any
 linkage check has to match both the static and the dynamic import form.
 
-### Phase 2 — the sweep
+### Phase 2 — the sweep — **LANDED**
 
-Convert route-by-route in batches: simple role-gated JSON routes first, then multipart
-and odd shapes, then the recorded exceptions. Each conversion: move to `defineRoute`,
-normalize its error map to the default table (each divergence resolved deliberately and
-noted), give ad-hoc bodies a schema (and params/query schemas where read), keep or
-revoke raw-message forwarding explicitly. Write the missing integration tests (the
-nine), converting `test: null` entries to real links. Deliberate, recorded fixes that
-belong here rather than in silent conversion: the locale route moves onto the standard
-session primitive; the webhook GET challenge gains a timing-safe compare; incidental
-raw-message forwards close. End state: zero `test: null`, zero unreasoned carve-outs,
-and the playbook's instance table flipped to done.
+Converted route-by-route in batches — simple role-gated JSON routes, then the rest of
+the gated surface, then multipart and the public routes — with the spine green between
+batches. Thirty-one of the thirty-nine route files now go through the primitive. The
+eight that do not are the postures it deliberately does not cover: the two
+session-mutating redirect flows, the signed-token PIN reset, the api-key server-to-server
+check, the optional-auth room token, and the three webhook verifiers. Each is a reasoned
+carve-out in the registry rather than an omission, which is the honest boundary the
+design was aiming for.
+
+**The three counters are at zero and stay there.** No handler is unclassified, no JSON
+body is unschema'd, no handler is untested, no route stands off the primitive without a
+written reason. Two of those are now assertions against an empty list rather than
+assertions that were deleted once they emptied — kept deliberately as ratchets, so a
+regression fails CI immediately instead of quietly starting a fresh backlog.
+
+**What the sweep changed, and what it deliberately did not.** No route's posture moved.
+The one apparent exception is not one: the route that hand-rolled its session check now
+declares the any-authenticated posture, which is what its code always did. Everything
+else that changed is input handling, error mapping and message disclosure.
+
+**Error-mapping decisions worth carrying forward.** Three patterns recurred:
+
+- An unrecognized database code is a logged 500 everywhere now, not a 400 reported to
+  the caller as their mistake. Several routes had a catch-all `else 400` that turned
+  every unanticipated failure into a client error and hid it.
+- `no_data_found` really did need deciding per route, exactly as Phase 1 predicted. The
+  split turned out to be clean: a route whose subject is named in the URL path answers
+  404, because a missing one is a missing resource; a route whose subject arrives in the
+  body answers 400, because the caller's input names something that does not exist. Both
+  answers appear on the surface, each with the reason written beside it.
+- A status the shared table has no default for stays an explicit response with its
+  reason recorded — an upstream payment failure as 502, an exhausted retry loop as 503,
+  a broken money-path invariant as 500 through a per-route override.
+
+**Message disclosure is now a decision rather than an accident.** Every route that
+forwards an underlying message opts in by name and says why; the rest answer a generic
+message for the status and log the real one. The routes that kept the opt-in are the
+ones whose underlying messages are genuinely the user-facing explanation — a refused
+signup, a refused waitlist join, a refused batch of group changes, a refused product
+write — and on those the handler is written so nothing raw can escape past it. Everywhere
+else the forwarding was incidental and is closed. Curated copy survived only where it
+tells the caller something the status alone does not; where it merely restated the
+status, the shared generic replaced it.
+
+**Where schemas live.** Feature contract files gained the shapes that were floating in
+routes, and two features that had none now have one. Body schemas belong there because
+both ends of an internal call then import the same shape; a schema declared inline in
+the route is fine when nothing else consumes it, and the registry records which is which.
+
+**One shape the primitive does not express, recorded rather than worked around.** A
+route whose payload is an RPC's `Json` result cannot use the response-schema slot
+directly: the generated type is `Json`, the slot's type is the contract shape, and
+nothing bridges them without a cast. Those routes narrow the result in the handler
+instead — the shape the Phase 1 exemplar already used — and the response slot is used
+where the route assembles the payload itself. Worth revisiting only if a wrapper change
+can remove the cast without weakening the handler's return type everywhere else.
+
+**The deliberate fixes.** The hand-rolled session check moved onto the primitive, and
+the spine's recorded exception expired by itself as designed — the check fails a file
+that carries the excuse while using the gate, so deleting the annotation was forced by
+the same change rather than left to be remembered. The webhook challenge that compared
+its verify token with a plain equality check now uses the same constant-time compare its
+sibling handler always used for the HMAC, and the registry's verifier name changed with
+it so the annotation cannot outlive the fix.
+
+**Where this doc should live.** Phase 1 deferred the question; the recommendation is to
+leave it here in `docs/` rather than colocate it. The reasoning is the one the deferral
+anticipated: this system has three homes in the tree — the primitive, the routes, and
+the registry that classifies them — and no single directory a route author works in
+would auto-load a doc covering all three. What belongs colocated is the *operating
+rule*, and that already is: the testing conventions carry how to add a route to the
+registry and what a reason has to say, which is what someone adding a route needs at the
+moment they need it. This doc is the design record behind that rule — why the boundary
+is mechanically verified at all — and it is read deliberately, not incidentally. Moving
+it would trade a doc a human opens on purpose for one that auto-loads in one of three
+places and is wrong about the other two.
 
 ---
 
@@ -325,5 +403,11 @@ and the playbook's instance table flipped to done.
   are shared by routes and pages, so their authorization can't be encoded purely at the
   route boundary. Recorded, not solved here.
 - **Response localization** and any change to the `{ error, code }` wire contract.
-- **Changing what any route actually authorizes.** Posture changes are findings for a
-  human decision, not sweep work.
+- **Changing what any route actually authorizes.** Posture changes were findings for a
+  human decision, not sweep work — and none were made. The one posture question the
+  sweep surfaced and left alone: the feedback route names all four roles, which is the
+  shared gate's way of spelling "any authenticated caller", and it stays role-gated
+  because that is what the code does. It loads the profile the notification email needs
+  and applies the parent-PIN gate on the way, neither of which the any-authenticated
+  posture does. Reclassifying it would be a behaviour change wearing a tidy-up's
+  clothes.

--- a/src/app/api/admin/locations/[id]/route.ts
+++ b/src/app/api/admin/locations/[id]/route.ts
@@ -1,39 +1,38 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
 import { updateLocationBody } from "@/services/locations/locations.contracts";
 
-// See ../create/route.ts — `locations` writes run on the user-bound client
-// behind the admin_manage_locations policy.
+/**
+ * PATCH /api/admin/locations/[id]
+ *
+ * See ../create/route.ts — `locations` writes run on the user-bound client
+ * behind the admin_manage_locations policy.
+ */
+export const PATCH = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can update locations",
+  // The id used to be checked for emptiness only, which let a malformed value
+  // reach the database and come back as an unmapped driver error. A location
+  // id is a uuid, so validating it here turns that into a plain 400.
+  params: z.object({ id: z.string().uuid() }),
+  body: updateLocationBody,
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can update locations",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+  // `no_data_found`: PostgREST raises PGRST116 when the id matches no row.
+  // This route's id comes from the URL path, so an unknown one means the
+  // resource is missing rather than the input being wrong — the shared table's
+  // 404 is right and no override is needed. (It used to be a 400 carrying the
+  // driver's own "0 rows returned" text.)
 
-  const { id } = await params;
-  if (!id) {
-    return NextResponse.json({ error: "Missing id" }, { status: 400 });
-  }
+  handler: async ({ supabase, params, body }) => {
+    const { data, error } = await supabase
+      .from("locations")
+      .update(body)
+      .eq("id", params.id)
+      .select()
+      .single();
 
-  const body = await parseJsonBody(request, updateLocationBody);
-  if (body instanceof NextResponse) return body;
-
-  const { data, error } = await supabase
-    .from("locations")
-    .update(body)
-    .eq("id", id)
-    .select()
-    .single();
-
-  if (error) {
-    const status = error.code === "42501" ? 403 : 400;
-    return NextResponse.json({ error: error.message }, { status });
-  }
-  return NextResponse.json(data);
-}
+    if (error) throw error;
+    return data;
+  },
+});

--- a/src/app/api/admin/locations/create/route.ts
+++ b/src/app/api/admin/locations/create/route.ts
@@ -1,34 +1,36 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { defineRoute } from "@/lib/api/define-route";
 import { createLocationBody } from "@/services/locations/locations.contracts";
 
-// `locations` is admin-only reference data. The write runs on the USER-bound
-// client: `authenticated` holds INSERT/UPDATE on the table and the
-// admin_manage_locations policy decides who may use it, so the route's role
-// check and the database's own answer have to agree before a row lands.
+/**
+ * POST /api/admin/locations/create
+ *
+ * `locations` is admin-only reference data. The write runs on the USER-bound
+ * client: `authenticated` holds INSERT/UPDATE on the table and the
+ * admin_manage_locations policy decides who may use it, so the route's role
+ * check and the database's own answer have to agree before a row lands.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can create locations",
+  body: createLocationBody,
 
-export async function POST(request: Request) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can create locations",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+  // No per-route overrides. The route used to answer 400 for every code other
+  // than the policy refusal; the shared table is strictly better here — a
+  // duplicate name is a 409 rather than a 400, and a code nobody anticipated
+  // is a logged 500 rather than being reported to the admin as their mistake.
+  //
+  // Message disclosure stays off: this route's failures were Postgres text
+  // forwarded incidentally, never copy written for an admin to read.
 
-  const body = await parseJsonBody(request, createLocationBody);
-  if (body instanceof NextResponse) return body;
+  handler: async ({ supabase, body }) => {
+    const { data, error } = await supabase
+      .from("locations")
+      .insert(body)
+      .select()
+      .single();
 
-  const { data, error } = await supabase
-    .from("locations")
-    .insert(body)
-    .select()
-    .single();
-
-  if (error) {
-    // 42501 is PostgreSQL's own refusal (grant or policy); anything else is the
-    // payload failing a constraint.
-    const status = error.code === "42501" ? 403 : 400;
-    return NextResponse.json({ error: error.message }, { status });
-  }
-  return NextResponse.json(data);
-}
+    if (error) throw error;
+    return data;
+  },
+});

--- a/src/app/api/admin/products/[id]/groups/apply/route.ts
+++ b/src/app/api/admin/products/[id]/groups/apply/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import {
   applyGroupChangesResult,
   groupChangeSet,
@@ -18,40 +18,46 @@ import {
  * here. The legacy provisioning logic wires those up and stays available for
  * future reuse.
  */
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can manage product groups",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can manage product groups",
+  params: z.object({ id: z.string().uuid() }),
+  body: groupChangeSet,
 
-  const { id: productId } = await params;
+  // `no_data_found`: the RPC raises it for a product that is not there, and the
+  // product is named by the URL path — a missing one is a missing resource, so
+  // the shared table's 404 stands and no override is needed. Every other code
+  // the RPC can raise (constraint violations from a malformed batch) also lands
+  // on the shared table; this route used to collapse all of them to 400.
+  discloseErrorMessages:
+    "apply_group_changes raises with a written explanation of which change in the batch was refused, and the groups panel shows it verbatim beside the failed action",
 
-  const changes = await parseJsonBody(request, groupChangeSet);
-  if (changes instanceof NextResponse) return changes;
+  handler: async ({ supabase, params, body }) => {
+    const { data, error } = await supabase.rpc("apply_group_changes", {
+      p_product_id: params.id,
+      p_added_groups: body.addedGroups,
+      p_renamed_groups: body.renamedGroups,
+      p_deleted_group_ids: body.deletedGroupIds,
+      p_gedu_assignments_added: body.geduAssignmentsAdded,
+      p_gedu_assignments_removed: body.geduAssignmentsRemoved,
+      p_participation_moves: body.participationMoves,
+    });
 
-  const { data, error } = await supabase.rpc("apply_group_changes", {
-    p_product_id: productId,
-    p_added_groups: changes.addedGroups,
-    p_renamed_groups: changes.renamedGroups,
-    p_deleted_group_ids: changes.deletedGroupIds,
-    p_gedu_assignments_added: changes.geduAssignmentsAdded,
-    p_gedu_assignments_removed: changes.geduAssignmentsRemoved,
-    p_participation_moves: changes.participationMoves,
-  });
+    if (error) throw error;
 
-  if (error) {
-    // P0002 = product not found; surface as 404. Everything else is a 400
-    // (constraint violation, malformed batch) — the RPC raises with a
-    // descriptive message so we forward it.
-    const status = error.code === "P0002" ? 404 : 400;
-    return NextResponse.json({ error: error.message }, { status });
-  }
-
-  // The RPC returns `Json`; validate it really is the tempMap shape before
-  // handing it to the client (the service parses the same contract schema).
-  return NextResponse.json(applyGroupChangesResult.parse(data));
-}
+    // The RPC is typed `Json` by codegen, so the contract schema is what
+    // narrows it. A mismatch is our bug, not the caller's: a logged 500. The
+    // zod detail goes to the log rather than into the ApiError, because this
+    // route discloses its error messages and that detail is not admin copy.
+    const parsed = applyGroupChangesResult.safeParse(data);
+    if (!parsed.success) {
+      console.error(
+        "apply_group_changes returned an unexpected shape:",
+        parsed.error.message,
+      );
+      throw new ApiError("Failed to apply group changes", 500);
+    }
+    return parsed.data;
+  },
+});

--- a/src/app/api/admin/products/[id]/participations/[participationId]/route.ts
+++ b/src/app/api/admin/products/[id]/participations/[participationId]/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import {
   adminRemoveParticipationRpcResult,
   demoteToWaitlistRpcResult,
   promoteFromWaitlistRpcResult,
   waitlistTransitionBody,
 } from "@/services/participations/participations.contracts";
+
+/** Both handlers address one participation on one product, by URL path. */
+const routeParams = z.object({
+  id: z.string().uuid(),
+  participationId: z.string().uuid(),
+});
 
 /**
  * DELETE /api/admin/products/[id]/participations/[participationId]
@@ -34,98 +41,89 @@ import {
  *
  * No refund is issued: nothing here calls Stripe.
  */
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string; participationId: string }> },
-) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can remove gamers from a product",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase, user } = result;
+export const DELETE = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can remove gamers from a product",
+  params: routeParams,
 
-  const { id: productId, participationId } = await params;
+  // 55000 (object_not_in_prerequisite_state) is this route's only divergence
+  // from the shared table: it is the live-subscription refusal, which is not
+  // the admin's mistake but a broken invariant, so it stays a 500.
+  //
+  // `no_data_found`: the participation is named by the URL path, so a
+  // participation that is not on this product is a missing resource — the
+  // shared table's 404 is what this route already answered.
+  errorStatus: { "55000": 500 },
 
-  const { data, error } = await supabase.rpc("admin_remove_participation", {
-    p_product_id: productId,
-    p_participation_id: participationId,
-  });
+  handler: async ({ supabase, user, params }) => {
+    const { id: productId, participationId } = params;
 
-  if (error) {
-    if (error.code === "42501") {
-      return NextResponse.json(
-        { error: "Only admins can remove gamers from a product" },
-        { status: 403 },
-      );
+    const { data, error } = await supabase.rpc("admin_remove_participation", {
+      p_product_id: productId,
+      p_participation_id: participationId,
+    });
+
+    if (error) {
+      // Two codes carry copy the admin needs, and the shared table's generic
+      // message for the status would not tell them what to do next.
+      if (error.code === "55000") {
+        console.error(
+          JSON.stringify({
+            event: "admin_remove_gamer_blocked_live_subscription",
+            admin_id: user.id,
+            product_id: productId,
+            participation_id: participationId,
+            detail: error.message,
+            at: new Date().toISOString(),
+          }),
+        );
+        return NextResponse.json(
+          {
+            error:
+              "This participation has a live Stripe subscription and can't be removed here. Cancel the subscription first.",
+          },
+          { status: 500 },
+        );
+      }
+      if (error.code === "23514") {
+        return NextResponse.json(
+          {
+            error:
+              "Admin remove-gamer is not supported for consumer clubs (recurring billing). Cancel the subscription instead.",
+          },
+          { status: 400 },
+        );
+      }
+      throw error;
     }
-    if (error.code === "P0002") {
-      return NextResponse.json(
-        { error: "Participation not found on this product" },
-        { status: 404 },
-      );
-    }
-    // 55000 (object_not_in_prerequisite_state) is the live-subscription
-    // refusal. It means an invariant we believe holds has stopped holding, so
-    // it is logged at error level with the identifiers needed to chase it.
-    if (error.code === "55000") {
+
+    const parsed = adminRemoveParticipationRpcResult.safeParse(data);
+    if (!parsed.success) {
       console.error(
-        JSON.stringify({
-          event: "admin_remove_gamer_blocked_live_subscription",
-          admin_id: user.id,
-          product_id: productId,
-          participation_id: participationId,
-          detail: error.message,
-          at: new Date().toISOString(),
-        }),
+        "admin_remove_participation returned an unexpected shape:",
+        parsed.error.message,
       );
-      return NextResponse.json(
-        {
-          error:
-            "This participation has a live Stripe subscription and can't be removed here. Cancel the subscription first.",
-        },
-        { status: 500 },
-      );
+      throw new ApiError("Failed to remove gamer", 500);
     }
-    if (error.code === "23514") {
-      return NextResponse.json(
-        {
-          error:
-            "Admin remove-gamer is not supported for consumer clubs (recurring billing). Cancel the subscription instead.",
-        },
-        { status: 400 },
-      );
-    }
-    return NextResponse.json({ error: error.message }, { status: 400 });
-  }
 
-  const parsed = adminRemoveParticipationRpcResult.safeParse(data);
-  if (!parsed.success) {
-    console.error(
-      "admin_remove_participation returned an unexpected shape:",
-      parsed.error.message,
+    // Audit trail — mirrors admin_add_gamer so we can answer "which admin
+    // removed this gamer (and was anyone unenrolled who'd paid)?" later. Hosted
+    // log aggregation picks this up; no DB write.
+    console.info(
+      JSON.stringify({
+        event: "admin_remove_gamer",
+        admin_id: user.id,
+        product_id: productId,
+        participation_id: participationId,
+        result: parsed.data,
+        at: new Date().toISOString(),
+      }),
     );
-    return NextResponse.json(
-      { error: "Failed to remove gamer" },
-      { status: 500 },
-    );
-  }
 
-  // Audit trail — mirrors admin_add_gamer so we can answer "which admin
-  // removed this gamer (and was anyone unenrolled who'd paid)?" later. Hosted
-  // log aggregation picks this up; no DB write.
-  console.info(
-    JSON.stringify({
-      event: "admin_remove_gamer",
-      admin_id: user.id,
-      product_id: productId,
-      participation_id: participationId,
-      result: parsed.data,
-      at: new Date().toISOString(),
-    }),
-  );
-
-  return NextResponse.json({ ok: true });
-}
+    return { ok: true };
+  },
+});
 
 /**
  * PATCH /api/admin/products/[id]/participations/[participationId]
@@ -146,96 +144,87 @@ export async function DELETE(
  * where promotion would mean an unbilled active seat and demotion would strand
  * a paying subscriber on the waitlist.
  */
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string; participationId: string }> },
-) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can change waitlist status",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase, user } = result;
+export const PATCH = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can change waitlist status",
+  params: routeParams,
+  body: waitlistTransitionBody,
 
-  const { id: productId, participationId } = await params;
+  // No overrides. `no_data_found` keeps the shared 404 for the same reason as
+  // the DELETE handler: the participation is named by the URL path. The reads
+  // and the RPCs used to answer 400 with raw Postgres text for every other
+  // failure; they now go through the shared table with a generic message.
 
-  const body = await parseJsonBody(request, waitlistTransitionBody);
-  if (body instanceof NextResponse) return body;
+  handler: async ({ supabase, user, params, body }) => {
+    const { id: productId, participationId } = params;
 
-  // IDOR guard: the participation must belong to THIS product (else a
-  // participationId from another product could be transitioned via this URL).
-  const { data: participation, error: fetchError } = await supabase
-    .from("participations")
-    .select("id, product_id")
-    .eq("id", participationId)
-    .maybeSingle();
+    // IDOR guard: the participation must belong to THIS product (else a
+    // participationId from another product could be transitioned via this URL).
+    const { data: participation, error: fetchError } = await supabase
+      .from("participations")
+      .select("id, product_id")
+      .eq("id", participationId)
+      .maybeSingle();
 
-  if (fetchError) {
-    return NextResponse.json({ error: fetchError.message }, { status: 400 });
-  }
-  if (!participation || participation.product_id !== productId) {
-    return NextResponse.json(
-      { error: "Participation not found on this product" },
-      { status: 404 },
-    );
-  }
-
-  // Block consumer_club — symmetric with the add/remove gate (defense in depth).
-  const { data: product, error: productError } = await supabase
-    .from("products")
-    .select("product_type")
-    .eq("id", productId)
-    .maybeSingle();
-
-  if (productError) {
-    return NextResponse.json({ error: productError.message }, { status: 400 });
-  }
-  if (!product) {
-    return NextResponse.json({ error: "Product not found" }, { status: 404 });
-  }
-  if (product.product_type === "consumer_club") {
-    return NextResponse.json(
-      {
-        error:
-          "Waitlist promote/demote is not supported for consumer clubs (recurring billing).",
-      },
-      { status: 400 },
-    );
-  }
-
-  // Dispatch to the matching RPC and validate its Json result shape before
-  // responding (the db tests parse real RPC output through the same schemas).
-  if (body.action === "promote") {
-    const { data, error } = await supabase.rpc("promote_from_waitlist", {
-      p_participation_id: participationId,
-      p_group_id: body.groupId ?? undefined,
-    });
-    if (error) {
-      const status = error.code === "P0002" ? 404 : 400;
-      return NextResponse.json({ error: error.message }, { status });
+    if (fetchError) throw fetchError;
+    if (!participation || participation.product_id !== productId) {
+      return NextResponse.json(
+        { error: "Participation not found on this product" },
+        { status: 404 },
+      );
     }
-    promoteFromWaitlistRpcResult.parse(data);
-  } else {
-    const { data, error } = await supabase.rpc("demote_to_waitlist", {
-      p_participation_id: participationId,
-    });
-    if (error) {
-      const status = error.code === "P0002" ? 404 : 400;
-      return NextResponse.json({ error: error.message }, { status });
+
+    // Block consumer_club — symmetric with the add/remove gate (defense in depth).
+    const { data: product, error: productError } = await supabase
+      .from("products")
+      .select("product_type")
+      .eq("id", productId)
+      .maybeSingle();
+
+    if (productError) throw productError;
+    if (!product) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
     }
-    demoteToWaitlistRpcResult.parse(data);
-  }
+    if (product.product_type === "consumer_club") {
+      return NextResponse.json(
+        {
+          error:
+            "Waitlist promote/demote is not supported for consumer clubs (recurring billing).",
+        },
+        { status: 400 },
+      );
+    }
 
-  // Audit trail — mirrors admin_add_gamer / admin_remove_gamer.
-  console.info(
-    JSON.stringify({
-      event: "admin_waitlist_transition",
-      action: body.action,
-      admin_id: user.id,
-      product_id: productId,
-      participation_id: participationId,
-      at: new Date().toISOString(),
-    }),
-  );
+    // Dispatch to the matching RPC and validate its Json result shape before
+    // responding (the db tests parse real RPC output through the same schemas).
+    if (body.action === "promote") {
+      const { data, error } = await supabase.rpc("promote_from_waitlist", {
+        p_participation_id: participationId,
+        p_group_id: body.groupId ?? undefined,
+      });
+      if (error) throw error;
+      promoteFromWaitlistRpcResult.parse(data);
+    } else {
+      const { data, error } = await supabase.rpc("demote_to_waitlist", {
+        p_participation_id: participationId,
+      });
+      if (error) throw error;
+      demoteToWaitlistRpcResult.parse(data);
+    }
 
-  return NextResponse.json({ ok: true });
-}
+    // Audit trail — mirrors admin_add_gamer / admin_remove_gamer.
+    console.info(
+      JSON.stringify({
+        event: "admin_waitlist_transition",
+        action: body.action,
+        admin_id: user.id,
+        product_id: productId,
+        participation_id: participationId,
+        at: new Date().toISOString(),
+      }),
+    );
+
+    return { ok: true };
+  },
+});

--- a/src/app/api/admin/products/[id]/participations/route.ts
+++ b/src/app/api/admin/products/[id]/participations/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
-import { adminEnrollGamerRpcResult } from "@/services/participations/participations.contracts";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
+import {
+  adminEnrollGamerBody,
+  adminEnrollGamerRpcResult,
+} from "@/services/participations/participations.contracts";
 
 /**
  * POST /api/admin/products/[id]/participations
@@ -20,76 +23,65 @@ import { adminEnrollGamerRpcResult } from "@/services/participations/participati
  * hold for any admin calling it, not only for requests that came through this
  * handler.
  */
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can add gamers directly to a product",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase, user } = result;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can add gamers directly to a product",
+  params: z.object({ id: z.string().uuid() }),
+  body: adminEnrollGamerBody,
 
-  const { id: productId } = await params;
+  // Every code this RPC raises already lands where this route used to put it:
+  // the already-enrolled unique violation on 409, the guard's refusal on 403,
+  // and `no_data_found` on 404. That last one is the per-route decision — the
+  // product is named by the URL path, so "the product does not exist" is a
+  // missing resource rather than a malformed field, and the shared 404 is
+  // right. What changes is the fall-through: an unrecognized code used to be
+  // reported to the admin as a 400 carrying raw Postgres text, and is now a
+  // logged 500, because an error nobody anticipated is a server error.
 
-  const body = await parseJsonBody(
-    request,
-    z.object({ gamerId: z.string().min(1, "gamerId is required") }),
-  );
-  if (body instanceof NextResponse) return body;
-  const { gamerId } = body;
+  handler: async ({ supabase, user, params, body }) => {
+    const { data, error } = await supabase.rpc("admin_enroll_gamer", {
+      p_product_id: params.id,
+      p_gamer_id: body.gamerId,
+    });
 
-  const { data, error } = await supabase.rpc("admin_enroll_gamer", {
-    p_product_id: productId,
-    p_gamer_id: gamerId,
-  });
+    if (error) {
+      // The one code carrying copy the admin needs: the shared table's bare
+      // "Conflict" would not tell them the gamer is already on the product.
+      if (error.code === "23505") {
+        return NextResponse.json(
+          { error: "This gamer is already enrolled on the product" },
+          { status: 409 },
+        );
+      }
+      throw error;
+    }
 
-  if (error) {
-    // 23505 = the partial unique index on (product_id, gamer_id) for
-    // non-reserving statuses fired — the gamer is already enrolled (active,
-    // waitlisted, or completed).
-    if (error.code === "23505") {
-      return NextResponse.json(
-        { error: "This gamer is already enrolled on the product" },
-        { status: 409 },
+    const parsed = adminEnrollGamerRpcResult.safeParse(data);
+    if (!parsed.success) {
+      console.error(
+        "admin_enroll_gamer returned an unexpected shape:",
+        parsed.error.message,
       );
+      throw new ApiError("Failed to enroll gamer", 500);
     }
-    if (error.code === "42501") {
-      return NextResponse.json(
-        { error: "Only admins can add gamers directly to a product" },
-        { status: 403 },
-      );
-    }
-    if (error.code === "P0002") {
-      return NextResponse.json({ error: "Product not found" }, { status: 404 });
-    }
-    return NextResponse.json({ error: error.message }, { status: 400 });
-  }
 
-  const parsed = adminEnrollGamerRpcResult.safeParse(data);
-  if (!parsed.success) {
-    console.error(
-      "admin_enroll_gamer returned an unexpected shape:",
-      parsed.error.message,
+    // Audit log line — there's no audit column on participations per the product
+    // spec, but a server-side trail is necessary so we can answer "which admin
+    // comped this gamer onto this product?" later. Hosted log aggregation picks
+    // this up; no DB write.
+    console.info(
+      JSON.stringify({
+        event: "admin_add_gamer",
+        admin_id: user.id,
+        product_id: params.id,
+        gamer_id: body.gamerId,
+        customer_id: parsed.data.customer_id,
+        participation_id: parsed.data.participation_id,
+        at: new Date().toISOString(),
+      }),
     );
-    return NextResponse.json({ error: "Failed to enroll gamer" }, { status: 500 });
-  }
 
-  // Audit log line — there's no audit column on participations per the product
-  // spec, but a server-side trail is necessary so we can answer "which admin
-  // comped this gamer onto this product?" later. Hosted log aggregation picks
-  // this up; no DB write.
-  console.info(
-    JSON.stringify({
-      event: "admin_add_gamer",
-      admin_id: user.id,
-      product_id: productId,
-      gamer_id: gamerId,
-      customer_id: parsed.data.customer_id,
-      participation_id: parsed.data.participation_id,
-      at: new Date().toISOString(),
-    }),
-  );
-
-  return NextResponse.json({ participation_id: parsed.data.participation_id });
-}
+    return { participation_id: parsed.data.participation_id };
+  },
+});

--- a/src/app/api/admin/products/[id]/update/route.ts
+++ b/src/app/api/admin/products/[id]/update/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
-import { requireRole } from "@/lib/auth";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import { parseBodyValue } from "@/lib/api/json-body.server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { updateProductData } from "@/services/products/products.contracts";
@@ -40,174 +42,184 @@ function resolveUploadMeta(
   return { path: `${randomUUID()}.${normalised}`, contentType };
 }
 
-export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
+/**
+ * POST /api/admin/products/[id]/update — multipart, same shape as the create
+ * route: a JSON `data` field beside an optional image `file`.
+ *
+ * No body schema is declared on the primitive, which is what leaves the request
+ * stream untouched so this handler can read the form itself; the `data` field
+ * is then validated through the same contract schema a JSON route would use.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can update products",
+  params: z.object({ id: z.string().uuid() }),
 
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can update products",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+  // Same shape as the create route: every database failure is turned into
+  // admin-facing copy inside the handler, so the disclosure opt-in below only
+  // ever forwards text written for an admin to read.
+  discloseErrorMessages:
+    "update_product's own RAISE messages are the admin-facing explanation of a refused update, and the product form shows them verbatim; the two native codes it can also raise are given written explanations first",
 
-  let formData: FormData;
-  try {
-    formData = await request.formData();
-  } catch {
-    return NextResponse.json(
-      { error: "Request must be multipart/form-data" },
-      { status: 400 },
-    );
-  }
+  handler: async ({ request, supabase, params }) => {
+    const { id } = params;
 
-  const dataField = formData.get("data");
-  if (typeof dataField !== "string") {
-    return NextResponse.json({ error: "Missing 'data' field" }, { status: 400 });
-  }
-
-  let raw: unknown;
-  try {
-    raw = JSON.parse(dataField);
-  } catch {
-    return NextResponse.json(
-      { error: "'data' field must be valid JSON" },
-      { status: 400 },
-    );
-  }
-  const body = parseBodyValue(raw, updateProductData);
-  if (body instanceof NextResponse) return body;
-
-  const file = formData.get("file");
-  const hasNewImage = file instanceof File;
-  if (hasNewImage && file.size > MAX_FILE_BYTES) {
-    return NextResponse.json(
-      { error: "Image must be 5 MB or smaller" },
-      { status: 413 },
-    );
-  }
-  const uploadMeta = hasNewImage ? resolveUploadMeta(file) : null;
-  if (hasNewImage && !uploadMeta) {
-    return NextResponse.json(
-      { error: "Unsupported file type. Use JPEG, PNG, WEBP, AVIF, or SVG." },
-      { status: 415 },
-    );
-  }
-
-  const clearImage = formData.get("clear_image") === "true";
-
-  // Read existing image_path so we know what blob (if any) to delete on a
-  // successful replace/clear. Doubles as a "does this product exist" check
-  // before we bother uploading anything.
-  const admin = createAdminClient();
-  const { data: existing, error: readError } = await admin
-    .from("products")
-    .select("image_path")
-    .eq("id", id)
-    .maybeSingle();
-  if (readError) {
-    return NextResponse.json({ error: readError.message }, { status: 400 });
-  }
-  if (!existing) {
-    return NextResponse.json({ error: "Product not found" }, { status: 404 });
-  }
-  const existingPath = existing.image_path;
-
-  // Upload the new blob FIRST so the RPC can commit image_path atomically
-  // with the rest of the update. If the RPC then fails, we delete the
-  // newly-uploaded blob to avoid an orphan in the bucket. Mirrors the
-  // legacy update-product route.
-  if (hasNewImage && uploadMeta) {
-    const { error: uploadError } = await admin.storage
-      .from("product-images")
-      .upload(uploadMeta.path, file, {
-        contentType: uploadMeta.contentType,
-        upsert: false,
-      });
-    if (uploadError) {
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch {
       return NextResponse.json(
-        { error: uploadError.message },
-        { status: 500 },
+        { error: "Request must be multipart/form-data" },
+        { status: 400 },
       );
     }
-  }
 
-  // Final image_path to commit. We deliberately don't trust any path
-  // string from the client — the existing path comes from the DB and the
-  // new path comes from the just-uploaded blob.
-  const finalImagePath: string | null = uploadMeta
-    ? uploadMeta.path
-    : clearImage
-      ? null
-      : existingPath;
-
-  // p_image_path's DEFAULT is NULL, so omitting it (undefined) and passing
-  // NULL produce the same effect — image_path is wiped. The cleared case
-  // (finalImagePath === null) and the "no DEFAULT for a nullable string"
-  // RpcArgs typing both land on undefined here.
-  const rpcArgs: RpcArgs = {
-    p_id: id,
-    p_billing_mode: body.billing_mode,
-    p_translations: body.translations,
-    p_topic: body.topic,
-    p_min_age: body.min_age,
-    p_max_age: body.max_age,
-    p_spoken_language_code: body.spoken_language_code,
-    p_is_remote: body.is_remote,
-    p_timezone: body.timezone,
-    p_registration_opens_at: body.registration_opens_at,
-    p_is_visible: body.is_visible,
-    p_waitlist_enabled: body.waitlist_enabled,
-    p_image_path: finalImagePath ?? undefined,
-    p_padlet_url: body.padlet_url ?? undefined,
-    p_location_id: body.location_id ?? undefined,
-    p_signup_threshold: body.signup_threshold ?? undefined,
-    p_start_date: body.start_date ?? undefined,
-    p_end_date: body.end_date ?? undefined,
-    p_seat_count: body.seat_count ?? undefined,
-    p_refund_policy_days: body.refund_policy_days ?? undefined,
-    p_schedule_slots: body.schedule_slots,
-    p_prices: body.prices,
-    p_holiday_calendar_ids: body.holiday_calendar_ids,
-    // null (unknown/none) maps to undefined so the RPC's DEFAULT NULL clears
-    // the column; 0 (volunteer) survives `??` since it's not nullish.
-    p_primary_gedu_fee_cents: body.primary_gedu_fee_cents ?? undefined,
-    p_assistant_gedu_fee_cents: body.assistant_gedu_fee_cents ?? undefined,
-    p_municipality_fee_cents: body.municipality_fee_cents ?? undefined,
-  };
-
-  const { data: productId, error: rpcError } = await supabase.rpc(
-    "update_product",
-    rpcArgs,
-  );
-
-  if (rpcError) {
-    if (uploadMeta) {
-      await admin.storage.from("product-images").remove([uploadMeta.path]);
+    const dataField = formData.get("data");
+    if (typeof dataField !== "string") {
+      return NextResponse.json(
+        { error: "Missing 'data' field" },
+        { status: 400 },
+      );
     }
-    return NextResponse.json(
-      { error: friendlyRpcError(rpcError) },
-      { status: 400 },
-    );
-  }
-  if (!productId) {
-    if (uploadMeta) {
-      await admin.storage.from("product-images").remove([uploadMeta.path]);
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(dataField);
+    } catch {
+      return NextResponse.json(
+        { error: "'data' field must be valid JSON" },
+        { status: 400 },
+      );
     }
-    return NextResponse.json(
-      { error: "Failed to update product" },
-      { status: 500 },
+    const body = parseBodyValue(raw, updateProductData);
+    if (body instanceof NextResponse) return body;
+
+    const file = formData.get("file");
+    const hasNewImage = file instanceof File;
+    if (hasNewImage && file.size > MAX_FILE_BYTES) {
+      return NextResponse.json(
+        { error: "Image must be 5 MB or smaller" },
+        { status: 413 },
+      );
+    }
+    const uploadMeta = hasNewImage ? resolveUploadMeta(file) : null;
+    if (hasNewImage && !uploadMeta) {
+      return NextResponse.json(
+        { error: "Unsupported file type. Use JPEG, PNG, WEBP, AVIF, or SVG." },
+        { status: 415 },
+      );
+    }
+
+    const clearImage = formData.get("clear_image") === "true";
+
+    // Read existing image_path so we know what blob (if any) to delete on a
+    // successful replace/clear. Doubles as a "does this product exist" check
+    // before we bother uploading anything.
+    const admin = createAdminClient();
+    const { data: existing, error: readError } = await admin
+      .from("products")
+      .select("image_path")
+      .eq("id", id)
+      .maybeSingle();
+    if (readError) {
+      console.error("[products/update] image_path read failed", readError);
+      throw new ApiError("Could not read the product. Please try again.", 500);
+    }
+    if (!existing) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
+    }
+    const existingPath = existing.image_path;
+
+    // Upload the new blob FIRST so the RPC can commit image_path atomically
+    // with the rest of the update. If the RPC then fails, we delete the
+    // newly-uploaded blob to avoid an orphan in the bucket.
+    if (hasNewImage && uploadMeta) {
+      const { error: uploadError } = await admin.storage
+        .from("product-images")
+        .upload(uploadMeta.path, file, {
+          contentType: uploadMeta.contentType,
+          upsert: false,
+        });
+      if (uploadError) {
+        console.error("[products/update] image upload failed", uploadError);
+        throw new ApiError(
+          "The image could not be uploaded. Please try again.",
+          500,
+        );
+      }
+    }
+
+    // Final image_path to commit. We deliberately don't trust any path string
+    // from the client — the existing path comes from the DB and the new path
+    // comes from the just-uploaded blob.
+    const finalImagePath: string | null = uploadMeta
+      ? uploadMeta.path
+      : clearImage
+        ? null
+        : existingPath;
+
+    // p_image_path's DEFAULT is NULL, so omitting it (undefined) and passing
+    // NULL produce the same effect — image_path is wiped. The cleared case
+    // (finalImagePath === null) and the "no DEFAULT for a nullable string"
+    // RpcArgs typing both land on undefined here.
+    const rpcArgs: RpcArgs = {
+      p_id: id,
+      p_billing_mode: body.billing_mode,
+      p_translations: body.translations,
+      p_topic: body.topic,
+      p_min_age: body.min_age,
+      p_max_age: body.max_age,
+      p_spoken_language_code: body.spoken_language_code,
+      p_is_remote: body.is_remote,
+      p_timezone: body.timezone,
+      p_registration_opens_at: body.registration_opens_at,
+      p_is_visible: body.is_visible,
+      p_waitlist_enabled: body.waitlist_enabled,
+      p_image_path: finalImagePath ?? undefined,
+      p_padlet_url: body.padlet_url ?? undefined,
+      p_location_id: body.location_id ?? undefined,
+      p_signup_threshold: body.signup_threshold ?? undefined,
+      p_start_date: body.start_date ?? undefined,
+      p_end_date: body.end_date ?? undefined,
+      p_seat_count: body.seat_count ?? undefined,
+      p_refund_policy_days: body.refund_policy_days ?? undefined,
+      p_schedule_slots: body.schedule_slots,
+      p_prices: body.prices,
+      p_holiday_calendar_ids: body.holiday_calendar_ids,
+      // null (unknown/none) maps to undefined so the RPC's DEFAULT NULL clears
+      // the column; 0 (volunteer) survives `??` since it's not nullish.
+      p_primary_gedu_fee_cents: body.primary_gedu_fee_cents ?? undefined,
+      p_assistant_gedu_fee_cents: body.assistant_gedu_fee_cents ?? undefined,
+      p_municipality_fee_cents: body.municipality_fee_cents ?? undefined,
+    };
+
+    const { data: productId, error: rpcError } = await supabase.rpc(
+      "update_product",
+      rpcArgs,
     );
-  }
 
-  // Delete the old blob if its path is no longer referenced. Storage and
-  // DB are separate systems, so this cleanup happens after the RPC
-  // succeeds; if it fails we accept an orphan rather than rolling back
-  // the (now-committed) DB update.
-  if (existingPath && existingPath !== finalImagePath) {
-    await admin.storage.from("product-images").remove([existingPath]);
-  }
+    if (rpcError) {
+      if (uploadMeta) {
+        await admin.storage.from("product-images").remove([uploadMeta.path]);
+      }
+      throw new ApiError(friendlyRpcError(rpcError), 400);
+    }
+    if (!productId) {
+      if (uploadMeta) {
+        await admin.storage.from("product-images").remove([uploadMeta.path]);
+      }
+      throw new ApiError("Failed to update product", 500);
+    }
 
-  return NextResponse.json({ product_id: productId });
-}
+    // Delete the old blob if its path is no longer referenced. Storage and DB
+    // are separate systems, so this cleanup happens after the RPC succeeds; if
+    // it fails we accept an orphan rather than rolling back the (now-committed)
+    // DB update.
+    if (existingPath && existingPath !== finalImagePath) {
+      await admin.storage.from("product-images").remove([existingPath]);
+    }
+
+    return { product_id: productId };
+  },
+});

--- a/src/app/api/admin/products/create/route.ts
+++ b/src/app/api/admin/products/create/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import { parseBodyValue } from "@/lib/api/json-body.server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createProductData } from "@/services/products/products.contracts";
@@ -34,7 +35,7 @@ function friendlyRpcError(err: { code?: string; message: string }): string {
 }
 
 function resolveUploadMeta(
-  file: File
+  file: File,
 ): { path: string; contentType: string } | null {
   const ext = (file.name.split(".").pop() ?? "").toLowerCase();
   const contentType = EXT_TO_MIME[ext];
@@ -43,145 +44,156 @@ function resolveUploadMeta(
   return { path: `${randomUUID()}.${normalised}`, contentType };
 }
 
-export async function POST(request: Request) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can create products",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+/**
+ * POST /api/admin/products/create — multipart: a JSON `data` field beside an
+ * optional image `file`.
+ *
+ * No body schema is declared on the primitive, which is what leaves the request
+ * stream untouched so this handler can read the form itself; the `data` field
+ * is then validated through the same contract schema a JSON route would use.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can create products",
 
-  let formData: FormData;
-  try {
-    formData = await request.formData();
-  } catch {
-    return NextResponse.json(
-      { error: "Request must be multipart/form-data" },
-      { status: 400 }
-    );
-  }
+  // Every database failure here is turned into admin-facing copy before it
+  // leaves the handler: the two native codes get written explanations, and our
+  // own RPC's RAISE messages already are the explanation. That is what the
+  // disclosure opt-in below covers — no raw driver text reaches the client,
+  // because nothing raw is thrown past this handler.
+  discloseErrorMessages:
+    "create_product's own RAISE messages are the admin-facing explanation of a refused create, and the product form shows them verbatim; the two native codes it can also raise are given written explanations first",
 
-  const dataField = formData.get("data");
-  if (typeof dataField !== "string") {
-    return NextResponse.json({ error: "Missing 'data' field" }, { status: 400 });
-  }
-
-  let raw: unknown;
-  try {
-    raw = JSON.parse(dataField);
-  } catch {
-    return NextResponse.json(
-      { error: "'data' field must be valid JSON" },
-      { status: 400 }
-    );
-  }
-  const body = parseBodyValue(raw, createProductData);
-  if (body instanceof NextResponse) return body;
-
-  const file = formData.get("file");
-  const hasImage = file instanceof File;
-  if (hasImage && file.size > MAX_FILE_BYTES) {
-    return NextResponse.json(
-      { error: "Image must be 5 MB or smaller" },
-      { status: 413 }
-    );
-  }
-  const uploadMeta = hasImage ? resolveUploadMeta(file) : null;
-  if (hasImage && !uploadMeta) {
-    return NextResponse.json(
-      { error: "Unsupported file type. Use JPEG, PNG, WEBP, AVIF, or SVG." },
-      { status: 415 }
-    );
-  }
-
-  // Build RPC args. Nullable fields go in as undefined so the RPC uses its
-  // DEFAULT NULL. Semantic validation beyond the contract schema's shapes
-  // lives in the DB (CHECK constraints + location trigger on products).
-  const rpcArgs: RpcArgs = {
-    p_product_type: body.product_type,
-    p_billing_mode: body.billing_mode,
-    p_translations: body.translations,
-    p_topic: body.topic,
-    p_min_age: body.min_age,
-    p_max_age: body.max_age,
-    p_spoken_language_code: body.spoken_language_code,
-    p_is_remote: body.is_remote,
-    p_timezone: body.timezone,
-    p_status: body.status,
-    p_is_visible: body.is_visible,
-    p_waitlist_enabled: body.waitlist_enabled,
-    p_padlet_url: body.padlet_url ?? undefined,
-    p_location_id: body.location_id ?? undefined,
-    p_signup_threshold: body.signup_threshold ?? undefined,
-    p_start_date: body.start_date ?? undefined,
-    p_end_date: body.end_date ?? undefined,
-    p_seat_count: body.seat_count ?? undefined,
-    p_registration_opens_at: body.registration_opens_at,
-    p_refund_policy_days: body.refund_policy_days ?? undefined,
-    p_schedule_slots: body.schedule_slots,
-    p_prices: body.prices,
-    p_holiday_calendar_ids: body.holiday_calendar_ids,
-    p_primary_gedu_fee_cents: body.primary_gedu_fee_cents ?? undefined,
-    p_assistant_gedu_fee_cents: body.assistant_gedu_fee_cents ?? undefined,
-    p_municipality_fee_cents: body.municipality_fee_cents ?? undefined,
-  };
-
-  // Call RPC through the user's session client — SECURITY INVOKER means
-  // get_user_role() needs auth.uid() populated. RLS on each table gates the
-  // inserts; the explicit admin check inside the RPC is belt-and-suspenders.
-  const { data: productId, error: rpcError } = await supabase.rpc(
-    "create_product",
-    rpcArgs
-  );
-
-  if (rpcError) {
-    // The form validates everything client-side, so RPC errors here are
-    // mostly race conditions (an admin deleted a location / holiday calendar
-    // between page load and submit). Translate Postgres native error
-    // codes to actionable messages; RAISE EXCEPTION messages from our
-    // own functions are already user-friendly and pass through.
-    return NextResponse.json(
-      { error: friendlyRpcError(rpcError) },
-      { status: 400 }
-    );
-  }
-  if (!productId) {
-    return NextResponse.json(
-      { error: "Failed to create product" },
-      { status: 500 }
-    );
-  }
-
-  // Image-last pattern: if the RPC succeeded but upload or path-update fails,
-  // we return a soft warning. The product exists and is editable — admin can
-  // retry the image on the edit page. No orphan-image cleanup needed.
-  if (hasImage && uploadMeta) {
-    const admin = createAdminClient();
-    const { error: uploadError } = await admin.storage
-      .from("product-images")
-      .upload(uploadMeta.path, file, {
-        contentType: uploadMeta.contentType,
-        upsert: false,
-      });
-
-    if (uploadError) {
-      return NextResponse.json({
-        product_id: productId,
-        warning: `Product created but image upload failed: ${uploadError.message}. Retry from the edit page.`,
-      });
+  handler: async ({ request, supabase }) => {
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch {
+      return NextResponse.json(
+        { error: "Request must be multipart/form-data" },
+        { status: 400 },
+      );
     }
 
-    const { error: updateError } = await supabase
-      .from("products")
-      .update({ image_path: uploadMeta.path })
-      .eq("id", productId);
-
-    if (updateError) {
-      return NextResponse.json({
-        product_id: productId,
-        warning: `Product created and image uploaded but DB update failed: ${updateError.message}. Retry from the edit page.`,
-      });
+    const dataField = formData.get("data");
+    if (typeof dataField !== "string") {
+      return NextResponse.json(
+        { error: "Missing 'data' field" },
+        { status: 400 },
+      );
     }
-  }
 
-  return NextResponse.json({ product_id: productId });
-}
+    let raw: unknown;
+    try {
+      raw = JSON.parse(dataField);
+    } catch {
+      return NextResponse.json(
+        { error: "'data' field must be valid JSON" },
+        { status: 400 },
+      );
+    }
+    const body = parseBodyValue(raw, createProductData);
+    if (body instanceof NextResponse) return body;
+
+    const file = formData.get("file");
+    const hasImage = file instanceof File;
+    if (hasImage && file.size > MAX_FILE_BYTES) {
+      return NextResponse.json(
+        { error: "Image must be 5 MB or smaller" },
+        { status: 413 },
+      );
+    }
+    const uploadMeta = hasImage ? resolveUploadMeta(file) : null;
+    if (hasImage && !uploadMeta) {
+      return NextResponse.json(
+        { error: "Unsupported file type. Use JPEG, PNG, WEBP, AVIF, or SVG." },
+        { status: 415 },
+      );
+    }
+
+    // Build RPC args. Nullable fields go in as undefined so the RPC uses its
+    // DEFAULT NULL. Semantic validation beyond the contract schema's shapes
+    // lives in the DB (CHECK constraints + location trigger on products).
+    const rpcArgs: RpcArgs = {
+      p_product_type: body.product_type,
+      p_billing_mode: body.billing_mode,
+      p_translations: body.translations,
+      p_topic: body.topic,
+      p_min_age: body.min_age,
+      p_max_age: body.max_age,
+      p_spoken_language_code: body.spoken_language_code,
+      p_is_remote: body.is_remote,
+      p_timezone: body.timezone,
+      p_status: body.status,
+      p_is_visible: body.is_visible,
+      p_waitlist_enabled: body.waitlist_enabled,
+      p_padlet_url: body.padlet_url ?? undefined,
+      p_location_id: body.location_id ?? undefined,
+      p_signup_threshold: body.signup_threshold ?? undefined,
+      p_start_date: body.start_date ?? undefined,
+      p_end_date: body.end_date ?? undefined,
+      p_seat_count: body.seat_count ?? undefined,
+      p_registration_opens_at: body.registration_opens_at,
+      p_refund_policy_days: body.refund_policy_days ?? undefined,
+      p_schedule_slots: body.schedule_slots,
+      p_prices: body.prices,
+      p_holiday_calendar_ids: body.holiday_calendar_ids,
+      p_primary_gedu_fee_cents: body.primary_gedu_fee_cents ?? undefined,
+      p_assistant_gedu_fee_cents: body.assistant_gedu_fee_cents ?? undefined,
+      p_municipality_fee_cents: body.municipality_fee_cents ?? undefined,
+    };
+
+    // Call the RPC through the user's session client — SECURITY INVOKER means
+    // the role lookup needs auth.uid() populated. RLS on each table gates the
+    // inserts; the explicit admin check inside the RPC is belt-and-suspenders.
+    const { data: productId, error: rpcError } = await supabase.rpc(
+      "create_product",
+      rpcArgs,
+    );
+
+    if (rpcError) {
+      // The form validates everything client-side, so RPC errors here are
+      // mostly race conditions (an admin deleted a location / holiday calendar
+      // between page load and submit).
+      throw new ApiError(friendlyRpcError(rpcError), 400);
+    }
+    if (!productId) {
+      throw new ApiError("Failed to create product", 500);
+    }
+
+    // Image-last pattern: if the RPC succeeded but upload or path-update fails,
+    // we return a soft warning. The product exists and is editable — the admin
+    // can retry the image on the edit page. No orphan-image cleanup needed.
+    if (hasImage && uploadMeta) {
+      const admin = createAdminClient();
+      const { error: uploadError } = await admin.storage
+        .from("product-images")
+        .upload(uploadMeta.path, file, {
+          contentType: uploadMeta.contentType,
+          upsert: false,
+        });
+
+      if (uploadError) {
+        return {
+          product_id: productId,
+          warning: `Product created but image upload failed: ${uploadError.message}. Retry from the edit page.`,
+        };
+      }
+
+      const { error: updateError } = await supabase
+        .from("products")
+        .update({ image_path: uploadMeta.path })
+        .eq("id", productId);
+
+      if (updateError) {
+        return {
+          product_id: productId,
+          warning: `Product created and image uploaded but DB update failed: ${updateError.message}. Retry from the edit page.`,
+        };
+      }
+    }
+
+    return { product_id: productId };
+  },
+});

--- a/src/app/api/admin/send-test-email/route.ts
+++ b/src/app/api/admin/send-test-email/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
 import { sendTransactionalEmail } from "@/lib/brevo";
 import { SENDER_EMAIL } from "@/lib/constants";
 import { templateRegistry } from "@/lib/email-templates/registry";
@@ -7,7 +8,6 @@ import { getEmailTranslator } from "@/lib/email-templates/translator";
 import { escapeHtml } from "@/lib/email-templates/utils";
 import { parseEmails } from "@/lib/utils";
 import { resolveLocale } from "@/lib/constants/locales";
-import { z } from "zod";
 
 // --- Request schemas ---
 
@@ -32,25 +32,25 @@ const templateSchema = z.object({
 
 const requestSchema = z.discriminatedUnion("mode", [customSchema, templateSchema]);
 
-export async function POST(request: Request) {
-  try {
-    const result = await requireRole("admin", {
-      forbiddenMessage: "Only admins can send test emails",
-    });
-    if (result instanceof NextResponse) return result;
+/**
+ * POST /api/admin/send-test-email
+ *
+ * The admin email-preview harness: render either a hand-written message or a
+ * registered template, and send it through the transactional provider.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can send test emails",
+  body: requestSchema,
 
-    const body = await request.json();
-    const parsed = requestSchema.safeParse(body);
+  // No database calls, so the shared error table never comes into play. What
+  // changes is the catch-all: a provider failure used to be returned to the
+  // admin as a 500 carrying the thrown message, which is the incidental
+  // forwarding shape. It is now logged and answered generically.
 
-    if (!parsed.success) {
-      const firstError = parsed.error.errors[0];
-      return NextResponse.json(
-        { error: `${firstError.path.join(".")}: ${firstError.message}` },
-        { status: 400 },
-      );
-    }
-
-    const toEmails = parseEmails(parsed.data.toEmail);
+  handler: async ({ body }) => {
+    const toEmails = parseEmails(body.toEmail);
     const emailSchema = z.string().email();
     for (const email of toEmails) {
       if (!emailSchema.safeParse(email).success) {
@@ -66,21 +66,21 @@ export async function POST(request: Request) {
     let htmlContent: string;
     let replyToEmail: string | undefined;
 
-    if (parsed.data.mode === "custom") {
-      fromName = parsed.data.fromName;
-      subject = parsed.data.subject;
-      replyToEmail = parsed.data.replyToEmail;
-      htmlContent = escapeHtml(parsed.data.body).replace(/\n/g, "<br/>");
+    if (body.mode === "custom") {
+      fromName = body.fromName;
+      subject = body.subject;
+      replyToEmail = body.replyToEmail;
+      htmlContent = escapeHtml(body.body).replace(/\n/g, "<br/>");
     } else {
-      if (!(parsed.data.template in templateRegistry)) {
+      if (!(body.template in templateRegistry)) {
         return NextResponse.json(
-          { error: `Unknown template: ${parsed.data.template}` },
+          { error: `Unknown template: ${body.template}` },
           { status: 400 },
         );
       }
-      const tmpl = templateRegistry[parsed.data.template];
+      const tmpl = templateRegistry[body.template];
 
-      const paramsParsed = tmpl.schema.safeParse(parsed.data.params);
+      const paramsParsed = tmpl.schema.safeParse(body.params);
       if (!paramsParsed.success) {
         const firstError = paramsParsed.error.errors[0];
         return NextResponse.json(
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
         );
       }
 
-      const locale = resolveLocale(parsed.data.locale);
+      const locale = resolveLocale(body.locale);
       const t = await getEmailTranslator(locale);
 
       fromName = t(tmpl.fromNameKey);
@@ -107,10 +107,6 @@ export async function POST(request: Request) {
       replyToEmail,
     });
 
-    return NextResponse.json({ messageId: emailResult.messageId });
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Internal server error";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+    return { messageId: emailResult.messageId };
+  },
+});

--- a/src/app/api/admin/site-notes/route.ts
+++ b/src/app/api/admin/site-notes/route.ts
@@ -1,53 +1,55 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
-import { updateSiteNotesBody } from "@/services/products/reference-data.contracts";
+import { defineRoute } from "@/lib/api/define-route";
+import {
+  updateSiteNotesBody,
+  updateSiteNotesResponse,
+} from "@/services/products/reference-data.contracts";
 
-// PATCH /api/admin/site-notes
-// Body: { location_id, member?: { address?, notes? }, staff?: { notes? } }
-//
-// Upserts the corresponding site_details / site_staff_details row by
-// location_id. Either side is optional; sending only the half that's being
-// edited keeps the request shape obvious. RLS already restricts both writes
-// to admin, so no extra gating beyond requireRole is needed.
+/**
+ * PATCH /api/admin/site-notes
+ *
+ * Upserts the corresponding site_details / site_staff_details row by
+ * location_id. Either side is optional; sending only the half that's being
+ * edited keeps the request shape obvious. RLS already restricts both writes
+ * to admin, so no extra gating beyond the role posture is needed.
+ */
+export const PATCH = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can edit site notes",
+  body: updateSiteNotesBody,
+  response: updateSiteNotesResponse,
 
-export async function PATCH(request: Request) {
-  const result = await requireRole("admin", {
-    forbiddenMessage: "Only admins can edit site notes",
-  });
-  if (result instanceof NextResponse) return result;
-  const { supabase } = result;
+  // No overrides and no disclosure. Both upserts used to answer 400 carrying
+  // the driver's own text for any failure; on the shared table a policy refusal
+  // is a 403, a bad location_id is a 400 foreign-key violation, and anything
+  // unrecognized is a logged 500.
 
-  const body = await parseJsonBody(request, updateSiteNotesBody);
-  if (body instanceof NextResponse) return body;
-  const locationId = body.location_id;
+  handler: async ({ supabase, body }) => {
+    const locationId = body.location_id;
 
-  if (body.member) {
-    const memberRow = {
-      location_id: locationId,
-      address: body.member.address?.trim() || null,
-      notes: body.member.notes?.trim() || null,
-    };
-    const { error } = await supabase
-      .from("site_details")
-      .upsert(memberRow, { onConflict: "location_id" });
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
+    if (body.member) {
+      const { error } = await supabase.from("site_details").upsert(
+        {
+          location_id: locationId,
+          address: body.member.address?.trim() || null,
+          notes: body.member.notes?.trim() || null,
+        },
+        { onConflict: "location_id" },
+      );
+      if (error) throw error;
     }
-  }
 
-  if (body.staff) {
-    const staffRow = {
-      location_id: locationId,
-      notes: body.staff.notes?.trim() || null,
-    };
-    const { error } = await supabase
-      .from("site_staff_details")
-      .upsert(staffRow, { onConflict: "location_id" });
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
+    if (body.staff) {
+      const { error } = await supabase.from("site_staff_details").upsert(
+        {
+          location_id: locationId,
+          notes: body.staff.notes?.trim() || null,
+        },
+        { onConflict: "location_id" },
+      );
+      if (error) throw error;
     }
-  }
 
-  return NextResponse.json({ ok: true });
-}
+    return { ok: true } as const;
+  },
+});

--- a/src/app/api/admin/whatsapp/send/route.ts
+++ b/src/app/api/admin/whatsapp/send/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { sendWhatsAppMessage } from "@/lib/whatsapp";
-import { WHATSAPP_DIRECTION, WHATSAPP_MESSAGE_STATUS } from "@/types";
 import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { sendWhatsAppMessage } from "@/lib/whatsapp";
+import { sendWhatsAppResponse } from "@/services/whatsapp/whatsapp.contracts";
+import { WHATSAPP_DIRECTION, WHATSAPP_MESSAGE_STATUS } from "@/types";
 
 const requestSchema = z.object({
   // No format validation — `to` always comes from a whatsapp_contacts row
@@ -11,43 +11,36 @@ const requestSchema = z.object({
   body: z.string().min(1).max(4096),
 });
 
-export async function POST(request: Request) {
-  try {
-    const result = await requireRole("admin", {
-      forbiddenMessage: "Only admins can send WhatsApp messages",
-    });
-    if (result instanceof NextResponse) return result;
-    const { supabase } = result;
+/**
+ * POST /api/admin/whatsapp/send
+ *
+ * Sends an outbound text through the Graph API, then records it. Neither DB
+ * write fails the request: the message is already at Meta by then, so a 500
+ * would tell the admin their message didn't send when it did.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "admin",
+  forbiddenMessage: "Only admins can send WhatsApp messages",
+  body: requestSchema,
+  response: sendWhatsAppResponse,
 
-    const json = await request.json();
-    const parsed = requestSchema.safeParse(json);
+  // The Graph client throws on a non-OK response, and that message used to be
+  // returned to the admin as a 500 body — incidental forwarding of a third
+  // party's error text. It is now logged and answered generically.
 
-    if (!parsed.success) {
-      const firstError = parsed.error.errors[0];
-      return NextResponse.json(
-        { error: `${firstError.path.join(".")}: ${firstError.message}` },
-        { status: 400 },
-      );
-    }
+  handler: async ({ supabase, body: { to, body } }) => {
+    const { messageId } = await sendWhatsAppMessage(to, { type: "text", body });
 
-    const { to, body } = parsed.data;
-
-    const { messageId } = await sendWhatsAppMessage(to, {
-      type: "text",
-      body,
-    });
-
-    // Store outbound message and upsert contact on the USER-bound client: the
-    // whatsapp_contacts insert/update and whatsapp_messages insert policies each
-    // re-check that the caller is an admin, and the message policy additionally
-    // pins `direction` to outbound — so this route cannot forge inbound history
+    // Both writes run on the USER-bound client: the whatsapp_contacts
+    // insert/update and whatsapp_messages insert policies each re-check that
+    // the caller is an admin, and the message policy additionally pins
+    // `direction` to outbound — so this route cannot forge inbound history
     // even if it tried.
     //
-    // Neither failure fails the request: the message is already at Meta by this
-    // point, so a 500 would tell the admin their message didn't send when it
-    // did. They are logged instead — under RLS a DB refusal here is a real
-    // signal (it used to be near-impossible under service role), so it must not
-    // be swallowed silently.
+    // Failures are logged rather than thrown — under RLS a DB refusal here is
+    // a real signal (it used to be near-impossible under service role), so it
+    // must not be swallowed silently.
     const now = new Date().toISOString();
 
     const { error: contactError } = await supabase
@@ -72,10 +65,6 @@ export async function POST(request: Request) {
       console.error("[whatsapp/send] message insert failed", messageError);
     }
 
-    return NextResponse.json({ messageId });
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Internal server error";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+    return { messageId };
+  },
+});

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -48,72 +48,72 @@ export const POST = defineRoute({
 
 /** Everything that can fail. The caller swallows the outcome on purpose. */
 async function sendResetLink(request: Request): Promise<void> {
-    const parsed = requestSchema.safeParse(
-      await request.json().catch(() => null),
-    );
-    if (!parsed.success) return;
+  const parsed = requestSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) return;
 
-    // Trusted origin, never the raw Host/request URL — the reset link goes into
-    // an email and carries a recovery token, so a spoofed Host would turn it
-    // into an account-takeover phishing link.
-    const origin = getOrigin(request);
-    const adminClient = createAdminClient();
+  // Trusted origin, never the raw Host/request URL — the reset link goes into
+  // an email and carries a recovery token, so a spoofed Host would turn it
+  // into an account-takeover phishing link.
+  const origin = getOrigin(request);
+  const adminClient = createAdminClient();
 
-    // Fetch locale preference and generate the reset link in parallel.
-    const [profileResult, linkResult] = await Promise.all([
-      adminClient
-        .from("profiles")
-        .select("locale")
-        .eq("email", parsed.data.email)
-        .single(),
-      // We only consume the single-use token_hash from the result (see the
-      // emailed-link construction below) — not the action_link — so no
-      // redirectTo is needed.
-      adminClient.auth.admin.generateLink({
-        type: "recovery",
-        email: parsed.data.email,
-      }),
-    ]);
+  // Fetch locale preference and generate the reset link in parallel.
+  const [profileResult, linkResult] = await Promise.all([
+    adminClient
+      .from("profiles")
+      .select("locale")
+      .eq("email", parsed.data.email)
+      .single(),
+    // We only consume the single-use token_hash from the result (see the
+    // emailed-link construction below) — not the action_link — so no
+    // redirectTo is needed.
+    adminClient.auth.admin.generateLink({
+      type: "recovery",
+      email: parsed.data.email,
+    }),
+  ]);
 
-    if (linkResult.error) {
-      // Don't leak whether the email exists — log and stop.
-      console.error("generateLink error:", linkResult.error.message);
-      return;
-    }
+  if (linkResult.error) {
+    // Don't leak whether the email exists — log and stop.
+    console.error("generateLink error:", linkResult.error.message);
+    return;
+  }
 
-    // Resolve locale: profile preference → Accept-Language header → English.
-    const pref = profileResult.data?.locale;
-    const locale = isSupportedLocale(pref)
-      ? pref
-      : detectLocaleFromHeader(request.headers.get("Accept-Language"));
+  // Resolve locale: profile preference → Accept-Language header → English.
+  const pref = profileResult.data?.locale;
+  const locale = isSupportedLocale(pref)
+    ? pref
+    : detectLocaleFromHeader(request.headers.get("Accept-Language"));
 
-    const t = await getEmailTranslator(locale);
+  const t = await getEmailTranslator(locale);
 
-    // Email a link to OUR reset page carrying the single-use token_hash — NOT
-    // Supabase's action_link. The action_link is a bare GET on /auth/v1/verify
-    // that consumes the token on *access*, so corporate email security scanners
-    // that pre-fetch links burn it before the real user clicks. Our page
-    // consumes the token only on submit — a POST a passive scanner never makes.
-    //
-    // The token_hash rides in the query string. That's safe because our global
-    // `Referrer-Policy: strict-origin-when-cross-origin` strips the query from
-    // any cross-origin Referer, so it never leaves our domain — the assumption
-    // behind Supabase's documented token_hash pattern.
-    //
-    // `email` is the username hint for the reset page's hidden
-    // autocomplete="username" field, so password managers save the new password
-    // against the right account. Not a credential — the page uses it only as a
-    // hint, the token authorizes the reset. It's the recipient's own email: no
-    // enumeration exposure, same low-sensitivity URL channel as the token.
-    const resetUrl = `${origin}${ROUTES.resetPassword}?token_hash=${encodeURIComponent(
-      linkResult.data.properties.hashed_token,
-    )}&type=recovery&email=${encodeURIComponent(parsed.data.email)}`;
+  // Email a link to OUR reset page carrying the single-use token_hash — NOT
+  // Supabase's action_link. The action_link is a bare GET on /auth/v1/verify
+  // that consumes the token on *access*, so corporate email security scanners
+  // that pre-fetch links burn it before the real user clicks. Our page
+  // consumes the token only on submit — a POST a passive scanner never makes.
+  //
+  // The token_hash rides in the query string. That's safe because our global
+  // `Referrer-Policy: strict-origin-when-cross-origin` strips the query from
+  // any cross-origin Referer, so it never leaves our domain — the assumption
+  // behind Supabase's documented token_hash pattern.
+  //
+  // `email` is the username hint for the reset page's hidden
+  // autocomplete="username" field, so password managers save the new password
+  // against the right account. Not a credential — the page uses it only as a
+  // hint, the token authorizes the reset. It's the recipient's own email: no
+  // enumeration exposure, same low-sensitivity URL channel as the token.
+  const resetUrl = `${origin}${ROUTES.resetPassword}?token_hash=${encodeURIComponent(
+    linkResult.data.properties.hashed_token,
+  )}&type=recovery&email=${encodeURIComponent(parsed.data.email)}`;
 
-    await sendTransactionalEmail({
-      fromEmail: SENDER_EMAIL,
-      fromName: t("senderAuth"),
-      toEmail: parsed.data.email,
-      subject: t("passwordReset.subject"),
-      htmlContent: buildPasswordResetEmail(t, resetUrl, locale),
-    });
+  await sendTransactionalEmail({
+    fromEmail: SENDER_EMAIL,
+    fromName: t("senderAuth"),
+    toEmail: parsed.data.email,
+    subject: t("passwordReset.subject"),
+    htmlContent: buildPasswordResetEmail(t, resetUrl, locale),
+  });
 }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
 import { getOrigin } from "@/lib/url";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendTransactionalEmail } from "@/lib/brevo";
@@ -7,29 +7,59 @@ import { SENDER_EMAIL } from "@/lib/constants";
 import { ROUTES } from "@/lib/constants/routes";
 import { buildPasswordResetEmail } from "@/lib/email-templates/password-reset";
 import { getEmailTranslator } from "@/lib/email-templates/translator";
-import { detectLocaleFromHeader, isSupportedLocale } from "@/lib/constants/locales";
+import {
+  detectLocaleFromHeader,
+  isSupportedLocale,
+} from "@/lib/constants/locales";
 
 const requestSchema = z.object({
   email: z.string().email(),
 });
 
-export async function POST(request: Request) {
-  try {
-    const body = await request.json();
-    const parsed = requestSchema.safeParse(body);
+/**
+ * POST /api/auth/forgot-password
+ *
+ * Always answers 200, whatever happens. That is the enumeration defence, and it
+ * is why the body is parsed inside the handler rather than through the
+ * primitive's body slot: the slot answers 400 on a schema failure, which would
+ * tell a prober that a well-formed address had been accepted and a malformed
+ * one had not. Every failure path below returns the same success body.
+ */
+export const POST = defineRoute({
+  posture: "public",
+  reason:
+    "a password reset is requested by someone who cannot sign in. Always answers 200 regardless of whether the address exists, which is the enumeration defence",
 
-    if (!parsed.success) {
-      // Generic response to prevent user enumeration
-      return NextResponse.json({ success: true });
+  handler: async ({ request }) => {
+    const success = { success: true };
+    try {
+      await sendResetLink(request);
+    } catch (error) {
+      // Still 200, for the same reason every named failure path below is: a
+      // 500 from the wrapper's catch would itself be an enumeration signal.
+      console.error(
+        "Forgot password error:",
+        error instanceof Error ? error.message : error,
+      );
     }
+    return success;
+  },
+});
 
-    // Trusted origin, never the raw Host/request URL — the reset link goes
-    // into an email and carries a recovery token, so a spoofed Host would
-    // turn it into an account-takeover phishing link.
+/** Everything that can fail. The caller swallows the outcome on purpose. */
+async function sendResetLink(request: Request): Promise<void> {
+    const parsed = requestSchema.safeParse(
+      await request.json().catch(() => null),
+    );
+    if (!parsed.success) return;
+
+    // Trusted origin, never the raw Host/request URL — the reset link goes into
+    // an email and carries a recovery token, so a spoofed Host would turn it
+    // into an account-takeover phishing link.
     const origin = getOrigin(request);
     const adminClient = createAdminClient();
 
-    // Fetch locale preference and generate reset link in parallel
+    // Fetch locale preference and generate the reset link in parallel.
     const [profileResult, linkResult] = await Promise.all([
       adminClient
         .from("profiles")
@@ -46,12 +76,12 @@ export async function POST(request: Request) {
     ]);
 
     if (linkResult.error) {
-      // Don't leak whether the email exists — log and return success
+      // Don't leak whether the email exists — log and stop.
       console.error("generateLink error:", linkResult.error.message);
-      return NextResponse.json({ success: true });
+      return;
     }
 
-    // Resolve locale: profile preference → Accept-Language header → English
+    // Resolve locale: profile preference → Accept-Language header → English.
     const pref = profileResult.data?.locale;
     const locale = isSupportedLocale(pref)
       ? pref
@@ -62,14 +92,13 @@ export async function POST(request: Request) {
     // Email a link to OUR reset page carrying the single-use token_hash — NOT
     // Supabase's action_link. The action_link is a bare GET on /auth/v1/verify
     // that consumes the token on *access*, so corporate email security scanners
-    // (SafeLinks / Proofpoint / etc.) that pre-fetch links burn it before the
-    // real user clicks. Our page consumes the token via verifyOtp() only on
-    // submit — a POST a passive scanner never makes.
+    // that pre-fetch links burn it before the real user clicks. Our page
+    // consumes the token only on submit — a POST a passive scanner never makes.
     //
     // The token_hash rides in the query string. That's safe because our global
-    // `Referrer-Policy: strict-origin-when-cross-origin` (next.config.ts) strips
-    // the query from any cross-origin Referer, so it never leaves our domain —
-    // the assumption behind Supabase's documented token_hash pattern.
+    // `Referrer-Policy: strict-origin-when-cross-origin` strips the query from
+    // any cross-origin Referer, so it never leaves our domain — the assumption
+    // behind Supabase's documented token_hash pattern.
     //
     // `email` is the username hint for the reset page's hidden
     // autocomplete="username" field, so password managers save the new password
@@ -87,14 +116,4 @@ export async function POST(request: Request) {
       subject: t("passwordReset.subject"),
       htmlContent: buildPasswordResetEmail(t, resetUrl, locale),
     });
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    // Still return success to prevent enumeration, but log the error
-    console.error(
-      "Forgot password error:",
-      error instanceof Error ? error.message : error,
-    );
-    return NextResponse.json({ success: true });
-  }
 }

--- a/src/app/api/auth/pin/forgot/route.ts
+++ b/src/app/api/auth/pin/forgot/route.ts
@@ -1,12 +1,14 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
 import { sendTransactionalEmail } from "@/lib/brevo";
 import { SENDER_EMAIL } from "@/lib/constants";
 import { ROUTES } from "@/lib/constants/routes";
 import { createPinResetToken } from "@/lib/pin-session";
 import { buildPinResetEmail } from "@/lib/email-templates/pin-reset";
 import { getEmailTranslator } from "@/lib/email-templates/translator";
-import { detectLocaleFromHeader, isSupportedLocale } from "@/lib/constants/locales";
+import {
+  detectLocaleFromHeader,
+  isSupportedLocale,
+} from "@/lib/constants/locales";
 import { getOrigin } from "@/lib/url";
 
 /**
@@ -14,49 +16,53 @@ import { getOrigin } from "@/lib/url";
  * lock gate (allowUnverified), so the link goes ONLY to the account email — a
  * child triggering this just sends mail to the parent, gaining nothing.
  */
-export async function POST(request: Request) {
-  const auth = await requireRole("customer", { allowUnverified: true });
-  if (auth instanceof NextResponse) return auth;
-  const { user, profile, supabase } = auth;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  allowUnverified: true,
 
-  // No email on file → nothing to send. Succeed silently (no info leak).
-  if (!profile.email) {
-    return NextResponse.json({ success: true });
-  }
+  handler: async ({ request, supabase, user, profile }) => {
+    // No email on file → nothing to send. Succeed silently (no info leak).
+    if (!profile.email) return { success: true };
 
-  // Bind the token to the current PIN hash so it's single-use: completing the
-  // reset rotates the hash and the token stops validating (see pin-session.ts).
-  // Read on the user-bound client — the caller's own customer_profiles row is
-  // inside their RLS view, so nothing here needs the service-role bypass. The
-  // hash is used only to derive the signature and never leaves the server.
-  const { data: cp } = await supabase
-    .from("customer_profiles")
-    .select("pin_hash")
-    .eq("user_id", user.id)
-    .single();
+    // Bind the token to the current PIN hash so it's single-use: completing the
+    // reset rotates the hash and the token stops validating. Read on the
+    // user-bound client — the caller's own customer_profiles row is inside
+    // their RLS view, so nothing here needs the service-role bypass. The hash
+    // is used only to derive the signature and never leaves the server.
+    const { data: cp } = await supabase
+      .from("customer_profiles")
+      .select("pin_hash")
+      .eq("user_id", user.id)
+      .single();
 
-  // Build the emailed link off the TRUSTED origin, not the raw Host header.
-  // `getOrigin` accepts the incoming Host only if it matches a known-trusted
-  // source, else falls back to canonical NEXT_PUBLIC_SITE_URL — so a spoofed
-  // `Host: evil.com` can't turn this reset link (which carries a valid token)
-  // into a credential-phishing URL. See src/lib/url.ts.
-  const origin = getOrigin(request);
-  const token = await createPinResetToken(user.id, cp?.pin_hash ?? "", Date.now());
-  const resetLink = `${origin}${ROUTES.resetPin}?token=${encodeURIComponent(token)}`;
+    // Build the emailed link off the TRUSTED origin, not the raw Host header.
+    // `getOrigin` accepts the incoming Host only if it matches a known-trusted
+    // source, else falls back to canonical NEXT_PUBLIC_SITE_URL — so a spoofed
+    // `Host: evil.com` can't turn this reset link (which carries a valid token)
+    // into a credential-phishing URL.
+    const origin = getOrigin(request);
+    const token = await createPinResetToken(
+      user.id,
+      cp?.pin_hash ?? "",
+      Date.now(),
+    );
+    const resetLink = `${origin}${ROUTES.resetPin}?token=${encodeURIComponent(token)}`;
 
-  const pref = profile.locale;
-  const locale = isSupportedLocale(pref)
-    ? pref
-    : detectLocaleFromHeader(request.headers.get("Accept-Language"));
-  const t = await getEmailTranslator(locale);
+    const pref = profile.locale;
+    const locale = isSupportedLocale(pref)
+      ? pref
+      : detectLocaleFromHeader(request.headers.get("Accept-Language"));
+    const t = await getEmailTranslator(locale);
 
-  await sendTransactionalEmail({
-    fromEmail: SENDER_EMAIL,
-    fromName: t("senderAuth"),
-    toEmail: profile.email,
-    subject: t("pinReset.subject"),
-    htmlContent: buildPinResetEmail(t, resetLink, locale),
-  });
+    await sendTransactionalEmail({
+      fromEmail: SENDER_EMAIL,
+      fromName: t("senderAuth"),
+      toEmail: profile.email,
+      subject: t("pinReset.subject"),
+      htmlContent: buildPinResetEmail(t, resetLink, locale),
+    });
 
-  return NextResponse.json({ success: true });
-}
+    return { success: true };
+  },
+});

--- a/src/app/api/auth/pin/route.ts
+++ b/src/app/api/auth/pin/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { z } from "zod";
-import { requireRole } from "@/lib/auth";
-import { PIN_COOKIE_NAME, isPinTokenValid, pinCookieOptions, pinTokenFor } from "@/lib/pin-session";
-
-const schema = z.object({ pin: z.string().regex(/^\d{4}$/) });
+import { defineRoute } from "@/lib/api/define-route";
+import { pinBody } from "@/services/pin/pin.contracts";
+import {
+  PIN_COOKIE_NAME,
+  isPinTokenValid,
+  pinCookieOptions,
+  pinTokenFor,
+} from "@/lib/pin-session";
 
 /**
  * Create or change the parent PIN.
@@ -14,58 +17,63 @@ const schema = z.object({ pin: z.string().regex(/^\d{4}$/) });
  *  - PIN already set → overwriting requires an already-UNLOCKED session — the
  *    same bar as changing a password requires being logged in. A locked session
  *    (e.g. a child at the gate) can't take this path; a forgotten PIN is reset
- *    via the emailed link (/api/auth/pin/reset), never here. This is what stops
- *    a locked child from blind-overwriting the PIN.
+ *    via the emailed link, never here. This is what stops a locked child from
+ *    blind-overwriting the PIN.
  *
  * Either way it (re)sets the unlock cookie, so the session ends up unlocked.
  *
  * allowUnverified: the create case runs while still locked; the change case
  * enforces the unlock requirement explicitly below.
  */
-export async function POST(request: Request) {
-  const auth = await requireRole("customer", { allowUnverified: true });
-  if (auth instanceof NextResponse) return auth;
-  const { user, supabase } = auth;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  allowUnverified: true,
+  body: pinBody,
 
-  const parsed = schema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid PIN" }, { status: 400 });
-  }
+  // No database codes to map: both RPCs are self-scoping and their only
+  // interesting failure is "it did not work", which the shared table answers
+  // as a logged, generic 500.
 
-  const { data: hasPin, error: hasPinError } = await supabase.rpc("pin_is_set");
-  if (hasPinError) {
-    console.error("pin: pin_is_set failed", hasPinError);
-    return NextResponse.json({ error: "Failed to set PIN" }, { status: 500 });
-  }
+  handler: async ({ supabase, user, body }) => {
+    const { data: hasPin, error: hasPinError } = await supabase.rpc("pin_is_set");
+    if (hasPinError) throw hasPinError;
 
-  const { data: claimsData } = await supabase.auth.getClaims();
-  const sessionId = claimsData?.claims.session_id;
-  const cookieStore = await cookies();
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const sessionId = claimsData?.claims.session_id;
+    const cookieStore = await cookies();
 
-  if (hasPin) {
-    const unlocked =
-      !!sessionId &&
-      (await isPinTokenValid(cookieStore.get(PIN_COOKIE_NAME)?.value, user.id, sessionId));
-    if (!unlocked) {
-      return NextResponse.json(
-        { error: "Unlock required to change the PIN", code: "PIN_LOCKED" },
-        { status: 403 },
+    if (hasPin) {
+      const unlocked =
+        !!sessionId &&
+        (await isPinTokenValid(
+          cookieStore.get(PIN_COOKIE_NAME)?.value,
+          user.id,
+          sessionId,
+        ));
+      if (!unlocked) {
+        return NextResponse.json(
+          { error: "Unlock required to change the PIN", code: "PIN_LOCKED" },
+          { status: 403 },
+        );
+      }
+    }
+
+    const { error: setError } = await supabase.rpc("set_my_pin", {
+      p_pin: body.pin,
+    });
+    if (setError) throw setError;
+
+    // Setting a PIN also unlocks the current session (covers create-at-gate and
+    // keeps the settings session unlocked after a change).
+    if (sessionId) {
+      cookieStore.set(
+        PIN_COOKIE_NAME,
+        await pinTokenFor(user.id, sessionId),
+        pinCookieOptions(),
       );
     }
-  }
 
-  const { error: setError } = await supabase.rpc("set_my_pin", { p_pin: parsed.data.pin });
-  if (setError) {
-    console.error("pin: set_my_pin failed", setError);
-    return NextResponse.json({ error: "Failed to set PIN" }, { status: 500 });
-  }
-
-  // Setting a PIN also unlocks the current session (covers create-at-gate and
-  // keeps the settings session unlocked after a change).
-  if (sessionId) {
-    const token = await pinTokenFor(user.id, sessionId);
-    cookieStore.set(PIN_COOKIE_NAME, token, pinCookieOptions());
-  }
-
-  return NextResponse.json({ success: true });
-}
+    return { success: true };
+  },
+});

--- a/src/app/api/auth/pin/status/route.ts
+++ b/src/app/api/auth/pin/status/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
+import { pinStatusResponse } from "@/services/pin/pin.contracts";
 import { PIN_COOKIE_NAME, isPinTokenValid } from "@/lib/pin-session";
 
 /**
@@ -12,22 +12,26 @@ import { PIN_COOKIE_NAME, isPinTokenValid } from "@/lib/pin-session";
  * allowUnverified: a LOCKED customer must be able to query this — it's how the
  * gate decides whether to show the create/enter pad in the first place.
  */
-export async function GET() {
-  const auth = await requireRole("customer", { allowUnverified: true });
-  if (auth instanceof NextResponse) return auth;
-  const { user, supabase } = auth;
+export const GET = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  allowUnverified: true,
+  response: pinStatusResponse,
 
-  const { data: isSet, error } = await supabase.rpc("pin_is_set");
-  if (error) {
-    console.error("pin/status: pin_is_set failed", error);
-    return NextResponse.json({ error: "Failed to load PIN status" }, { status: 500 });
-  }
+  handler: async ({ supabase, user }) => {
+    const { data: isSet, error } = await supabase.rpc("pin_is_set");
+    if (error) throw error;
 
-  const { data: claimsData } = await supabase.auth.getClaims();
-  const sessionId = claimsData?.claims.session_id;
-  const unlocked =
-    !!sessionId &&
-    (await isPinTokenValid((await cookies()).get(PIN_COOKIE_NAME)?.value, user.id, sessionId));
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const sessionId = claimsData?.claims.session_id;
+    const unlocked =
+      !!sessionId &&
+      (await isPinTokenValid(
+        (await cookies()).get(PIN_COOKIE_NAME)?.value,
+        user.id,
+        sessionId,
+      ));
 
-  return NextResponse.json({ isSet, unlocked });
-}
+    return { isSet, unlocked };
+  },
+});

--- a/src/app/api/auth/pin/verify/route.ts
+++ b/src/app/api/auth/pin/verify/route.ts
@@ -1,47 +1,49 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { z } from "zod";
-import { requireRole } from "@/lib/auth";
-import { PIN_COOKIE_NAME, pinCookieOptions, pinTokenFor } from "@/lib/pin-session";
-
-const schema = z.object({ pin: z.string().regex(/^\d{4}$/) });
+import { defineRoute } from "@/lib/api/define-route";
+import { pinBody, pinVerifyResponse } from "@/services/pin/pin.contracts";
+import {
+  PIN_COOKIE_NAME,
+  pinCookieOptions,
+  pinTokenFor,
+} from "@/lib/pin-session";
 
 /**
  * Verify the parent PIN and unlock the session. allowUnverified: this is the
  * route a locked customer calls to BECOME unlocked, so it must not be gated.
  */
-export async function POST(request: Request) {
-  const auth = await requireRole("customer", { allowUnverified: true });
-  if (auth instanceof NextResponse) return auth;
-  const { user, supabase } = auth;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  allowUnverified: true,
+  body: pinBody,
+  response: pinVerifyResponse,
 
-  const parsed = schema.safeParse(await request.json().catch(() => null));
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid PIN" }, { status: 400 });
-  }
+  handler: async ({ supabase, user, body }) => {
+    const { data: ok, error } = await supabase.rpc("verify_my_pin", {
+      p_pin: body.pin,
+    });
+    if (error) throw error;
 
-  const { data: ok, error } = await supabase.rpc("verify_my_pin", { p_pin: parsed.data.pin });
-  if (error) {
-    console.error("pin/verify: verify_my_pin failed", error);
-    return NextResponse.json({ error: "Failed to verify PIN" }, { status: 500 });
-  }
-  // A wrong PIN is a normal outcome, not an auth failure (the session is valid —
-  // requireRole already passed), so it's a 200 with verified:false rather than a
-  // 401. That keeps an expected wrong guess out of the browser's error console
-  // and out of network-error monitoring; a real 401 then means the session
-  // itself failed.
-  if (!ok) {
-    return NextResponse.json({ verified: false });
-  }
+    // A wrong PIN is a normal outcome, not an auth failure (the session is
+    // valid — the role gate already passed), so it's a 200 with
+    // verified:false rather than a 401. That keeps an expected wrong guess out
+    // of the browser's error console and out of network-error monitoring; a
+    // real 401 then means the session itself failed.
+    if (!ok) return { verified: false };
 
-  const { data: claimsData } = await supabase.auth.getClaims();
-  const sessionId = claimsData?.claims.session_id;
-  if (!sessionId) {
-    return NextResponse.json({ error: "No active session" }, { status: 401 });
-  }
+    const { data: claimsData } = await supabase.auth.getClaims();
+    const sessionId = claimsData?.claims.session_id;
+    if (!sessionId) {
+      return NextResponse.json({ error: "No active session" }, { status: 401 });
+    }
 
-  const token = await pinTokenFor(user.id, sessionId);
-  (await cookies()).set(PIN_COOKIE_NAME, token, pinCookieOptions());
+    (await cookies()).set(
+      PIN_COOKIE_NAME,
+      await pinTokenFor(user.id, sessionId),
+      pinCookieOptions(),
+    );
 
-  return NextResponse.json({ verified: true });
-}
+    return { verified: true };
+  },
+});

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { PIN_COOKIE_NAME } from "@/lib/pin-session";
@@ -11,7 +11,9 @@ import { PIN_COOKIE_NAME } from "@/lib/pin-session";
 // POST (not GET) + SameSite=Lax cookies prevents forced-logout CSRF —
 // cross-origin top-level POST navigations don't carry Lax cookies, so a
 // malicious page can't trigger sign-out. See docs/SECURITY_REPORT.md #8.
-export async function POST(request: NextRequest) {
+// The handler reads only `request.url`, so it takes the platform `Request`
+// rather than the framework's subclass — Next.js passes one either way.
+export async function POST(request: Request) {
   const supabase = await createClient();
   await supabase.auth.signOut();
   // Drop the parent-PIN unlock cookie so the next session starts locked.

--- a/src/app/api/auth/switch-account/route.ts
+++ b/src/app/api/auth/switch-account/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { requireRole } from "@/lib/auth";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import { PIN_COOKIE_NAME } from "@/lib/pin-session";
+
+/** Request body of POST /api/auth/switch-account. */
+const switchAccountBody = z.object({
+  userId: z.string().min(1, "userId is required"),
+});
 
 /**
  * Switch the current session to another family member.
@@ -22,121 +29,119 @@ import { PIN_COOKIE_NAME } from "@/lib/pin-session";
  *
  * Future: gamer → parent should be gated behind a parent PIN code; tracked
  * separately and intentionally out of scope for this change.
+ *
+ * allowUnverified: a locked customer (no PIN entered) must still be able to
+ * switch DOWN to one of their gamers — switching is how they hand the device
+ * back to a child without unlocking the parent account.
  */
-export async function POST(request: Request) {
-  // allowUnverified: a locked customer (no PIN entered) must still be able to
-  // switch DOWN to one of their gamers — switching is how they hand the device
-  // back to a child without unlocking the parent account.
-  const auth = await requireRole(["customer", "gamer"], { allowUnverified: true });
-  if (auth instanceof NextResponse) return auth;
-  const { user, profile, supabase } = auth;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: ["customer", "gamer"],
+  allowUnverified: true,
+  body: switchAccountBody,
 
-  let body: { userId?: string };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
+  handler: async ({ supabase, user, profile, body }) => {
+    const { userId } = body;
 
-  const { userId } = body;
-  if (!userId || typeof userId !== "string") {
-    return NextResponse.json({ error: "userId is required" }, { status: 400 });
-  }
-
-  if (userId === user.id) {
-    return NextResponse.json({ error: "Cannot switch to yourself" }, { status: 400 });
-  }
-
-  const admin = createAdminClient();
-
-  const { data: target, error: targetError } = await admin
-    .from("profiles")
-    .select("id, role, email")
-    .eq("id", userId)
-    .maybeSingle();
-
-  if (targetError) {
-    console.error("switch-account: target lookup failed", targetError);
-    return NextResponse.json({ error: "Failed to verify target" }, { status: 500 });
-  }
-
-  if (!target) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const allowed = await isFamilyMember({
-    admin,
-    callerId: user.id,
-    callerRole: profile.role,
-    targetId: target.id,
-    targetRole: target.role,
-  });
-
-  if (allowed instanceof NextResponse) return allowed;
-  if (!allowed) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  // Resolve the target's email so we can mint a magic-link OTP for it.
-  // Gamer emails are synthetic (<token>@gamer.sogverse.internal) but stored on
-  // the profile like any other role's, so read them straight from the row.
-  // Customer emails come from auth.users (admin lookup — we don't trust the
-  // cookie session, and a parent could have changed their email there).
-  let targetEmail: string;
-  if (target.role === "gamer") {
-    if (!target.email) {
+    if (userId === user.id) {
       return NextResponse.json(
-        { error: "Gamer account is not properly configured" },
-        { status: 500 },
+        { error: "Cannot switch to yourself" },
+        { status: 400 },
       );
     }
-    targetEmail = target.email;
-  } else {
-    const { data: authUser, error: authError } = await admin.auth.admin.getUserById(target.id);
-    if (authError || !authUser.user.email) {
-      console.error("switch-account: parent email lookup failed", authError);
-      return NextResponse.json({ error: "Failed to look up target email" }, { status: 500 });
+
+    const admin = createAdminClient();
+
+    const { data: target, error: targetError } = await admin
+      .from("profiles")
+      .select("id, role, email")
+      .eq("id", userId)
+      .maybeSingle();
+
+    if (targetError) throw targetError;
+
+    // A target that does not exist and a target outside the family are the
+    // same answer on purpose: 403 either way, so this route cannot be used to
+    // probe which account ids exist.
+    if (!target) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    targetEmail = authUser.user.email;
-  }
 
-  // Generate magic-link OTP first — non-destructive, safe to fail before
-  // touching the caller's session.
-  const { data: linkData, error: generateError } = await admin.auth.admin.generateLink({
-    type: "magiclink",
-    email: targetEmail,
-  });
+    const allowed = await isFamilyMember({
+      admin,
+      callerId: user.id,
+      callerRole: profile.role,
+      targetId: target.id,
+      targetRole: target.role,
+    });
 
-  if (generateError || !linkData.properties.email_otp) {
-    console.error("switch-account: generateLink failed", generateError);
-    return NextResponse.json({ error: "Failed to generate session" }, { status: 500 });
-  }
+    if (!allowed) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
 
-  const otp = linkData.properties.email_otp;
+    // Resolve the target's email so we can mint a magic-link OTP for it.
+    // Gamer emails are synthetic (<token>@gamer.sogverse.internal) but stored on
+    // the profile like any other role's, so read them straight from the row.
+    // Customer emails come from auth.users (admin lookup — we don't trust the
+    // cookie session, and a parent could have changed their email there).
+    let targetEmail: string;
+    if (target.role === "gamer") {
+      if (!target.email) {
+        throw new ApiError(
+          `gamer ${target.id} has no synthetic email on its profile`,
+          500,
+        );
+      }
+      targetEmail = target.email;
+    } else {
+      const { data: authUser, error: authError } =
+        await admin.auth.admin.getUserById(target.id);
+      if (authError || !authUser.user.email) {
+        console.error("switch-account: parent email lookup failed", authError);
+        throw new ApiError("could not resolve the target account's email", 500);
+      }
+      targetEmail = authUser.user.email;
+    }
 
-  // Sign out caller (clears session cookies), then verify OTP on a fresh
-  // server client so the new cookies land in the response.
-  await supabase.auth.signOut();
+    // Generate magic-link OTP first — non-destructive, safe to fail before
+    // touching the caller's session.
+    const { data: linkData, error: generateError } =
+      await admin.auth.admin.generateLink({
+        type: "magiclink",
+        email: targetEmail,
+      });
 
-  const freshClient = await createClient();
-  const { error: verifyError } = await freshClient.auth.verifyOtp({
-    email: targetEmail,
-    token: otp,
-    type: "magiclink",
-  });
+    if (generateError || !linkData.properties.email_otp) {
+      console.error("switch-account: generateLink failed", generateError);
+      throw new ApiError("could not mint a session for the target account", 500);
+    }
 
-  if (verifyError) {
-    console.error("switch-account: verifyOtp failed", verifyError);
-    return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
-  }
+    const otp = linkData.properties.email_otp;
 
-  // Clear the parent-PIN unlock cookie: the new session has a different
-  // session_id so the old token wouldn't match anyway, but dropping it keeps
-  // the cookie jar honest. Switching INTO a parent therefore always re-locks.
-  (await cookies()).delete(PIN_COOKIE_NAME);
+    // Sign out caller (clears session cookies), then verify OTP on a fresh
+    // server client so the new cookies land in the response.
+    await supabase.auth.signOut();
 
-  return NextResponse.json({ success: true });
-}
+    const freshClient = await createClient();
+    const { error: verifyError } = await freshClient.auth.verifyOtp({
+      email: targetEmail,
+      token: otp,
+      type: "magiclink",
+    });
+
+    if (verifyError) {
+      console.error("switch-account: verifyOtp failed", verifyError);
+      throw new ApiError("could not establish the target session", 500);
+    }
+
+    // Clear the parent-PIN unlock cookie: the new session has a different
+    // session_id so the old token wouldn't match anyway, but dropping it keeps
+    // the cookie jar honest. Switching INTO a parent therefore always re-locks.
+    (await cookies()).delete(PIN_COOKIE_NAME);
+
+    return { success: true };
+  },
+});
 
 type AdminClient = ReturnType<typeof createAdminClient>;
 
@@ -146,7 +151,7 @@ async function isFamilyMember(args: {
   callerRole: string;
   targetId: string;
   targetRole: string;
-}): Promise<boolean | NextResponse> {
+}): Promise<boolean> {
   const { admin, callerId, callerRole, targetId, targetRole } = args;
 
   if (callerRole === "customer") {
@@ -157,10 +162,7 @@ async function isFamilyMember(args: {
       .eq("parent_id", callerId)
       .eq("gamer_id", targetId)
       .maybeSingle();
-    if (error) {
-      console.error("switch-account: parent_gamer lookup failed", error);
-      return NextResponse.json({ error: "Failed to verify relationship" }, { status: 500 });
-    }
+    if (error) throw error;
     return !!data;
   }
 
@@ -172,10 +174,7 @@ async function isFamilyMember(args: {
         .eq("parent_id", targetId)
         .eq("gamer_id", callerId)
         .maybeSingle();
-      if (error) {
-        console.error("switch-account: parent_gamer lookup failed", error);
-        return NextResponse.json({ error: "Failed to verify relationship" }, { status: 500 });
-      }
+      if (error) throw error;
       return !!data;
     }
     if (targetRole === "gamer") {
@@ -184,10 +183,8 @@ async function isFamilyMember(args: {
         .from("parent_gamer")
         .select("parent_id, gamer_id")
         .in("gamer_id", [callerId, targetId]);
-      if (error) {
-        console.error("switch-account: sibling lookup failed", error);
-        return NextResponse.json({ error: "Failed to verify relationship" }, { status: 500 });
-      }
+      if (error) throw error;
+
       const callerParents = new Set<string>();
       const targetParents = new Set<string>();
       for (const row of data) {

--- a/src/app/api/checkout/products/create/route.ts
+++ b/src/app/api/checkout/products/create/route.ts
@@ -1,19 +1,20 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import { createAdminClient } from "@/lib/supabase/admin";
-import {
-  isSupportedCurrency,
-  type SupportedCurrency,
-} from "@/lib/constants/currency";
+import type { SupportedCurrency } from "@/lib/constants/currency";
 import {
   isSupportedLocale,
   resolveLocale,
   type SupportedLocale,
 } from "@/lib/constants/locales";
 import { resolveTranslation } from "@/lib/i18n/resolve-translation";
-import { createParticipationRpcResult } from "@/services/participations/participations.contracts";
-import type { PurchaseShape } from "@/types";
+import {
+  createCheckoutBody,
+  createParticipationResponse,
+  createParticipationRpcResult,
+} from "@/services/participations/participations.contracts";
 import { ROUTES } from "@/lib/constants";
 import {
   computeSinglePaymentAmount,
@@ -25,369 +26,324 @@ import { getOrigin } from "@/lib/url";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
-// Discriminated success bodies. Client switches on `status`.
-//
-//   redirect       — paid signup (single-payment OR subscription). Always send
-//                    the parent to Stripe Checkout — even with a saved card —
-//                    for the trust/safety moment. Each subscription is its own
-//                    Stripe sub (one per gamer×club), so there is no inline add.
-//   free_confirmed     — free event; no Stripe involvement.
-//   external_confirmed — municipality club; invoiced off-platform, no Stripe.
-//   full               — seat gone; UI flips to waitlist CTA.
-type CreateResponseBody =
-  | { status: "redirect"; checkoutUrl: string }
-  | { status: "free_confirmed"; participationId: string }
-  | { status: "external_confirmed"; participationId: string }
-  | { status: "full" };
+/**
+ * POST /api/checkout/products/create
+ *
+ * Discriminated success bodies; the client switches on `status`.
+ *
+ *   redirect           — paid signup (single-payment OR subscription). Always
+ *                        send the parent to Stripe Checkout — even with a saved
+ *                        card — for the trust/safety moment. Each subscription
+ *                        is its own Stripe sub (one per gamer x club), so there
+ *                        is no inline add.
+ *   free_confirmed     — free event; no Stripe involvement.
+ *   external_confirmed — municipality club; invoiced off-platform, no Stripe.
+ *   full               — seat gone; UI flips to the waitlist CTA.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  forbiddenMessage: "Only customers can sign gamers up for products",
+  // The body used to be read as a bag of optional strings and checked field by
+  // field. The schema states the same rules once, and `purchaseShape` and
+  // `currency` arrive as the supported enums rather than as strings the handler
+  // has to re-test.
+  body: createCheckoutBody,
+  response: createParticipationResponse,
 
-const ALLOWED_SHAPES: ReadonlySet<PurchaseShape> = new Set<PurchaseShape>([
-  "subscription_monthly",
-  "single_payment",
-  "free",
-  "external",
-]);
+  // `no_data_found`: the RPC raises it for a product that does not exist, which
+  // is the same call the waitlist route makes and gets the same answer — the
+  // parent named a product from a page they were browsing, so the shop surface
+  // treats it as bad input beside the signup button rather than sending them to
+  // a not-found page. Every other code the RPC raises (its check violations,
+  // the already-enrolled unique violation) already lands where this route put
+  // it by hand.
+  errorStatus: { P0002: 400 },
 
-export async function POST(request: Request) {
-  const result = await requireRole("customer", {
-    forbiddenMessage: "Only customers can sign gamers up for products",
-  });
-  if (result instanceof NextResponse) return result;
-  const { user, profile } = result;
+  // The RPC's refusals are written for the parent to read — "registration has
+  // not yet opened", "product is not accepting signups" — and the shop renders
+  // them verbatim beside the signup button.
+  discloseErrorMessages:
+    "create_participation's messages are the user-facing explanation of a refused signup, and the shop surface renders them as-is",
 
-  let body: {
-    productId?: string;
-    gamerId?: string;
-    purchaseShape?: PurchaseShape;
-    currency?: string;
-  };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
+  handler: async ({ request, user, profile, body }) => {
+    const { productId, gamerId, purchaseShape } = body;
+    const currency: SupportedCurrency = body.currency;
 
-  const { productId, gamerId, purchaseShape, currency: rawCurrency } = body;
+    const admin = createAdminClient();
 
-  if (!productId || !gamerId || !purchaseShape) {
-    return NextResponse.json(
-      { error: "productId, gamerId and purchaseShape are required" },
-      { status: 400 },
-    );
-  }
-
-  if (!ALLOWED_SHAPES.has(purchaseShape)) {
-    return NextResponse.json(
-      { error: `Unsupported purchaseShape: ${purchaseShape}` },
-      { status: 400 },
-    );
-  }
-
-  if (!isSupportedCurrency(rawCurrency)) {
-    return NextResponse.json(
-      { error: "Unsupported currency" },
-      { status: 400 },
-    );
-  }
-  const currency: SupportedCurrency = rawCurrency;
-
-  const admin = createAdminClient();
-
-  const { data: product, error: productErr } = await admin
-    .from("products")
-    .select(
-      "id, product_type, billing_mode, seat_count, timezone, product_translations(locale, name)",
-    )
-    .eq("id", productId)
-    .single();
-  if (productErr) {
-    return NextResponse.json({ error: "Product not found" }, { status: 404 });
-  }
-  // Prefer the parent's locale for every customer-facing name we control on
-  // the Checkout page: the single-payment line item (inline price_data) and the
-  // subscription description both use this. `resolveLocale` coerces the nullable
-  // profile locale to a SupportedLocale (→ 'en' when absent), and
-  // `resolveTranslation` walks the shared fallback chain (locale → en → first).
-  // The subscription line item itself is the one name we can't localize here —
-  // it's the cached Stripe Product's name, shared across all locales (see
-  // getOrCreateSubscriptionPrice).
-  const productName =
-    resolveTranslation(
-      product.product_translations,
-      resolveLocale(profile.locale),
-    )?.name ?? "School of Gaming product";
-
-  // Shape × billing_mode must agree. Each billing mode has exactly one valid
-  // shape family: free→'free', external_contract→'external', paid→subscription/
-  // single_payment. Mismatches are rejected up front so the RPC only ever sees
-  // a coherent (shape, product) pair.
-  if (purchaseShape === "free" && product.billing_mode !== "free") {
-    return NextResponse.json(
-      { error: "Only free products accept the 'free' purchase shape" },
-      { status: 400 },
-    );
-  }
-  if (
-    purchaseShape === "external" &&
-    product.billing_mode !== "external_contract"
-  ) {
-    return NextResponse.json(
-      {
-        error:
-          "Only externally-contracted products accept the 'external' purchase shape",
-      },
-      { status: 400 },
-    );
-  }
-  if (
-    purchaseShape !== "free" &&
-    purchaseShape !== "external" &&
-    product.billing_mode !== "paid"
-  ) {
-    return NextResponse.json(
-      { error: "Paid purchase shapes only apply to paid products" },
-      { status: 400 },
-    );
-  }
-  const isSubscription = purchaseShape.startsWith("subscription_");
-  const isSinglePayment = purchaseShape === "single_payment";
-
-  if (isSinglePayment && product.product_type === "consumer_club") {
-    return NextResponse.json(
-      { error: "Consumer clubs use subscriptions, not single-payment" },
-      { status: 400 },
-    );
-  }
-  if (isSubscription && product.product_type !== "consumer_club") {
-    return NextResponse.json(
-      { error: "Only consumer clubs accept subscriptions" },
-      { status: 400 },
-    );
-  }
-
-  // Each click is an independent reservation. If the parent abandoned a
-  // previous Stripe session, that row stays in the seat-count until Stripe
-  // fires `checkout.session.expired` (~30 min) and the webhook deletes it.
-  // The schema's unique index on (product_id, gamer_id) excludes 'reserving',
-  // so multiple held rows for the same parent/gamer coexist fine. Pay-twice
-  // is bounded by the unique index firing on the second confirm — see the
-  // webhook for the 23505 catch.
-  const { data: rpcResult, error: rpcErr } = await admin.rpc(
-    "create_participation",
-    {
-      p_product_id: productId,
-      p_gamer_id: gamerId,
-      p_customer_id: user.id,
-      p_purchase_shape: purchaseShape,
-      p_currency: currency,
-    },
-  );
-
-  if (rpcErr) {
-    return NextResponse.json(
-      { error: rpcErr.message },
-      { status: rpcErr.code === "23505" ? 409 : 400 },
-    );
-  }
-
-  const rpcParsed = createParticipationRpcResult.safeParse(rpcResult);
-  if (!rpcParsed.success) {
-    console.error(
-      "create_participation returned an unexpected shape:",
-      rpcParsed.error,
-    );
-    return NextResponse.json(
-      { error: "Failed to start checkout" },
-      { status: 500 },
-    );
-  }
-  const rpcJson = rpcParsed.data;
-
-  if (rpcJson.kind === "full") {
-    const respBody: CreateResponseBody = { status: "full" };
-    return NextResponse.json(respBody);
-  }
-
-  if (rpcJson.kind === "free_active") {
-    if (!rpcJson.participation_id) {
-      return NextResponse.json(
-        { error: "RPC returned no participation id" },
-        { status: 500 },
-      );
+    const { data: product, error: productErr } = await admin
+      .from("products")
+      .select(
+        "id, product_type, billing_mode, seat_count, timezone, product_translations(locale, name)",
+      )
+      .eq("id", productId)
+      .single();
+    if (productErr) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
     }
-    const respBody: CreateResponseBody = {
-      status: "free_confirmed",
-      participationId: rpcJson.participation_id,
-    };
-    return NextResponse.json(respBody);
-  }
 
-  if (rpcJson.kind === "external_active") {
-    if (!rpcJson.participation_id) {
+    // Prefer the parent's locale for every customer-facing name we control on
+    // the Checkout page: the single-payment line item (inline price_data) and
+    // the subscription description both use this. The subscription line item
+    // itself is the one name we can't localize here — it's the cached Stripe
+    // Product's name, shared across all locales.
+    const productName =
+      resolveTranslation(
+        product.product_translations,
+        resolveLocale(profile.locale),
+      )?.name ?? "School of Gaming product";
+
+    // Shape x billing_mode must agree. Each billing mode has exactly one valid
+    // shape family: free→'free', external_contract→'external', paid→
+    // subscription/single_payment. Mismatches are rejected up front so the RPC
+    // only ever sees a coherent (shape, product) pair. These stay in the route
+    // rather than in the body schema because they need the product row.
+    if (purchaseShape === "free" && product.billing_mode !== "free") {
       return NextResponse.json(
-        { error: "RPC returned no participation id" },
-        { status: 500 },
-      );
-    }
-    // Municipality clubs are invoiced off-platform — the participation is
-    // already active, so we never touch Stripe. Same confirmation page as the
-    // free flow.
-    const respBody: CreateResponseBody = {
-      status: "external_confirmed",
-      participationId: rpcJson.participation_id,
-    };
-    return NextResponse.json(respBody);
-  }
-
-  // kind === 'reserving'
-  if (!rpcJson.participation_id) {
-    return NextResponse.json(
-      { error: "RPC returned no reservation id" },
-      { status: 500 },
-    );
-  }
-  const reservationId = rpcJson.participation_id;
-
-  const stripeCustomerId = await getOrCreateStripeCustomer(admin, user.id);
-
-  // Every paid signup — single-payment AND subscription — goes through Stripe
-  // Checkout. Each consumer-club subscription is its own Stripe subscription
-  // (one per gamer×club), created fresh below in `mode: "subscription"`. There
-  // is no inline `subscriptions.update`: a parent with a card on file still
-  // sees Checkout (the trust moment), and one sub per club means each is
-  // independently cancelable from the Stripe portal. See
-  // docs/products-architecture.md §4.5b / §4.5c.
-
-  const origin = getOrigin(request);
-  // Success lands on the dedicated purchase-confirmation page, keyed by this
-  // reservation id. By the time Stripe redirects, the `checkout.session.completed`
-  // webhook has already run `confirm_reservation` (Stripe waits up to 10s for
-  // our endpoint to respond before redirecting), so the row is 'active' — but
-  // every field the page shows lives on the row from creation, so the page
-  // renders correctly even in the rare case the redirect beats the webhook. No
-  // polling, no `?signup=` flag.
-  const successUrl = `${origin}${ROUTES.shopConfirmation(reservationId)}`;
-  // Cancel bounces straight back to the product page so the parent can retry.
-  // We do NOT free the seat — the reserving row stays held until either Stripe
-  // fires session.completed (→ confirm) or session.expired (→ expire). A parent
-  // who clicks Sign Up again creates a fresh reservation (their old row stays
-  // held until its session expires). On the rare last-seat case they'd see
-  // "Fully booked" and can join the waitlist instead.
-  const cancelUrl = `${origin}${ROUTES.shopProduct(productId)}`;
-
-  const metadata = {
-    reservationId,
-    customerId: user.id,
-    gamerId,
-    productId,
-    purchaseShape,
-    currency,
-  };
-
-  // Stripe Checkout's session expiry IS our reservation lifetime: Stripe
-  // refuses payment past `expires_at` and fires checkout.session.expired,
-  // which our webhook turns into expire_reservation.
-  const expiresAt = Math.floor(Date.now() / 1000) + RESERVATION_LIFETIME_MINUTES * 60;
-
-  // Adaptive Pricing presents each customer their local currency and lets
-  // Stripe convert, while the Session/PaymentIntent still report our EUR
-  // integration currency and settle us in EUR at the price we set. That's
-  // how "buy in another currency" works without us modelling other
-  // currencies internally. See src/lib/constants/currency.ts.
-  const sessionParams: Stripe.Checkout.SessionCreateParams = {
-    customer: stripeCustomerId,
-    adaptive_pricing: { enabled: true },
-    // Render Stripe's own chrome ("Subscribe", "Pay", field labels) in the
-    // parent's app locale. Falls back to 'auto' (browser Accept-Language) for
-    // locales Stripe doesn't support — e.g. Klingon.
-    locale: stripeCheckoutLocale(profile.locale),
-    // Show the "Add promotion code" field. Codes themselves are created and
-    // managed in the Stripe dashboard (per mode — test and live separately);
-    // nothing in our DB models them. With Adaptive Pricing, percent-off
-    // coupons convert cleanly; amount_off coupons are currency-bound, so
-    // prefer percent-off when creating codes.
-    allow_promotion_codes: true,
-    // Enable Stripe Tax so new signups get VAT itemized like the migrated
-    // Chargebee subs do. `customer_update: { address: "auto" }` is required by
-    // Stripe whenever a `customer` is pre-set on the session with automatic_tax
-    // on; it also makes Checkout collect the billing address and persist it back
-    // onto the Customer (getOrCreateStripeCustomer creates customers with email
-    // + name only, no address), which Stripe Tax needs to locate the customer.
-    // Session-level automatic_tax covers both "subscription" and "payment" modes.
-    automatic_tax: { enabled: true },
-    customer_update: { address: "auto" },
-    expires_at: expiresAt,
-    metadata,
-    success_url: successUrl,
-    cancel_url: cancelUrl,
-    line_items: [],
-  };
-
-  if (isSinglePayment) {
-    const amount = await computeSinglePaymentAmount(admin, productId, currency);
-    if (amount === null) {
-      await rollbackReservation(admin, reservationId);
-      return NextResponse.json(
-        { error: `Product is not sold in ${currency}` },
+        { error: "Only free products accept the 'free' purchase shape" },
         { status: 400 },
       );
     }
-    sessionParams.mode = "payment";
-    sessionParams.line_items = [
-      {
-        quantity: 1,
-        price_data: {
-          currency,
-          unit_amount: amount,
-          product_data: { name: productName },
+    if (
+      purchaseShape === "external" &&
+      product.billing_mode !== "external_contract"
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Only externally-contracted products accept the 'external' purchase shape",
         },
-      },
-    ];
-    // Offer to save the card for future purchases. Checked = saved with
-    // `allow_redisplay: always`, so it's offered/prefilled on the customer's
-    // next Checkout and manageable from the billing portal. Subscriptions
-    // (the other branch) already save the card by necessity.
-    sessionParams.saved_payment_method_options = {
-      payment_method_save: "enabled",
-    };
-  } else {
-    const priceRow = await getOrCreateSubscriptionPrice(
-      admin,
-      productId,
-      currency,
-    );
-    if (!priceRow) {
-      await rollbackReservation(admin, reservationId);
-      return NextResponse.json(
-        { error: `Product is not sold in ${currency}` },
         { status: 400 },
       );
     }
-    sessionParams.mode = "subscription";
-    sessionParams.line_items = [{ quantity: 1, price: priceRow.stripe_price_id }];
-    // Describe the sub as "{Club} — {Child}". A family has one Stripe sub per
-    // gamer×club, all listed together in the hosted portal; without a per-sub
-    // description they'd be indistinguishable there (and two kids in the same
-    // club would show as two identical rows). This is the label the parent
-    // reads when deciding which one to cancel.
-    sessionParams.subscription_data = {
-      metadata,
-      description: `${productName} — ${await pickGamerName(admin, gamerId)}`,
-    };
-  }
+    if (
+      purchaseShape !== "free" &&
+      purchaseShape !== "external" &&
+      product.billing_mode !== "paid"
+    ) {
+      return NextResponse.json(
+        { error: "Paid purchase shapes only apply to paid products" },
+        { status: 400 },
+      );
+    }
 
-  const session = await stripe.checkout.sessions.create(sessionParams);
+    const isSubscription = purchaseShape.startsWith("subscription_");
+    const isSinglePayment = purchaseShape === "single_payment";
 
-  if (!session.url) {
-    await rollbackReservation(admin, reservationId);
-    return NextResponse.json(
-      { error: "Stripe did not return a Checkout URL" },
-      { status: 502 },
+    if (isSinglePayment && product.product_type === "consumer_club") {
+      return NextResponse.json(
+        { error: "Consumer clubs use subscriptions, not single-payment" },
+        { status: 400 },
+      );
+    }
+    if (isSubscription && product.product_type !== "consumer_club") {
+      return NextResponse.json(
+        { error: "Only consumer clubs accept subscriptions" },
+        { status: 400 },
+      );
+    }
+
+    // Each click is an independent reservation. If the parent abandoned a
+    // previous Stripe session, that row stays in the seat-count until Stripe
+    // fires `checkout.session.expired` (~30 min) and the webhook deletes it.
+    // The schema's unique index on (product_id, gamer_id) excludes 'reserving',
+    // so multiple held rows for the same parent/gamer coexist fine. Pay-twice
+    // is bounded by the unique index firing on the second confirm — see the
+    // webhook for the 23505 catch.
+    const { data: rpcResult, error: rpcErr } = await admin.rpc(
+      "create_participation",
+      {
+        p_product_id: productId,
+        p_gamer_id: gamerId,
+        p_customer_id: user.id,
+        p_purchase_shape: purchaseShape,
+        p_currency: currency,
+      },
     );
-  }
 
-  const respBody: CreateResponseBody = { status: "redirect", checkoutUrl: session.url };
-  return NextResponse.json(respBody);
-}
+    if (rpcErr) throw rpcErr;
+
+    const rpcParsed = createParticipationRpcResult.safeParse(rpcResult);
+    if (!rpcParsed.success) {
+      console.error(
+        "create_participation returned an unexpected shape:",
+        rpcParsed.error.message,
+      );
+      throw new ApiError("Failed to start checkout", 500);
+    }
+    const rpcJson = rpcParsed.data;
+
+    if (rpcJson.kind === "full") {
+      return { status: "full" as const };
+    }
+
+    if (rpcJson.kind === "free_active" || rpcJson.kind === "external_active") {
+      if (!rpcJson.participation_id) {
+        throw new ApiError(
+          `create_participation returned ${rpcJson.kind} with no participation id`,
+          500,
+        );
+      }
+      // Municipality clubs are invoiced off-platform, so like the free flow the
+      // participation is already active and we never touch Stripe. Both land on
+      // the same confirmation page.
+      return rpcJson.kind === "free_active"
+        ? {
+            status: "free_confirmed" as const,
+            participationId: rpcJson.participation_id,
+          }
+        : {
+            status: "external_confirmed" as const,
+            participationId: rpcJson.participation_id,
+          };
+    }
+
+    // kind === 'reserving'
+    if (!rpcJson.participation_id) {
+      throw new ApiError(
+        "create_participation returned reserving with no reservation id",
+        500,
+      );
+    }
+    const reservationId = rpcJson.participation_id;
+
+    const stripeCustomerId = await getOrCreateStripeCustomer(admin, user.id);
+
+    // Every paid signup — single-payment AND subscription — goes through Stripe
+    // Checkout. Each consumer-club subscription is its own Stripe subscription
+    // (one per gamer x club), created fresh below in `mode: "subscription"`.
+    // There is no inline subscription update: a parent with a card on file
+    // still sees Checkout (the trust moment), and one sub per club means each
+    // is independently cancelable from the Stripe portal.
+
+    const origin = getOrigin(request);
+    // Success lands on the dedicated purchase-confirmation page, keyed by this
+    // reservation id. By the time Stripe redirects, the
+    // `checkout.session.completed` webhook has already confirmed the
+    // reservation (Stripe waits up to 10s for our endpoint before redirecting),
+    // so the row is 'active' — but every field the page shows lives on the row
+    // from creation, so the page renders correctly even in the rare case the
+    // redirect beats the webhook. No polling, no `?signup=` flag.
+    const successUrl = `${origin}${ROUTES.shopConfirmation(reservationId)}`;
+    // Cancel bounces straight back to the product page so the parent can retry.
+    // We do NOT free the seat — the reserving row stays held until either
+    // Stripe fires session.completed (→ confirm) or session.expired (→ expire).
+    const cancelUrl = `${origin}${ROUTES.shopProduct(productId)}`;
+
+    const metadata = {
+      reservationId,
+      customerId: user.id,
+      gamerId,
+      productId,
+      purchaseShape,
+      currency,
+    };
+
+    // Stripe Checkout's session expiry IS our reservation lifetime: Stripe
+    // refuses payment past `expires_at` and fires checkout.session.expired,
+    // which our webhook turns into expire_reservation.
+    const expiresAt =
+      Math.floor(Date.now() / 1000) + RESERVATION_LIFETIME_MINUTES * 60;
+
+    // Adaptive Pricing presents each customer their local currency and lets
+    // Stripe convert, while the Session/PaymentIntent still report our EUR
+    // integration currency and settle us in EUR at the price we set.
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
+      customer: stripeCustomerId,
+      adaptive_pricing: { enabled: true },
+      // Render Stripe's own chrome ("Subscribe", "Pay", field labels) in the
+      // parent's app locale. Falls back to 'auto' (browser Accept-Language) for
+      // locales Stripe doesn't support — e.g. Klingon.
+      locale: stripeCheckoutLocale(profile.locale),
+      // Show the "Add promotion code" field. Codes themselves are created and
+      // managed in the Stripe dashboard (per mode — test and live separately);
+      // nothing in our DB models them. With Adaptive Pricing, percent-off
+      // coupons convert cleanly; amount_off coupons are currency-bound, so
+      // prefer percent-off when creating codes.
+      allow_promotion_codes: true,
+      // Enable Stripe Tax so new signups get VAT itemized like the migrated
+      // subs do. `customer_update: { address: "auto" }` is required by Stripe
+      // whenever a `customer` is pre-set on the session with automatic_tax on;
+      // it also makes Checkout collect the billing address and persist it back
+      // onto the Customer, which Stripe Tax needs to locate the customer.
+      automatic_tax: { enabled: true },
+      customer_update: { address: "auto" },
+      expires_at: expiresAt,
+      metadata,
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      line_items: [],
+    };
+
+    if (isSinglePayment) {
+      const amount = await computeSinglePaymentAmount(admin, productId, currency);
+      if (amount === null) {
+        await rollbackReservation(admin, reservationId);
+        return NextResponse.json(
+          { error: `Product is not sold in ${currency}` },
+          { status: 400 },
+        );
+      }
+      sessionParams.mode = "payment";
+      sessionParams.line_items = [
+        {
+          quantity: 1,
+          price_data: {
+            currency,
+            unit_amount: amount,
+            product_data: { name: productName },
+          },
+        },
+      ];
+      // Offer to save the card for future purchases. Checked = saved with
+      // `allow_redisplay: always`, so it's offered/prefilled on the customer's
+      // next Checkout and manageable from the billing portal. Subscriptions
+      // (the other branch) already save the card by necessity.
+      sessionParams.saved_payment_method_options = {
+        payment_method_save: "enabled",
+      };
+    } else {
+      const priceRow = await getOrCreateSubscriptionPrice(
+        admin,
+        productId,
+        currency,
+      );
+      if (!priceRow) {
+        await rollbackReservation(admin, reservationId);
+        return NextResponse.json(
+          { error: `Product is not sold in ${currency}` },
+          { status: 400 },
+        );
+      }
+      sessionParams.mode = "subscription";
+      sessionParams.line_items = [
+        { quantity: 1, price: priceRow.stripe_price_id },
+      ];
+      // Describe the sub as "{Club} — {Child}". A family has one Stripe sub per
+      // gamer x club, all listed together in the hosted portal; without a
+      // per-sub description they'd be indistinguishable there (and two kids in
+      // the same club would show as two identical rows). This is the label the
+      // parent reads when deciding which one to cancel.
+      sessionParams.subscription_data = {
+        metadata,
+        description: `${productName} — ${await pickGamerName(admin, gamerId)}`,
+      };
+    }
+
+    const session = await stripe.checkout.sessions.create(sessionParams);
+
+    if (!session.url) {
+      await rollbackReservation(admin, reservationId);
+      return NextResponse.json(
+        { error: "Stripe did not return a Checkout URL" },
+        { status: 502 },
+      );
+    }
+
+    return { status: "redirect" as const, checkoutUrl: session.url };
+  },
+});
 
 // Resolve a short display name for the gamer, for the Stripe subscription
 // description (what the parent sees in the billing portal). Falls back to a

--- a/src/app/api/family/list/route.ts
+++ b/src/app/api/family/list/route.ts
@@ -1,31 +1,36 @@
-import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { resolveFamilyWithAdmin } from "@/services/family/family.server";
 
 /**
+ * GET /api/family/list
+ *
  * Return every member of the caller's family unit (the caller themselves,
  * any linked parent(s), and every gamer linked to any of those parents).
  *
  * Used by the dashboard profile selector. Service-role read so a gamer can
  * see their siblings — RLS otherwise restricts gamers to seeing only their
- * own parent_gamer rows. The resolution itself lives in
- * `resolveFamilyWithAdmin`, shared with the /select-profile RSC prefetch;
- * identity is the `requireRole`-verified `user.id`, never request input.
+ * own parent_gamer rows. The resolution lives in the shared family resolver;
+ * identity is the gate-verified `user.id`, never request input.
+ *
+ * allowUnverified: the profile chooser and the lock gate both need the family
+ * list while the customer session is still locked, so the parent can see and
+ * switch to a gamer without first entering the PIN.
  */
-export async function GET() {
-  // allowUnverified: the profile chooser (/select-profile) and the lock gate
-  // both need the family list while the customer session is still locked, so
-  // the parent can see and switch to a gamer without first entering the PIN.
-  const auth = await requireRole(["customer", "gamer"], { allowUnverified: true });
-  if (auth instanceof NextResponse) return auth;
-  const { user, profile } = auth;
+export const GET = defineRoute({
+  posture: "role-gated",
+  roles: ["customer", "gamer"],
+  allowUnverified: true,
 
-  try {
-    const family = await resolveFamilyWithAdmin(createAdminClient(), user.id, profile.role);
-    return NextResponse.json({ family });
-  } catch (error) {
-    console.error("family/list: failed to resolve family", error);
-    return NextResponse.json({ error: "Failed to load family" }, { status: 500 });
-  }
-}
+  // A resolver failure was already answered generically here; it now goes
+  // through the shared catch, which logs it with the route path attached.
+
+  handler: async ({ user, profile }) => {
+    const family = await resolveFamilyWithAdmin(
+      createAdminClient(),
+      user.id,
+      profile.role,
+    );
+    return { family };
+  },
+});

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,54 +1,57 @@
 import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { sendTransactionalEmail } from "@/lib/brevo";
 import { buildFeedbackEmail } from "@/lib/email-templates/feedback";
 import { getEmailTranslator } from "@/lib/email-templates/translator";
 import { SENDER_EMAIL } from "@/lib/constants";
-import { detectLocaleFromHeader, isSupportedLocale } from "@/lib/constants/locales";
+import {
+  detectLocaleFromHeader,
+  isSupportedLocale,
+} from "@/lib/constants/locales";
 import { ROLE_LABEL_KEYS } from "@/lib/constants/roles";
-import { z } from "zod";
 
 const feedbackSchema = z.object({
-  message: z.string().min(10, "Message must be at least 10 characters").max(2000, "Message must be at most 2000 characters"),
+  message: z
+    .string()
+    .min(10, "Message must be at least 10 characters")
+    .max(2000, "Message must be at most 2000 characters"),
 });
 
-export async function POST(request: Request) {
-  try {
-    const result = await requireRole(["admin", "customer", "gamer", "gedu"]);
-    if (result instanceof NextResponse) return result;
+/**
+ * POST /api/feedback
+ *
+ * Naming all four roles is this gate's way of spelling "any authenticated
+ * caller", and it stays that way deliberately: it loads the profile (the email
+ * template needs the name, role and locale) and applies the parent-PIN gate
+ * along the way, neither of which the any-authenticated posture does.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: ["admin", "customer", "gamer", "gedu"],
+  body: feedbackSchema,
 
-    const { user, profile, supabase } = result;
+  // The submission RPC is self-scoping and its only failure is "the write did
+  // not happen", which the shared table answers as a logged, generic 500. The
+  // route used to return the thrown message from its own catch — incidental
+  // forwarding, now closed.
 
-    const body = await request.json();
-    const parsed = feedbackSchema.safeParse(body);
-
-    if (!parsed.success) {
-      const firstError = parsed.error.errors[0];
-      return NextResponse.json(
-        { error: firstError.message },
-        { status: 400 }
-      );
-    }
-
+  handler: async ({ request, supabase, user, profile, body }) => {
     // Atomic rate-limit check + insert via a self-scoping RPC on the USER-bound
     // client: `submit_my_feedback` writes a row for `auth.uid()` and has no
     // parameter naming a user, so this handler cannot file feedback as anyone
     // else. It re-checks the same length bounds the schema above enforces.
     const { data: accepted, error: rpcError } = await supabase.rpc(
       "submit_my_feedback",
-      { p_message: parsed.data.message },
+      { p_message: body.message },
     );
-
-    if (rpcError) {
-      console.error("Failed to submit feedback:", rpcError);
-      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-    }
-
+    if (rpcError) throw rpcError;
     if (!accepted) {
       return NextResponse.json(
         { error: "Too many feedback submissions. Please try again later." },
-        { status: 429 }
+        { status: 429 },
       );
     }
 
@@ -67,12 +70,11 @@ export async function POST(request: Request) {
 
     if (adminsError || !admins.length) {
       console.error("Failed to fetch admin emails:", adminsError);
-      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+      throw new ApiError("no admin recipients for the feedback notification", 500);
     }
 
     const adminEmails = admins.flatMap((a) => (a.email ? [a.email] : []));
 
-    // Determine reply-to email
     const role = profile.role;
     const userEmail = profile.email || "";
     let replyToEmail = userEmail;
@@ -81,7 +83,6 @@ export async function POST(request: Request) {
 
     if (role === "gamer") {
       isGamer = true;
-      // Look up parent's email
       const { data: parentLink } = await adminClient
         .from("parent_gamer")
         .select("parent_id")
@@ -116,8 +117,11 @@ export async function POST(request: Request) {
       userName: displayName,
       userRole: role,
       userEmail: replyToEmail || userEmail,
-      message: parsed.data.message,
-      sentAt: new Date().toLocaleString(locale, { dateStyle: "medium", timeStyle: "short" }),
+      message: body.message,
+      sentAt: new Date().toLocaleString(locale, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
       isGamer,
       parentEmail,
     });
@@ -126,16 +130,14 @@ export async function POST(request: Request) {
       fromEmail: SENDER_EMAIL,
       fromName: t("senderFeedback"),
       toEmail: adminEmails,
-      subject: t("feedback.subject", { displayName, role: t(ROLE_LABEL_KEYS[role]) }),
+      subject: t("feedback.subject", {
+        displayName,
+        role: t(ROLE_LABEL_KEYS[role]),
+      }),
       htmlContent,
       replyToEmail: replyToEmail || undefined,
     });
 
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Internal server error";
-    console.error("Feedback submission error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+    return { success: true };
+  },
+});

--- a/src/app/api/gamers/[id]/route.ts
+++ b/src/app/api/gamers/[id]/route.ts
@@ -1,70 +1,42 @@
 import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
-import { DISPLAY_NAME_MIN, DISPLAY_NAME_MAX } from "@/lib/constants";
+import { lookupMinecraftUser } from "@/lib/mojang";
+import { updateGamerBody } from "@/services/gamers/gamers.contracts";
 
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  try {
-    // 1. Authenticate caller + enforce customer role
-    const result = await requireRole("customer", {
-      forbiddenMessage: "Only customers can update gamer accounts",
-    });
-    if (result instanceof NextResponse) return result;
-    const { supabase } = result;
+/**
+ * PATCH /api/gamers/[id] — a parent edits one of their own gamers.
+ *
+ * Two authorization layers before anything is written: the parent_gamer link is
+ * confirmed on the RLS-bound client (so the database agrees the caller owns the
+ * link), and the target's role is confirmed to be `gamer` on the admin client
+ * (so a link row can never be used to reach a non-gamer account).
+ */
+export const PATCH = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  forbiddenMessage: "Only customers can update gamer accounts",
+  params: z.object({ id: z.string().uuid() }),
+  body: updateGamerBody,
 
-    const { id: gamerId } = await params;
+  // The hand-rolled `typeof` checks are now the shared body schema, which also
+  // preserves the one distinction the old code carried in `"key" in body`: an
+  // explicit null Minecraft username unlinks, an absent key leaves it alone.
+  //
+  // Every write failure used to be returned as a 500 carrying the driver's or
+  // GoTrue's own message. Those are logged now and answered through the shared
+  // table; the already-linked conflict keeps its copy because the status alone
+  // does not explain it.
 
-    // 2. Validate input
-    const body = await request.json();
-    const { firstName, password } = body;
-    const hasMinecraft = "minecraftUsername" in body;
+  handler: async ({ supabase, user, params, body }) => {
+    const gamerId = params.id;
 
-    if (!firstName && !password && !hasMinecraft) {
-      return NextResponse.json(
-        { error: "At least one of firstName, password, or minecraftUsername is required" },
-        { status: 400 },
-      );
-    }
-
-    if (firstName !== undefined) {
-      if (typeof firstName !== "string" || firstName.trim().length < DISPLAY_NAME_MIN || firstName.trim().length > DISPLAY_NAME_MAX) {
-        return NextResponse.json(
-          { error: `First name must be between ${DISPLAY_NAME_MIN} and ${DISPLAY_NAME_MAX} characters` },
-          { status: 400 },
-        );
-      }
-    }
-
-    if ("password" in body) {
-      if (typeof password !== "string" || password.length < 6) {
-        return NextResponse.json(
-          { error: "Password must be at least 6 characters" },
-          { status: 400 },
-        );
-      }
-    }
-
-    if (hasMinecraft && body.minecraftUsername !== null) {
-      if (
-        typeof body.minecraftUsername !== "string" ||
-        !isValidMinecraftUsername(body.minecraftUsername)
-      ) {
-        return NextResponse.json(
-          { error: "Invalid Minecraft username. Must be 3-16 characters: letters, numbers, underscores." },
-          { status: 400 },
-        );
-      }
-    }
-
-    // 3. Verify parent-child relationship via RLS-protected client
+    // Verify parent-child relationship via the RLS-protected client.
     const { data: link, error: linkError } = await supabase
       .from("parent_gamer")
       .select("id")
-      .eq("parent_id", result.user.id)
+      .eq("parent_id", user.id)
       .eq("gamer_id", gamerId)
       .maybeSingle();
 
@@ -75,7 +47,7 @@ export async function PATCH(
       );
     }
 
-    // 4. Verify target is a gamer (defense-in-depth)
+    // Verify the target really is a gamer (defense in depth).
     const admin = createAdminClient();
     const { data: targetProfile, error: targetError } = await admin
       .from("profiles")
@@ -90,69 +62,53 @@ export async function PATCH(
       );
     }
 
-    // 5. Apply updates via admin client
-    if (firstName !== undefined) {
-      const trimmed = firstName.trim();
-
+    if (body.firstName !== undefined) {
       const { data: updatedRow, error: profileError } = await admin
         .from("profiles")
-        .update({ first_name: trimmed })
+        .update({ first_name: body.firstName })
         .eq("id", gamerId)
         .select("first_name, last_name")
         .single();
 
-      if (profileError) {
-        return NextResponse.json(
-          { error: profileError.message },
-          { status: 500 },
-        );
-      }
+      if (profileError) throw profileError;
 
       // Sync to auth metadata so the Supabase dashboard label stays current.
       // Compose display_name from the post-update row so the dashboard sees a
-      // human-readable full name. The profiles table is the source of truth —
-      // if this sync fails, the app is unaffected.
+      // human-readable full name. The profiles table is the source of truth.
       const composed = [updatedRow.first_name, updatedRow.last_name]
         .filter(Boolean)
         .join(" ");
       const { error: authError } = await admin.auth.admin.updateUserById(
         gamerId,
-        { user_metadata: { first_name: updatedRow.first_name, display_name: composed } },
+        {
+          user_metadata: {
+            first_name: updatedRow.first_name,
+            display_name: composed,
+          },
+        },
       );
 
-      if (authError) {
-        return NextResponse.json(
-          { error: authError.message },
-          { status: 500 },
-        );
-      }
+      if (authError) throw authError;
     }
 
-    if ("password" in body) {
-      const { error: pwError } = await admin.auth.admin.updateUserById(
-        gamerId,
-        { password },
-      );
-
-      if (pwError) {
-        return NextResponse.json({ error: pwError.message }, { status: 500 });
-      }
+    if (body.password !== undefined) {
+      const { error: pwError } = await admin.auth.admin.updateUserById(gamerId, {
+        password: body.password,
+      });
+      if (pwError) throw pwError;
     }
 
-    // 6. Update Minecraft username if provided (stored in minecraft_accounts)
-    if (hasMinecraft) {
-      let mcUpsert: { user_id: string; minecraft_username: string | null; minecraft_uuid: string | null };
-
-      if (body.minecraftUsername === null) {
-        mcUpsert = { user_id: gamerId, minecraft_username: null, minecraft_uuid: null };
-      } else {
-        const mojang = await lookupMinecraftUser(body.minecraftUsername);
-        mcUpsert = {
-          user_id: gamerId,
-          minecraft_username: body.minecraftUsername,
-          minecraft_uuid: mojang?.uuid ?? null,
-        };
-      }
+    if (body.minecraftUsername !== undefined) {
+      const username = body.minecraftUsername;
+      const mcUpsert =
+        username === null
+          ? { user_id: gamerId, minecraft_username: null, minecraft_uuid: null }
+          : {
+              user_id: gamerId,
+              minecraft_username: username,
+              minecraft_uuid:
+                (await lookupMinecraftUser(username))?.uuid ?? null,
+            };
 
       const { error: mcError } = await admin
         .from("minecraft_accounts")
@@ -161,33 +117,24 @@ export async function PATCH(
       if (mcError) {
         if (mcError.code === "23505") {
           return NextResponse.json(
-            { error: "This Minecraft account is already linked to another user" },
+            {
+              error: "This Minecraft account is already linked to another user",
+            },
             { status: 409 },
           );
         }
-        return NextResponse.json({ error: "Failed to update Minecraft account" }, { status: 500 });
+        throw mcError;
       }
     }
 
-    // 7. Return updated profile
     const { data: updatedProfile, error: fetchError } = await admin
       .from("profiles")
       .select("*")
       .eq("id", gamerId)
       .single();
 
-    if (fetchError) {
-      return NextResponse.json(
-        { error: fetchError.message },
-        { status: 500 },
-      );
-    }
+    if (fetchError) throw fetchError;
 
-    return NextResponse.json({ gamer: updatedProfile });
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
-}
+    return { gamer: updatedProfile };
+  },
+});

--- a/src/app/api/gamers/create/route.ts
+++ b/src/app/api/gamers/create/route.ts
@@ -1,22 +1,11 @@
 import { NextResponse } from "next/server";
 import { randomBytes } from "crypto";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { generateGamerEmail } from "@/lib/utils";
-import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
-import { DISPLAY_NAME_MIN, DISPLAY_NAME_MAX } from "@/lib/constants";
-import { Constants, type GenderType } from "@/types";
-
-// Runtime values of the gender_type DB enum — the source of truth for what
-// the gamer_profiles CHECK accepts, so route validation can't drift from it.
-const VALID_GENDERS = Constants.public.Enums.gender_type;
-
-function isGenderValue(value: unknown): value is GenderType {
-  return (
-    typeof value === "string" &&
-    (VALID_GENDERS as readonly string[]).includes(value)
-  );
-}
+import { lookupMinecraftUser } from "@/lib/mojang";
+import { createGamerBody } from "@/services/gamers/gamers.contracts";
+import type { GenderType } from "@/types";
 
 // Local part of the gamer's synthetic email + password. Opaque on purpose:
 // the parent never sees either (gamer login is via account-switching from the
@@ -29,61 +18,52 @@ function generateOpaqueGamerPassword(): string {
   return randomBytes(24).toString("base64url");
 }
 
-export async function POST(request: Request) {
-  // Hoisted so the catch can clean up: once the auth user is created, any later
-  // throw would orphan it (a login with no usable gamer record). The create_gamer
-  // RPC is transactional, so the DB itself is always left untouched on failure —
-  // this marker only tracks the auth-user side that lives outside that transaction.
-  const admin = createAdminClient();
-  let createdAuthUserId: string | null = null;
-  try {
-    const result = await requireRole("customer", {
-      forbiddenMessage: "Switch to a parent account to add a gamer.",
-    });
-    if (result instanceof NextResponse) return result;
-    const { user } = result;
+/**
+ * POST /api/gamers/create — a parent adds a child account.
+ *
+ * The auth user is created before the promotion RPC runs, so any failure after
+ * that point would orphan it (a login with no usable gamer record). The RPC is
+ * transactional, so the database is always left untouched on failure; the
+ * compensating delete below covers the auth-user side that lives outside that
+ * transaction, including the case where the wrapper's catch is what ends the
+ * request.
+ */
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  forbiddenMessage: "Switch to a parent account to add a gamer.",
+  body: createGamerBody,
 
-    const body = await request.json();
+  // The body's hand-rolled `typeof` checks are now the shared schema. The RPC's
+  // only reachable unique violation is the Minecraft UUID race, which keeps its
+  // explicit 409 and its stable `code` because the client maps it; every other
+  // failure is logged and answered generically, which is what this route
+  // already did deliberately ("it's Postgres text the parent shouldn't see").
+
+  handler: async ({ user, body }) => {
+    const admin = createAdminClient();
     const { firstName, dateOfBirth, gender: providedGender, minecraftUsername } = body;
-
-    if (!firstName || typeof firstName !== "string" || firstName.trim().length < DISPLAY_NAME_MIN || firstName.trim().length > DISPLAY_NAME_MAX) {
-      return NextResponse.json(
-        { error: `First name must be between ${DISPLAY_NAME_MIN} and ${DISPLAY_NAME_MAX} characters` },
-        { status: 400 }
-      );
-    }
-
-    if (!dateOfBirth || typeof dateOfBirth !== "string") {
-      return NextResponse.json(
-        { error: "Date of birth is required" },
-        { status: 400 }
-      );
-    }
 
     const dobDate = new Date(dateOfBirth + "T00:00:00");
     if (isNaN(dobDate.getTime()) || dobDate > new Date()) {
       return NextResponse.json(
         { error: "Date of birth cannot be in the future" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    let gender: GenderType | null;
-    if (providedGender === undefined || providedGender === null || providedGender === "") {
-      gender = null;
-    } else if (isGenderValue(providedGender)) {
-      gender = providedGender;
-    } else {
-      return NextResponse.json(
-        { error: "Gender must be boy, girl, or non_binary" },
-        { status: 400 }
-      );
-    }
+    // "" and null both mean "no value recorded".
+    const gender: GenderType | null =
+      providedGender === undefined ||
+      providedGender === null ||
+      providedGender === ""
+        ? null
+        : providedGender;
 
     const password = generateOpaqueGamerPassword();
 
-    // Belt-and-braces: 64 bits of entropy means collisions are
-    // vanishingly improbable, but check once and retry once just in case.
+    // Belt-and-braces: 64 bits of entropy means collisions are vanishingly
+    // improbable, but check once and retry once just in case.
     let syntheticEmail = generateGamerEmail(generateGamerEmailLocalPart());
     const { data: collision } = await admin
       .from("profiles")
@@ -92,15 +72,6 @@ export async function POST(request: Request) {
       .maybeSingle();
     if (collision) {
       syntheticEmail = generateGamerEmail(generateGamerEmailLocalPart());
-    }
-
-    if (minecraftUsername !== undefined && minecraftUsername !== null) {
-      if (typeof minecraftUsername !== "string" || !isValidMinecraftUsername(minecraftUsername)) {
-        return NextResponse.json(
-          { error: "Invalid Minecraft username. Must be 3-16 characters: letters, numbers, underscores." },
-          { status: 400 }
-        );
-      }
     }
 
     // Snapshot the parent's last_name onto the gamer at creation time. The
@@ -114,10 +85,10 @@ export async function POST(request: Request) {
       .single();
     const inheritedLastName = parentProfile?.last_name ?? "";
 
-    // Resolve Minecraft account BEFORE creating auth user — the UNIQUE
-    // constraint on minecraft_uuid can reject this, and createUser burns
-    // the username irreversibly. By checking first, the parent can retry
-    // with a different Minecraft name without losing the gamer username.
+    // Resolve Minecraft account BEFORE creating the auth user — the UNIQUE
+    // constraint on minecraft_uuid can reject this, and createUser burns the
+    // username irreversibly. By checking first, the parent can retry with a
+    // different Minecraft name without losing the gamer username.
     let resolvedMinecraft: { username: string; uuid: string | null } | null = null;
     if (minecraftUsername) {
       const mojang = await lookupMinecraftUser(minecraftUsername);
@@ -150,7 +121,7 @@ export async function POST(request: Request) {
       .filter(Boolean)
       .join(" ");
 
-    // Step 1: Create auth user — trigger assigns customer role by default
+    // Step 1: Create auth user — trigger assigns customer role by default.
     const { data: authData, error: authError } =
       await admin.auth.admin.createUser({
         email: syntheticEmail,
@@ -164,86 +135,87 @@ export async function POST(request: Request) {
       });
 
     if (authError) {
-      return NextResponse.json({ error: authError.message }, { status: 400 });
+      console.error("gamer creation: createUser failed", authError);
+      return NextResponse.json(
+        { error: "Something went wrong creating the gamer. Please try again." },
+        { status: 400 },
+      );
     }
 
     const gamerId = authData.user.id;
-    createdAuthUserId = gamerId;
 
-    // Step 2: Promote + link atomically. handle_new_user already seeded a
-    // 'customer' profile + customer_profiles row for the new auth user; this
-    // RPC swaps it to a gamer, inserts the gamer/minecraft rows, and links the
-    // parent — all in one transaction, so a failure can't leave a half-promoted
-    // orphan (see migration 00113). The synthetic email the trigger copied from
-    // auth.users is left untouched (gamers are email-first).
-    const { error: rpcError } = await admin.rpc("create_gamer", {
-      p_gamer_id: gamerId,
-      p_parent_id: user.id,
-      p_first_name: firstName,
-      p_last_name: inheritedLastName,
-      p_date_of_birth: dateOfBirth,
-      // Omit (→ undefined) rather than pass null: the RPC params default to
-      // null, and the generated Args type accepts undefined, not null. A null
-      // Mojang UUID still inserts a Minecraft row (username present, uuid null).
-      p_gender: gender ?? undefined,
-      p_minecraft_username: resolvedMinecraft?.username ?? undefined,
-      p_minecraft_uuid: resolvedMinecraft?.uuid ?? undefined,
-    });
+    try {
+      // Step 2: Promote + link atomically. handle_new_user already seeded a
+      // 'customer' profile + customer_profiles row for the new auth user; this
+      // RPC swaps it to a gamer, inserts the gamer/minecraft rows, and links the
+      // parent — all in one transaction, so a failure can't leave a
+      // half-promoted orphan. The synthetic email the trigger copied from
+      // auth.users is left untouched (gamers are email-first).
+      const { error: rpcError } = await admin.rpc("create_gamer", {
+        p_gamer_id: gamerId,
+        p_parent_id: user.id,
+        p_first_name: firstName,
+        p_last_name: inheritedLastName,
+        p_date_of_birth: dateOfBirth,
+        // Omit (→ undefined) rather than pass null: the RPC params default to
+        // null, and the generated Args type accepts undefined, not null. A null
+        // Mojang UUID still inserts a Minecraft row (username present, uuid null).
+        p_gender: gender ?? undefined,
+        p_minecraft_username: resolvedMinecraft?.username ?? undefined,
+        p_minecraft_uuid: resolvedMinecraft?.uuid ?? undefined,
+      });
 
-    if (rpcError) {
-      // The RPC ran in a transaction, so no partial gamer record persisted —
-      // but the auth user we created above would now be orphaned (a login with
-      // no usable gamer record), so delete it before returning the error.
-      await deleteOrphanedAuthUser(admin, gamerId);
+      if (rpcError) {
+        // The RPC ran in a transaction, so no partial gamer record persisted —
+        // but the auth user we created above would now be orphaned, so delete
+        // it before returning the error.
+        await deleteOrphanedAuthUser(admin, gamerId);
 
-      // The only unique constraint create_gamer can hit is minecraft_uuid: the
-      // 00114 guard makes a double-promote raise P0001 (not 23505) before any
-      // insert runs, and gamer_profiles/parent_gamer can't collide for a
-      // brand-new id. So a 23505 unambiguously means the minecraft_uuid race
-      // (claimed between our pre-check and the RPC's insert) — map it to the
-      // same 409 as before. Revisit this mapping if a future unique constraint
-      // is added inside the RPC.
-      const isMinecraftConflict = rpcError.code === "23505";
-      if (!isMinecraftConflict) {
+        // The only unique constraint create_gamer can hit is minecraft_uuid:
+        // the double-promote guard raises P0001 (not 23505) before any insert
+        // runs, and gamer_profiles/parent_gamer can't collide for a brand-new
+        // id. So a 23505 unambiguously means the minecraft_uuid race (claimed
+        // between our pre-check and the RPC's insert). Revisit this mapping if
+        // a future unique constraint is added inside the RPC.
+        if (rpcError.code === "23505") {
+          return NextResponse.json(
+            {
+              error: "This Minecraft account is already linked to another user",
+              code: "minecraft_already_linked",
+            },
+            { status: 409 },
+          );
+        }
+
         // Anything else is an internal failure (a constraint, the promote
         // guard's raise, a connection error). Log the raw error for debugging
         // but never surface it: it's Postgres text the parent shouldn't see,
         // and there's nothing actionable in it for them.
         console.error("create_gamer RPC failed", rpcError);
+        return NextResponse.json(
+          {
+            error:
+              "Something went wrong creating the gamer. Please try again.",
+          },
+          { status: 500 },
+        );
       }
-      return NextResponse.json(
-        isMinecraftConflict
-          ? {
-              error: "This Minecraft account is already linked to another user",
-              code: "minecraft_already_linked",
-            }
-          : { error: "Something went wrong creating the gamer. Please try again." },
-        { status: isMinecraftConflict ? 409 : 500 },
-      );
+    } catch (err) {
+      // A throw anywhere after the auth user was created would orphan it. The
+      // RPC is transactional, so the database is already untouched; delete the
+      // auth user so a retry starts from a clean slate rather than colliding or
+      // piling up. The wrapper's catch then turns this into a logged 500.
+      await deleteOrphanedAuthUser(admin, gamerId);
+      throw err;
     }
 
     // The RPC committed, so the gamer exists. Return only its id — the sole
-    // thing callers consume (to pre-select the new gamer). The client invalidates
-    // the gamers list on success and refetches the full row from there, so there's
-    // no reason to read it back here.
-    return NextResponse.json({ gamerId });
-  } catch (err) {
-    // Log the root cause: without this, a thrown failure (an rpc/network error,
-    // a thrown deleteUser, a read-back failure) produced a bare 500 with nothing
-    // recorded — exactly the failures hardest to reproduce.
-    console.error("gamer creation failed", err);
-    // A throw anywhere after the auth user was created would orphan it. The RPC
-    // is transactional, so the DB is already untouched; delete the auth user so
-    // a retry starts from a clean slate rather than colliding or piling up.
-    if (createdAuthUserId) {
-      await deleteOrphanedAuthUser(admin, createdAuthUserId);
-    }
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
-  }
-}
+    // thing callers consume (to pre-select the new gamer). The client
+    // invalidates the gamers list on success and refetches the full row from
+    // there, so there's no reason to read it back here.
+    return { gamerId };
+  },
+});
 
 // Best-effort cleanup of the auth user when post-auth creation fails. If the
 // delete itself fails we can't do anything useful — but we must record it: that

--- a/src/app/api/gedu/register/route.ts
+++ b/src/app/api/gedu/register/route.ts
@@ -1,19 +1,31 @@
 import { NextResponse } from "next/server";
+import { defineRoute } from "@/lib/api/define-route";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { parseJsonBody } from "@/lib/api/json-body.server";
 import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
 import { toE164Digits } from "@/lib/utils";
 import { resolveLocale } from "@/lib/constants/locales";
 import { registerGeduBody } from "@/services/gedu/gedu-registration.contracts";
 
-// Public, unauthenticated: gedus self-register (like parents). A new gedu is
-// created unverified; an admin verifies them before they can be assigned to a
-// group (the verification gate lives in the assignment UI, not here).
-export async function POST(request: Request) {
-  try {
-    const body = await parseJsonBody(request, registerGeduBody);
-    if (body instanceof NextResponse) return body;
+/**
+ * POST /api/gedu/register
+ *
+ * Educators self-register, like parents. A new gedu is created unverified; an
+ * admin verifies them before they can be assigned to a group (the verification
+ * gate lives in the assignment UI, not here).
+ */
+export const POST = defineRoute({
+  posture: "public",
+  reason:
+    "educators self-register, so no session can exist yet. The highest-value public route on the surface: it creates an account, and the account it creates is unverified until an admin approves it",
+  body: registerGeduBody,
 
+  // The promotion RPC's failure used to be returned to the registrant as a 500
+  // carrying its raw message. That is closed: the one outcome they can act on
+  // (the Minecraft account is taken) keeps its own copy, and everything else is
+  // logged and answered generically. Nothing here opts into disclosure, because
+  // an unauthenticated caller is the last one who should be shown database text.
+
+  handler: async ({ body }) => {
     const {
       email,
       password,
@@ -28,21 +40,24 @@ export async function POST(request: Request) {
 
     const locale = resolveLocale(requestedLocale);
 
-    // Phone → digits to match the profiles.phone CHECK (^\d{7,15}$). Empty/absent
-    // stays "" and the RPC NULLIFs it.
+    // Phone → digits to match the profiles.phone CHECK (^\d{7,15}$). Empty or
+    // absent stays "" and the RPC NULLIFs it.
     let phoneDigits = "";
     if (phone && phone.trim()) {
       const digits = toE164Digits(phone);
       if (!digits || !/^\d{7,15}$/.test(digits)) {
-        return NextResponse.json({ error: "Invalid phone number" }, { status: 400 });
+        return NextResponse.json(
+          { error: "Invalid phone number" },
+          { status: 400 },
+        );
       }
       phoneDigits = digits;
     }
 
     const admin = createAdminClient();
 
-    // Resolve Minecraft BEFORE creating the auth user — the UNIQUE constraint on
-    // minecraft_uuid can reject this, and createUser burns the email
+    // Resolve Minecraft BEFORE creating the auth user — the UNIQUE constraint
+    // on minecraft_uuid can reject this, and createUser burns the email
     // irreversibly. Checking first lets the gedu retry with a different name
     // without an orphaned auth user.
     let resolvedMc: { username: string; uuid: string | null } | null = null;
@@ -50,7 +65,10 @@ export async function POST(request: Request) {
     if (mcName) {
       if (!isValidMinecraftUsername(mcName)) {
         return NextResponse.json(
-          { error: "Invalid Minecraft username. Must be 3-16 characters: letters, numbers, underscores." },
+          {
+            error:
+              "Invalid Minecraft username. Must be 3-16 characters: letters, numbers, underscores.",
+          },
           { status: 400 },
         );
       }
@@ -65,7 +83,9 @@ export async function POST(request: Request) {
           .maybeSingle();
         if (existingMc) {
           return NextResponse.json(
-            { error: "This Minecraft account is already linked to another user" },
+            {
+              error: "This Minecraft account is already linked to another user",
+            },
             { status: 409 },
           );
         }
@@ -73,32 +93,43 @@ export async function POST(request: Request) {
     }
 
     // Step 1: create the auth user. The handle_new_user trigger seeds a
-    // customer-role profile + customer_profiles row; email_confirm short-circuits
-    // the (disabled) confirmation flow so the gedu can sign in immediately.
+    // customer-role profile + customer_profiles row; email_confirm
+    // short-circuits the (disabled) confirmation flow so the gedu can sign in
+    // immediately.
     const composedDisplayName = [firstName, lastName].filter(Boolean).join(" ");
-    const { data: authData, error: authError } = await admin.auth.admin.createUser({
-      email,
-      password,
-      email_confirm: true,
-      user_metadata: {
-        first_name: firstName,
-        last_name: lastName,
-        display_name: composedDisplayName,
-      },
-    });
+    const { data: authData, error: authError } =
+      await admin.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: {
+          first_name: firstName,
+          last_name: lastName,
+          display_name: composedDisplayName,
+        },
+      });
 
     if (authError) {
-      // Most commonly: the email is already registered.
-      return NextResponse.json({ error: authError.message }, { status: 400 });
+      // Most commonly: the email is already registered. That is the one thing
+      // the registrant can act on, so it keeps its own copy — and it says no
+      // more than the sign-in form would already tell them.
+      console.error("[gedu/register] createUser failed", authError);
+      return NextResponse.json(
+        {
+          error:
+            "That email could not be registered. If you already have an account, sign in instead.",
+        },
+        { status: 400 },
+      );
     }
 
     const userId = authData.user.id;
 
     // Step 2: atomic promotion. The RPC swaps customer→gedu, writes the profile
-    // fields, coverage, and Minecraft account in one transaction. On any failure
-    // we delete the auth user so no half-promoted debris survives — the narrow
-    // remaining gap (process death between createUser and the RPC) is far smaller
-    // than the old multi-step invite route's exposure.
+    // fields, coverage, and Minecraft account in one transaction. On any
+    // failure we delete the auth user so no half-promoted debris survives — the
+    // narrow remaining gap (process death between createUser and the RPC) is
+    // far smaller than the old multi-step invite route's exposure.
     const { error: rpcError } = await admin.rpc("register_gedu", {
       p_user_id: userId,
       p_first_name: firstName,
@@ -113,19 +144,19 @@ export async function POST(request: Request) {
 
     if (rpcError) {
       await admin.auth.admin.deleteUser(userId);
-      const isDupMc = rpcError.code === "23505";
+      if (rpcError.code === "23505") {
+        return NextResponse.json(
+          { error: "This Minecraft account is already linked to another user" },
+          { status: 409 },
+        );
+      }
+      console.error("[gedu/register] register_gedu failed", rpcError);
       return NextResponse.json(
-        {
-          error: isDupMc
-            ? "This Minecraft account is already linked to another user"
-            : rpcError.message,
-        },
-        { status: isDupMc ? 409 : 500 },
+        { error: "Registration could not be completed. Please try again." },
+        { status: 500 },
       );
     }
 
-    return NextResponse.json({ userId });
-  } catch {
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+    return { userId };
+  },
+});

--- a/src/app/api/minecraft/account/route.ts
+++ b/src/app/api/minecraft/account/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
-import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
+import { defineRoute } from "@/lib/api/define-route";
+import { lookupMinecraftUser } from "@/lib/mojang";
+import { updateMinecraftAccountBody } from "@/services/minecraft/minecraft.contracts";
 
 /**
  * PATCH /api/minecraft/account — link (or unlink) the CALLER'S OWN Minecraft
@@ -12,70 +13,54 @@ import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
  * session's user id and is never read from the request, so there is no way to
  * name someone else's row here — and if that ever changed, RLS would refuse it.
  */
-export async function PATCH(request: Request) {
-  try {
-    const result = await requireRole(["gamer", "gedu"], {
-      forbiddenMessage: "Only gamers and gedus can update their Minecraft username",
-    });
-    if (result instanceof NextResponse) return result;
-    const { supabase } = result;
+export const PATCH = defineRoute({
+  posture: "role-gated",
+  roles: ["gamer", "gedu"],
+  forbiddenMessage: "Only gamers and gedus can update their Minecraft username",
+  body: updateMinecraftAccountBody,
 
-    const { minecraftUsername } = await request.json();
+  // The two codes this route mapped by hand are the shared table's answers
+  // already: a unique violation is a 409 and a policy refusal is a 403. What
+  // changes is the fall-through, which used to be a blanket 500 with a fixed
+  // message and is now the shared table plus a logged generic message.
 
-    if (minecraftUsername !== null) {
-      if (
-        typeof minecraftUsername !== "string" ||
-        !isValidMinecraftUsername(minecraftUsername)
-      ) {
-        return NextResponse.json(
-          { error: "Invalid Minecraft username. Must be 3-16 characters: letters, numbers, underscores." },
-          { status: 400 },
-        );
-      }
-    }
+  handler: async ({ supabase, user, body }) => {
+    const { minecraftUsername } = body;
 
-    let upsertData: { user_id: string; minecraft_username: string | null; minecraft_uuid: string | null };
-
-    if (minecraftUsername === null) {
-      upsertData = { user_id: result.user.id, minecraft_username: null, minecraft_uuid: null };
-    } else {
-      const mojang = await lookupMinecraftUser(minecraftUsername);
-      upsertData = {
-        user_id: result.user.id,
-        minecraft_username: minecraftUsername,
-        minecraft_uuid: mojang?.uuid ?? null,
-      };
-    }
+    const upsertData =
+      minecraftUsername === null
+        ? {
+            user_id: user.id,
+            minecraft_username: null,
+            minecraft_uuid: null,
+          }
+        : {
+            user_id: user.id,
+            minecraft_username: minecraftUsername,
+            minecraft_uuid:
+              (await lookupMinecraftUser(minecraftUsername))?.uuid ?? null,
+          };
 
     const { error } = await supabase
       .from("minecraft_accounts")
       .upsert(upsertData, { onConflict: "user_id" });
 
     if (error) {
+      // The one code carrying copy the user needs: a bare "Conflict" would not
+      // tell them the account belongs to somebody else.
       if (error.code === "23505") {
         return NextResponse.json(
           { error: "This Minecraft account is already linked to another user" },
           { status: 409 },
         );
       }
-      if (error.code === "42501") {
-        return NextResponse.json(
-          { error: "Not authorized to update this Minecraft account" },
-          { status: 403 },
-        );
-      }
-      return NextResponse.json({ error: "Failed to update Minecraft account" }, { status: 500 });
+      throw error;
     }
 
-    return NextResponse.json({
+    return {
       success: true,
       minecraft_username: upsertData.minecraft_username,
       minecraft_uuid: upsertData.minecraft_uuid,
-    });
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
-}
+    };
+  },
+});

--- a/src/app/api/minecraft/verify/route.ts
+++ b/src/app/api/minecraft/verify/route.ts
@@ -1,36 +1,32 @@
 import { NextResponse } from "next/server";
-import { lookupMinecraftUser, isValidMinecraftUsername } from "@/lib/mojang";
+import { defineRoute } from "@/lib/api/define-route";
+import { lookupMinecraftUser } from "@/lib/mojang";
+import { verifyMinecraftQuery } from "@/services/minecraft/minecraft.contracts";
 
-// Public, unauthenticated: a read-only passthrough to Mojang's public
-// username→UUID API (no DB access, no secrets). The public gedu registration
-// page (/register-gedu) verifies a Minecraft username before any account
-// exists, so this can't require a session. The shared MinecraftUsernameField
-// uses it from authed pages too.
-export async function GET(request: Request) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const username = searchParams.get("username");
+/**
+ * GET /api/minecraft/verify — a read-only passthrough to Mojang's public
+ * username→UUID API (no database access, no secrets).
+ *
+ * The public educator registration page verifies a Minecraft username before
+ * any account exists, so this cannot require a session. The shared username
+ * field uses it from authenticated pages too.
+ */
+export const GET = defineRoute({
+  posture: "public",
+  reason:
+    "a read-only passthrough to Mojang's public username lookup — no database access and no secrets. The public educator registration page checks a username before any account exists, so it cannot require a session",
+  // The username used to be read off the URL and checked by hand; the query
+  // slot is the same rule declared where the rest of the surface declares it.
+  query: verifyMinecraftQuery,
 
-    if (!username || !isValidMinecraftUsername(username)) {
-      return NextResponse.json(
-        { error: "Invalid username. Must be 3-16 characters: letters, numbers, underscores." },
-        { status: 400 },
-      );
-    }
-
-    const profile = await lookupMinecraftUser(username);
+  handler: async ({ query }) => {
+    const profile = await lookupMinecraftUser(query.username);
     if (!profile) {
       return NextResponse.json(
         { error: "No Minecraft account found with that username" },
         { status: 404 },
       );
     }
-
-    return NextResponse.json(profile);
-  } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
-}
+    return profile;
+  },
+});

--- a/src/app/api/parent/billing-portal/route.ts
+++ b/src/app/api/parent/billing-portal/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
+import { z } from "zod";
 import { getLocale } from "next-intl/server";
-import { requireRole } from "@/lib/auth";
+import { defineRoute } from "@/lib/api/define-route";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getOrCreateStripeCustomer } from "@/lib/stripe/customer";
 import { getPortalConfigurationId } from "@/lib/stripe/portal-configuration";
@@ -21,46 +22,51 @@ const STRIPE_PORTAL_LOCALES: Record<
   sv: "sv",
 };
 
+/** Response of POST /api/parent/billing-portal. */
+const billingPortalResponse = z.object({ url: z.string() });
+
 /**
  * Create a Stripe Customer Portal session and hand back its URL. The parent's
  * billing card POSTs here, then does a full-page navigation to the returned
  * `url` so Stripe owns all payment-method / invoice / subscription management.
  *
- * We `getOrCreateStripeCustomer` rather than read-only lookup: the portal needs
- * a customer id, and a parent who's never purchased doesn't have one yet. This
- * lazily provisions it so the "Manage billing" link always works.
+ * We get-or-create the Stripe customer rather than doing a read-only lookup:
+ * the portal needs a customer id, and a parent who's never purchased doesn't
+ * have one yet. This lazily provisions it so "Manage billing" always works.
  */
-export async function POST(request: Request) {
-  const auth = await requireRole("customer");
-  if (auth instanceof NextResponse) return auth;
-  const { user } = auth;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: "customer",
+  response: billingPortalResponse,
 
-  const admin = createAdminClient();
+  handler: async ({ request, user }) => {
+    const admin = createAdminClient();
 
-  let url: string;
-  try {
-    const customerId = await getOrCreateStripeCustomer(admin, user.id);
-    const locale = await getLocale();
+    try {
+      const customerId = await getOrCreateStripeCustomer(admin, user.id);
+      const locale = await getLocale();
 
-    const session = await stripe.billingPortal.sessions.create({
-      customer: customerId,
-      // Our own configuration (not Stripe's dashboard default), so the portal
-      // never offers plan switching for tiers we don't sell. See
-      // `getPortalConfigurationId`.
-      configuration: await getPortalConfigurationId(),
-      // Send them back to the Billing section they came from. `getOrigin`
-      // only trusts known hosts, so a spoofed Host can't redirect elsewhere.
-      return_url: `${getOrigin(request)}/parent#billing`,
-      locale: STRIPE_PORTAL_LOCALES[locale] ?? "auto",
-    });
-    url = session.url;
-  } catch (err) {
-    console.error("[parent/billing-portal] Stripe portal session failed", err);
-    return NextResponse.json(
-      { error: "Failed to open billing portal" },
-      { status: 502 },
-    );
-  }
+      const session = await stripe.billingPortal.sessions.create({
+        customer: customerId,
+        // Our own configuration (not Stripe's dashboard default), so the portal
+        // never offers plan switching for tiers we don't sell.
+        configuration: await getPortalConfigurationId(),
+        // Send them back to the Billing section they came from. `getOrigin`
+        // only trusts known hosts, so a spoofed Host can't redirect elsewhere.
+        return_url: `${getOrigin(request)}/parent#billing`,
+        locale: STRIPE_PORTAL_LOCALES[locale] ?? "auto",
+      });
 
-  return NextResponse.json({ url });
-}
+      return { url: session.url };
+    } catch (err) {
+      // 502 rather than the shared table's 500: the failure is upstream at
+      // Stripe, and the parent's retry is worth prompting. Kept as an explicit
+      // response because the wrapper has no bad-gateway default.
+      console.error("[parent/billing-portal] Stripe portal session failed", err);
+      return NextResponse.json(
+        { error: "Failed to open billing portal" },
+        { status: 502 },
+      );
+    }
+  },
+});

--- a/src/app/api/user/locale/route.ts
+++ b/src/app/api/user/locale/route.ts
@@ -1,6 +1,11 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
-import { isSupportedLocale } from "@/lib/constants/locales";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
+import { SUPPORTED_LOCALES } from "@/lib/constants/locales";
+
+/** Request body of PATCH /api/user/locale. */
+const setLocaleBody = z.object({
+  locale: z.enum(SUPPORTED_LOCALES),
+});
 
 /**
  * PATCH /api/user/locale — set the caller's own UI locale.
@@ -10,53 +15,31 @@ import { isSupportedLocale } from "@/lib/constants/locales";
  * database refuses a write aimed at anyone else's row even though this handler
  * never aims one.
  *
- * (The route previously used the service-role client to work around a typing
- * problem in @supabase/ssr 0.5.2, where `.update()` resolved as `never`. That
- * dependency is on 0.9 now and the workaround was obsolete — the grant, not the
- * types, was the real reason the write couldn't run as the user.)
+ * The any-authenticated posture is the point of this route: every role sets
+ * their own interface language, and the write is scoped to the caller's own row
+ * by the grant plus the self-update policy, so the role is genuinely irrelevant.
+ * The caller's id comes from the verified session, never from the body.
  */
-export async function PATCH(request: Request) {
-  try {
-    const supabase = await createClient();
+export const PATCH = defineRoute({
+  posture: "any-authenticated",
+  reason:
+    "every role sets their own interface language, and the write is scoped to the caller's own row by a column grant plus a self-update policy, so the role is genuinely irrelevant here",
+  body: setLocaleBody,
+  response: setLocaleBody,
 
-    // `getClaims()` verifies the access token locally against the project JWKS —
-    // no GoTrue round-trip. We only need the subject.
-    const { data, error: claimsError } = await supabase.auth.getClaims();
-    const userId = data?.claims.sub;
+  // The route used to answer 500 for every database failure except the policy
+  // refusal. On the shared table the refusal is still a 403 and anything
+  // unrecognized is still a logged 500, so the observable mapping is unchanged
+  // — it is now the shared one rather than a local re-implementation.
 
-    if (claimsError || !userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { locale } = await request.json();
-
-    if (!isSupportedLocale(locale)) {
-      return NextResponse.json(
-        { error: "Invalid locale" },
-        { status: 400 },
-      );
-    }
-
+  handler: async ({ supabase, user, body }) => {
     const { error } = await supabase
       .from("profiles")
-      .update({ locale })
-      .eq("id", userId);
+      .update({ locale: body.locale })
+      .eq("id", user.id);
 
-    if (error) {
-      console.error("Locale update error:", error);
-      const status = error.code === "42501" ? 403 : 500;
-      return NextResponse.json(
-        { error: "Failed to update locale" },
-        { status },
-      );
-    }
+    if (error) throw error;
 
-    return NextResponse.json({ locale });
-  } catch (err) {
-    console.error("Locale update error:", err);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
-}
+    return { locale: body.locale };
+  },
+});

--- a/src/app/api/voice/instant/create/route.ts
+++ b/src/app/api/voice/instant/create/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
-import { requireRole } from "@/lib/auth";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
 import { createDailyRoom, isDailyDuplicateRoomError } from "@/lib/daily";
 import { generateVoiceRoomCode } from "@/lib/voice-room-code";
 import { VOICE_CONFIG } from "@/lib/constants/voice";
+
+/** Response of POST /api/voice/instant/create. */
+const createInstantRoomResponse = z.object({ code: z.string() });
 
 /**
  * Create a new instant voice room.
@@ -16,47 +20,50 @@ import { VOICE_CONFIG } from "@/lib/constants/voice";
  * Collisions are rare (~1 in 2,000 with 500 concurrent rooms) so we don't
  * pre-check the code. If Daily says the room name already exists, we
  * generate a fresh code and try again — `INSTANT_ROOM_CREATE_MAX_RETRIES`
- * times. (We can't use the `getOrCreateDailyRoom` helper here: random
- * codes are not authorization-pre-gated, so silently joining the existing
- * room on collision would let a caller into someone else's instant room.)
+ * times. (We can't use the get-or-create helper here: random codes are not
+ * authorization-pre-gated, so silently joining the existing room on collision
+ * would let a caller into someone else's instant room.)
  */
-export async function POST() {
-  const result = await requireRole(["admin", "gedu"], {
-    forbiddenMessage: "Only admins and educators can create voice rooms",
-    // An unverified gedu is not a trusted moderator: block room creation until
-    // an admin verifies them (the token route likewise denies them owner power).
-    requireVerifiedGedu: true,
-  });
-  if (result instanceof NextResponse) return result;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: ["admin", "gedu"],
+  forbiddenMessage: "Only admins and educators can create voice rooms",
+  // An unverified gedu is not a trusted moderator: block room creation until
+  // an admin verifies them (the token route likewise denies them owner power).
+  requireVerifiedGedu: true,
+  response: createInstantRoomResponse,
 
-  const expUnix =
-    Math.round(Date.now() / 1000) + VOICE_CONFIG.INSTANT_ROOM_EXP_SECONDS;
+  handler: async () => {
+    const expUnix =
+      Math.round(Date.now() / 1000) + VOICE_CONFIG.INSTANT_ROOM_EXP_SECONDS;
 
-  for (let attempt = 0; attempt < VOICE_CONFIG.INSTANT_ROOM_CREATE_MAX_RETRIES; attempt++) {
-    const code = generateVoiceRoomCode();
-    try {
-      await createDailyRoom({ name: code, expUnix });
-      return NextResponse.json({ code });
-    } catch (err) {
-      // Duplicate-name means the random code happened to collide — try
-      // again with a fresh code. Anything else is a real failure; bail.
-      if (isDailyDuplicateRoomError(err)) {
-        continue;
+    for (
+      let attempt = 0;
+      attempt < VOICE_CONFIG.INSTANT_ROOM_CREATE_MAX_RETRIES;
+      attempt++
+    ) {
+      const code = generateVoiceRoomCode();
+      try {
+        await createDailyRoom({ name: code, expUnix });
+        return { code };
+      } catch (err) {
+        // Duplicate-name means the random code happened to collide — try
+        // again with a fresh code. Anything else is a real failure; let the
+        // wrapper log it and answer a generic 500.
+        if (isDailyDuplicateRoomError(err)) continue;
+        throw err;
       }
-      console.error("Failed to create instant voice room:", err);
-      return NextResponse.json(
-        { error: "Failed to create voice room" },
-        { status: 500 },
-      );
     }
-  }
 
-  // Exhausted retries — astronomically unlikely. Surface so we hear about it.
-  console.error(
-    `Could not allocate an instant voice room code after ${VOICE_CONFIG.INSTANT_ROOM_CREATE_MAX_RETRIES} attempts`,
-  );
-  return NextResponse.json(
-    { error: "Could not allocate a voice room code; please try again" },
-    { status: 503 },
-  );
-}
+    // Exhausted retries — astronomically unlikely. 503 rather than the shared
+    // table's 500 because a retry really might succeed, and the wrapper has no
+    // service-unavailable default.
+    console.error(
+      `Could not allocate an instant voice room code after ${VOICE_CONFIG.INSTANT_ROOM_CREATE_MAX_RETRIES} attempts`,
+    );
+    return NextResponse.json(
+      { error: "Could not allocate a voice room code; please try again" },
+      { status: 503 },
+    );
+  },
+});

--- a/src/app/api/voice/instant/end/route.ts
+++ b/src/app/api/voice/instant/end/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { defineRoute } from "@/lib/api/define-route";
 import { deleteDailyRoom, DailyApiError } from "@/lib/daily";
 import { normalizeVoiceRoomCode } from "@/lib/voice-room-code";
 
@@ -10,44 +9,35 @@ import { normalizeVoiceRoomCode } from "@/lib/voice-room-code";
  *
  * Mods only — guests can leave individually but cannot kill the call.
  * Deleting the Daily.co room ejects every connected participant; the
- * client-side `left-meeting` event flows them through to the
- * call-ended screen. There's no ownership check beyond "is a mod" — any
- * admin or gedu with the code can end any room. Acceptable: mods are
- * trusted, and there's no concept of room ownership in this model.
+ * client-side `left-meeting` event flows them through to the call-ended
+ * screen. There's no ownership check beyond "is a mod" — any admin or gedu
+ * with the code can end any room. Acceptable: mods are trusted, and there's
+ * no concept of room ownership in this model.
  */
-export async function POST(request: Request) {
-  const result = await requireRole(["admin", "gedu"], {
-    forbiddenMessage: "Only admins and educators can end voice rooms",
-    // An unverified gedu is not a trusted moderator — same boundary as create.
-    requireVerifiedGedu: true,
-  });
-  if (result instanceof NextResponse) return result;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: ["admin", "gedu"],
+  forbiddenMessage: "Only admins and educators can end voice rooms",
+  // An unverified gedu is not a trusted moderator — same boundary as create.
+  requireVerifiedGedu: true,
+  body: z.object({ code: z.string() }),
 
-  const body = await parseJsonBody(
-    request,
-    z.object({ code: z.string() }),
-  );
-  if (body instanceof NextResponse) return body;
-
-  const code = normalizeVoiceRoomCode(body.code);
-  if (!code) {
-    return NextResponse.json({ error: "Invalid room code" }, { status: 400 });
-  }
-
-  try {
-    await deleteDailyRoom(code);
-  } catch (err) {
-    // 404 is a no-op success: the room was already ended, expired, or
-    // never existed. Any other status is a real failure.
-    if (err instanceof DailyApiError && err.status === 404) {
-      return new NextResponse(null, { status: 204 });
+  handler: async ({ body }) => {
+    const code = normalizeVoiceRoomCode(body.code);
+    if (!code) {
+      return NextResponse.json({ error: "Invalid room code" }, { status: 400 });
     }
-    console.error("Failed to delete instant voice room:", err);
-    return NextResponse.json(
-      { error: "Failed to end voice room" },
-      { status: 500 },
-    );
-  }
 
-  return new NextResponse(null, { status: 204 });
-}
+    try {
+      await deleteDailyRoom(code);
+    } catch (err) {
+      // 404 is a no-op success: the room was already ended, expired, or never
+      // existed. Any other status is a real failure — let the wrapper log it.
+      if (err instanceof DailyApiError && err.status === 404) return undefined;
+      throw err;
+    }
+
+    // Nothing to say beyond "it is gone": the wrapper turns undefined into 204.
+    return undefined;
+  },
+});

--- a/src/app/api/voice/instant/exists/route.ts
+++ b/src/app/api/voice/instant/exists/route.ts
@@ -1,34 +1,39 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/define-route";
 import { getDailyRoom } from "@/lib/daily";
 import { normalizeVoiceRoomCode } from "@/lib/voice-room-code";
 
 /**
- * Cheap existence check for an instant voice room.
+ * GET /api/voice/instant/exists — cheap existence check for an instant room.
  *
- * Public — anyone can call. Used by the lobby on mount so the
- * `RoomNotFoundScreen` can render before we ask the user to grant
- * camera/mic permission and pick a display name. Returning the same
- * 404/200 shape the token route uses keeps the lobby's transition
- * logic uniform.
+ * Used by the lobby on mount so the room-not-found screen can render before we
+ * ask the user to grant camera/mic permission and pick a display name.
+ * Returning the same 404/204 shape the token route uses keeps the lobby's
+ * transition logic uniform.
  *
- * The token route also re-validates existence at join time, so a
- * room that gets deleted between the check and the join still flows
- * through the not-found UX.
+ * The token route also re-validates existence at join time, so a room deleted
+ * between the check and the join still flows through the not-found UX.
  */
-export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const code = normalizeVoiceRoomCode(url.searchParams.get("code"));
-  if (!code) {
-    return NextResponse.json({ error: "Invalid room code" }, { status: 400 });
-  }
+export const GET = defineRoute({
+  posture: "public",
+  reason:
+    "the lobby checks whether a room code resolves before asking for camera and microphone permission, and a guest joining by link has no session. Reveals only that a code exists, which anyone holding the code could learn by joining",
+  query: z.object({ code: z.string() }),
 
-  const room = await getDailyRoom(code);
-  if (!room) {
-    return NextResponse.json(
-      { error: "room_not_found", code },
-      { status: 404 },
-    );
-  }
+  handler: async ({ query }) => {
+    const code = normalizeVoiceRoomCode(query.code);
+    if (!code) {
+      return NextResponse.json({ error: "Invalid room code" }, { status: 400 });
+    }
 
-  return new NextResponse(null, { status: 204 });
-}
+    const room = await getDailyRoom(code);
+    if (!room) {
+      // The echoed code lets the lobby show the user what they typed.
+      return NextResponse.json({ error: "room_not_found", code }, { status: 404 });
+    }
+
+    // Existence is the whole answer: the wrapper turns undefined into 204.
+    return undefined;
+  },
+});

--- a/src/app/api/voice/instant/token/route.ts
+++ b/src/app/api/voice/instant/token/route.ts
@@ -1,9 +1,33 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@/lib/api/json-body.server";
 import { instantRoomModerator } from "@/lib/voice/instant-room-moderator";
 import { createMeetingToken, getDailyRoom, buildUserName } from "@/lib/daily";
 import { normalizeVoiceRoomCode } from "@/lib/voice-room-code";
 import { DISPLAY_NAME_MIN, DISPLAY_NAME_MAX } from "@/lib/constants";
 import { VOICE_CONFIG } from "@/lib/constants/voice";
+
+/**
+ * The lobby's join request. Every field is optional and everything else is
+ * dropped: the schema is what makes "role", "owner" and "userId" in the body
+ * unreadable rather than merely unread, so a future edit cannot start trusting
+ * one by accident. Ownership comes from the server-side session lookup below.
+ *
+ * `displayName` is only length-checked on the guest path (a recognized
+ * moderator's name comes from their profile), so the schema takes any string
+ * and the guest branch applies the shared display-name bounds.
+ *
+ * The two media flags degrade to `undefined` instead of failing the request:
+ * they are lobby preferences, not authorization, and an older client sending a
+ * stringly-typed value should still be able to join with the defaults rather
+ * than be refused at the door.
+ */
+const instantRoomTokenBody = z.object({
+  code: z.string().optional(),
+  displayName: z.string().optional(),
+  micOn: z.boolean().optional().catch(undefined),
+  cameraOn: z.boolean().optional().catch(undefined),
+});
 
 /**
  * Mint a Daily.co meeting token for an instant voice room.
@@ -30,34 +54,18 @@ import { VOICE_CONFIG } from "@/lib/constants/voice";
  *     `is_owner` is the actual permission authority — but worth doing.
  */
 export async function POST(request: Request) {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const {
-    code: rawCode,
-    displayName: rawDisplayName,
-    micOn: rawMicOn,
-    cameraOn: rawCameraOn,
-  } = (body ?? {}) as {
-    code?: unknown;
-    displayName?: unknown;
-    micOn?: unknown;
-    cameraOn?: unknown;
-  };
+  const body = await parseJsonBody(request, instantRoomTokenBody);
+  if (body instanceof NextResponse) return body;
 
   // Lobby preview choices. Default to the historical (mic on, camera off)
   // shape if the client didn't send them — keeps older clients working and
   // the test surface predictable.
-  const micOn = typeof rawMicOn === "boolean" ? rawMicOn : true;
-  const cameraOn = typeof rawCameraOn === "boolean" ? rawCameraOn : false;
+  const micOn = body.micOn ?? true;
+  const cameraOn = body.cameraOn ?? false;
 
   // Validate code format BEFORE any Daily API call so a malformed code can't
   // produce a path-traversal request to Daily's API.
-  const code = normalizeVoiceRoomCode(rawCode);
+  const code = normalizeVoiceRoomCode(body.code);
   if (!code) {
     return NextResponse.json(
       { error: "Invalid room code" },
@@ -91,8 +99,7 @@ export async function POST(request: Request) {
     // (DISPLAY_NAME_MIN/MAX) so the constraint is consistent across the
     // app. We trim before checking because trailing whitespace is just
     // noise in display names.
-    const trimmed =
-      typeof rawDisplayName === "string" ? rawDisplayName.trim() : "";
+    const trimmed = body.displayName?.trim() ?? "";
     if (trimmed.length < DISPLAY_NAME_MIN || trimmed.length > DISPLAY_NAME_MAX) {
       return NextResponse.json(
         {

--- a/src/app/api/voice/token/route.ts
+++ b/src/app/api/voice/token/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { requireRole } from "@/lib/auth";
-import { parseJsonBody } from "@/lib/api/json-body.server";
+import { defineRoute } from "@/lib/api/define-route";
+import { ApiError } from "@/lib/api/api-error";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
   buildUserName,
@@ -12,53 +12,44 @@ import {
 import { computeSessionWindow } from "@/lib/session-schedule";
 import { VOICE_CONFIG } from "@/lib/constants/voice";
 import { tokenCanReceiveFor } from "@/lib/voice/receive-permissions";
+import { voiceTokenResponse } from "@/services/voice/voice.contracts";
 
 /**
  * Mint a Daily.co meeting token for a product group's voice room.
  *
- * Request body: `{ groupId: product_groups.id }`.
- *
- * There is no backing `voice_rooms` table — Daily.co is the single
- * source of truth for room existence. We derive a deterministic room name
- * from the group + the current session window, get-or-create on demand,
- * and set Daily's `exp` to the session-window close so the platform reaps
- * the room (and ejects late joiners) once the window passes.
+ * There is no backing `voice_rooms` table — Daily.co is the single source of
+ * truth for room existence. We derive a deterministic room name from the group
+ * + the current session window, get-or-create on demand, and set Daily's `exp`
+ * to the session-window close so the platform reaps the room (and ejects late
+ * joiners) once the window passes.
  *
  * Gates:
- *   1. Membership — gamers via `participations.status = 'active'`, gedus
- *      via `gedu_group_assignments` on the product (per redesign §4.10's
- *      cross-group voice mobility rule), admins pass through.
+ *   1. Membership — gamers via an active participation, gedus via a
+ *      product-level assignment (cross-group voice mobility), admins pass
+ *      through.
  *   2. Session window — at least one slot's window must be open right now.
  *
  * Notably absent: there is no "did you enroll before this session started?"
- * gate. Active membership is the binary access predicate — if
- * you're an active participant, you're in. (Credit-based billing makes a
- * mid-session enrollment cut-off irrelevant.)
+ * gate. Active membership is the binary access predicate. (Credit-based
+ * billing makes a mid-session enrollment cut-off irrelevant.)
  */
-export async function POST(request: Request) {
-  try {
-    const result = await requireRole(["gedu", "gamer", "admin"], {
-      forbiddenMessage: "You do not have permission to join voice rooms",
-    });
-    if (result instanceof NextResponse) return result;
-    const { user, profile } = result;
+export const POST = defineRoute({
+  posture: "role-gated",
+  roles: ["gedu", "gamer", "admin"],
+  forbiddenMessage: "You do not have permission to join voice rooms",
+  body: z.object({ groupId: z.string().min(1, "groupId is required") }),
+  response: voiceTokenResponse,
+
+  handler: async ({ user, profile, body }) => {
     const role = profile.role;
-
-    const body = await parseJsonBody(
-      request,
-      z.object({ groupId: z.string().min(1, "groupId is required") }),
-    );
-    if (body instanceof NextResponse) return body;
     const { groupId } = body;
-
     const admin = createAdminClient();
 
-    // Group → product → slots → timezone in one round trip. `!inner` is
-    // important: it makes PostgREST fail the parent select on a missing
-    // product (shouldn't happen given the FK, but defends against partially
-    // deleted rows). schedule_slots is keyed off `product_id`, so it
-    // nests inside the products join — `product_groups ↔
-    // schedule_slots` is not a direct FK pair.
+    // Group → product → slots → timezone in one round trip. `!inner` makes
+    // PostgREST fail the parent select on a missing product (shouldn't happen
+    // given the FK, but defends against partially deleted rows).
+    // schedule_slots is keyed off `product_id`, so it nests inside the products
+    // join — product_groups ↔ schedule_slots is not a direct FK pair.
     const { data: group, error: groupErr } = await admin
       .from("product_groups")
       .select(
@@ -73,14 +64,12 @@ export async function POST(request: Request) {
       .eq("id", groupId)
       .maybeSingle();
 
-    if (groupErr || !group) {
-      return NextResponse.json({ error: "Room not found" }, { status: 404 });
-    }
-
-    if (!group.product.is_remote) {
-      // In-person products have no voice room. 404 (not 403) matches the
-      // dashboard's "no destination" stance — the URL shape isn't a valid
-      // voice room.
+    if (groupErr) throw groupErr;
+    // In-person products have no voice room. 404 (not 403) matches the
+    // dashboard's "no destination" stance — the URL shape isn't a valid voice
+    // room — and it is the same answer as an unknown group, so this route
+    // cannot be used to probe which group ids exist.
+    if (!group || !group.product.is_remote) {
       return NextResponse.json({ error: "Room not found" }, { status: 404 });
     }
 
@@ -105,8 +94,8 @@ export async function POST(request: Request) {
         );
       }
     } else if (role === "gedu") {
-      // Per redesign §4.10, the gedu assignment predicate is on
-      // `product_id` (cross-group voice mobility), not `group_id`.
+      // The gedu assignment predicate is on `product_id` (cross-group voice
+      // mobility), not `group_id`.
       const { data: assignment } = await admin
         .from("gedu_group_assignments")
         .select("group_id")
@@ -127,13 +116,10 @@ export async function POST(request: Request) {
     // ---- Session window gate ----
     // Iterate every slot; the first whose window is currently open wins.
     // Mon-11pm + Tue-5am sessions for the same group sit on different slots
-    // (and end up with distinct Daily room names below), so checking each
-    // slot independently is correct.
+    // (and end up with distinct Daily room names below), so checking each slot
+    // independently is correct.
     const now = new Date();
-    let openSlot: {
-      windowOpensAt: Date;
-      windowClosesAt: Date;
-    } | null = null;
+    let openSlot: { windowOpensAt: Date; windowClosesAt: Date } | null = null;
     for (const slot of slots) {
       const window = computeSessionWindow(
         {
@@ -161,14 +147,13 @@ export async function POST(request: Request) {
 
     // Self-healing cleanup of private-zone occupancy: every join reaps this
     // group's occupancy rows from *prior* session windows. A row is only valid
-    // for its own window (privacy is scoped to session_opens_at), so older rows
-    // are dead — they'd otherwise block re-occupying via the (group_id, user_id)
-    // unique constraint, over-block a returning user's joiners, and grow
-    // unbounded. This is also what cleans up a user who never left (closed their
-    // laptop mid-session): their row lingers only until the window rolls, then
-    // the next join reaps it. No cron: someone joins every session, and because
-    // the table is in the realtime publication these DELETEs propagate to every
-    // client's projection. Best-effort — a failed prune just lingers.
+    // for its own window, so older rows are dead — they'd otherwise block
+    // re-occupying via the (group_id, user_id) unique constraint, over-block a
+    // returning user's joiners, and grow unbounded. This is also what cleans up
+    // a user who never left (closed their laptop mid-session). No cron: someone
+    // joins every session, and because the table is in the realtime publication
+    // these DELETEs propagate to every client's projection. Best-effort — a
+    // failed prune just lingers.
     await admin
       .from("voice_private_zone_occupants")
       .delete()
@@ -191,11 +176,11 @@ export async function POST(request: Request) {
     );
 
     // ---- Daily room: get-or-create ----
-    // The room name is content-addressable from (group, window open time),
-    // so every joiner derives the same name independently and the helper
-    // either returns the existing room or creates it. No race-on-first-join
-    // surfaces as a user-visible error — the duplicate-name path falls
-    // through silently inside the helper.
+    // The room name is content-addressable from (group, window open time), so
+    // every joiner derives the same name independently and the helper either
+    // returns the existing room or creates it. No race-on-first-join surfaces
+    // as a user-visible error — the duplicate-name path falls through silently
+    // inside the helper.
     const dailyRoomName = groupVoiceRoomName({
       groupId,
       windowOpensAt: openSlot.windowOpensAt,
@@ -210,60 +195,45 @@ export async function POST(request: Request) {
 
     const domain = process.env.NEXT_PUBLIC_DAILY_DOMAIN;
     if (!domain) {
-      console.error("Missing NEXT_PUBLIC_DAILY_DOMAIN environment variable");
-      return NextResponse.json(
-        { error: "Voice chat is not configured" },
-        { status: 500 },
-      );
+      throw new ApiError("missing NEXT_PUBLIC_DAILY_DOMAIN", 500);
     }
 
     // The joiner's own Minecraft identity rides along in the Daily token so
-    // peers can render the badge without a DB lookup — `minecraft_accounts`
-    // RLS forbids reading another user's row, so per-participant client
-    // fetches aren't possible. We read the joiner's own row (always passing
-    // the slots, even when there's no row, so the client shows "(Unknown)"
-    // rather than no badge for gamers/gedus).
+    // peers can render the badge without a DB lookup — `minecraft_accounts` RLS
+    // forbids reading another user's row, so per-participant client fetches
+    // aren't possible. We read the joiner's own row (always passing the slots,
+    // even when there's no row, so the client shows "(Unknown)" rather than no
+    // badge for gamers/gedus).
     const { data: minecraft } = await admin
       .from("minecraft_accounts")
       .select("minecraft_username, minecraft_uuid")
       .eq("user_id", user.id)
       .maybeSingle();
 
-    const userName = buildUserName({
-      userId: user.id,
-      role,
-      displayName: profile.first_name,
-      minecraftUsername: minecraft?.minecraft_username ?? null,
-      minecraftUuid: minecraft?.minecraft_uuid ?? null,
-    });
-    const roomUrl = `https://${domain}.daily.co/${dailyRoomName}`;
-    const isOwner = role !== "gamer";
-
     const token = await createMeetingToken({
       roomName: dailyRoomName,
-      isOwner,
-      userName,
+      isOwner: role !== "gamer",
+      userName: buildUserName({
+        userId: user.id,
+        role,
+        displayName: profile.first_name,
+        minecraftUsername: minecraft?.minecraft_username ?? null,
+        minecraftUuid: minecraft?.minecraft_uuid ?? null,
+      }),
       userId: user.id,
       canReceive,
       expUnix,
     });
 
     // sessionOpensAt lets the client stamp private-zone occupancy rows with the
-    // current window (`voice_private_zone_occupants.session_opens_at`). This same
-    // route reads current-window occupancy above to bake `canReceive`, and the
-    // client filters occupancy to the current window (`isCurrentSessionPlacement`)
+    // current window. This same route reads current-window occupancy above to
+    // bake `canReceive`, and the client filters occupancy to the current window
     // so a stale prior-session row can't affect routing or confinement.
-    return NextResponse.json({
+    return {
       token,
-      roomUrl,
+      roomUrl: `https://${domain}.daily.co/${dailyRoomName}`,
       role,
       sessionOpensAt: openSlot.windowOpensAt.toISOString(),
-    });
-  } catch (err) {
-    console.error("Voice token error:", err);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
-}
+    };
+  },
+});

--- a/src/app/api/webhooks/whatsapp/route.ts
+++ b/src/app/api/webhooks/whatsapp/route.ts
@@ -8,17 +8,27 @@ import type { Json, WhatsAppMessageUpdate } from "@/types";
 const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN!;
 const appSecret = process.env.WHATSAPP_APP_SECRET!;
 
+/**
+ * Compare two secrets without leaking how far they matched.
+ *
+ * `timingSafeEqual` throws on a length mismatch, so the lengths are checked
+ * first — which is fine: a length difference is not the leak that matters here,
+ * a per-character early exit is.
+ */
+function secretsMatch(expected: string, received: string | null): boolean {
+  if (received === null) return false;
+  const a = Buffer.from(expected);
+  const b = Buffer.from(received);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
 /** Verify that the request came from Meta using X-Hub-Signature-256 */
 function verifySignature(body: string, signature: string | null): boolean {
-  if (!signature) return false;
   const expected =
     "sha256=" +
     crypto.createHmac("sha256", appSecret).update(body).digest("hex");
-  if (expected.length !== signature.length) return false;
-  return crypto.timingSafeEqual(
-    Buffer.from(expected),
-    Buffer.from(signature)
-  );
+  return secretsMatch(expected, signature);
 }
 
 // --- Payload schemas ---
@@ -144,14 +154,23 @@ function extractMessageContent(message: InboundMessage): {
   }
 }
 
-/** Meta webhook verification challenge */
+/**
+ * Meta webhook verification challenge.
+ *
+ * The verify token is compared in constant time, like every other secret
+ * comparison on this surface. It used to be a plain `===`, which is a
+ * character-by-character compare that returns early on the first difference —
+ * the same class of leak the HMAC check above has always avoided, on a secret
+ * that is equally long-lived and equally sufficient on its own to pass this
+ * handshake.
+ */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const mode = searchParams.get("hub.mode");
   const token = searchParams.get("hub.verify_token");
   const challenge = searchParams.get("hub.challenge");
 
-  if (mode === "subscribe" && token === verifyToken) {
+  if (mode === "subscribe" && secretsMatch(verifyToken, token)) {
     return new Response(challenge, { status: 200 });
   }
 

--- a/src/services/gamers/gamers.contracts.ts
+++ b/src/services/gamers/gamers.contracts.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { Constants } from "@/types";
+import { DISPLAY_NAME_MIN, DISPLAY_NAME_MAX } from "@/lib/constants";
+import { minecraftUsernameValue } from "@/services/minecraft/minecraft.contracts";
+
+/**
+ * Request contracts for the gamer-account API. Both write routes used to check
+ * their bodies by hand with `typeof` tests; these schemas are the same rules
+ * stated once, so the create and update paths cannot drift apart.
+ */
+
+const firstName = z
+  .string()
+  .trim()
+  .min(
+    DISPLAY_NAME_MIN,
+    `First name must be between ${DISPLAY_NAME_MIN} and ${DISPLAY_NAME_MAX} characters`,
+  )
+  .max(
+    DISPLAY_NAME_MAX,
+    `First name must be between ${DISPLAY_NAME_MIN} and ${DISPLAY_NAME_MAX} characters`,
+  );
+
+/** Request body of POST /api/gamers/create. */
+export const createGamerBody = z.object({
+  firstName,
+  // A bare calendar date; the route additionally refuses one in the future.
+  dateOfBirth: z.string().min(1, "Date of birth is required"),
+  // The form sends "" for "prefer not to say"; that, null and an absent key all
+  // mean "no value recorded".
+  gender: z
+    .union([z.enum(Constants.public.Enums.gender_type), z.literal(""), z.null()])
+    .optional(),
+  minecraftUsername: minecraftUsernameValue.optional(),
+});
+
+/**
+ * Request body of PATCH /api/gamers/[id]. Every field is optional because the
+ * parent edits one thing at a time, but sending none of them is a no-op the
+ * route refuses rather than silently accepts. An explicit `null` Minecraft
+ * username unlinks; an absent key leaves the link alone.
+ */
+export const updateGamerBody = z
+  .object({
+    firstName: firstName.optional(),
+    password: z
+      .string()
+      .min(6, "Password must be at least 6 characters")
+      .optional(),
+    minecraftUsername: minecraftUsernameValue.optional(),
+  })
+  .refine(
+    (body) =>
+      body.firstName !== undefined ||
+      body.password !== undefined ||
+      body.minecraftUsername !== undefined,
+    {
+      message:
+        "At least one of firstName, password, or minecraftUsername is required",
+    },
+  );

--- a/src/services/minecraft/minecraft.contracts.ts
+++ b/src/services/minecraft/minecraft.contracts.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { isValidMinecraftUsername } from "@/lib/mojang";
+
+/**
+ * A Minecraft username as it travels on the wire, or `null` to unlink. The
+ * format rule is the shared Mojang one, so a value that parses can be handed
+ * straight to the lookup. Every route that accepts a Minecraft username imports
+ * this rather than restating the character rules.
+ */
+export const minecraftUsernameValue = z
+  .string()
+  .refine(isValidMinecraftUsername, {
+    message:
+      "Invalid Minecraft username. Must be 3-16 characters: letters, numbers, underscores.",
+  })
+  .nullable();
+
+/** Request body of PATCH /api/minecraft/account — link or unlink one's own. */
+export const updateMinecraftAccountBody = z.object({
+  minecraftUsername: minecraftUsernameValue,
+});
+
+/** Query string of GET /api/minecraft/verify — the public Mojang lookup. */
+export const verifyMinecraftQuery = z.object({
+  username: z.string().refine(isValidMinecraftUsername, {
+    message:
+      "Invalid username. Must be 3-16 characters: letters, numbers, underscores.",
+  }),
+});

--- a/src/services/participations/participations.contracts.ts
+++ b/src/services/participations/participations.contracts.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { SUPPORTED_CURRENCIES } from "@/lib/constants/currency";
+import type { PurchaseShape } from "@/types";
 
 /**
  * Response of POST /api/checkout/products/create — the signup outcomes: paid
@@ -20,6 +22,28 @@ export const createParticipationResponse = z.discriminatedUnion("status", [
 export type CreateParticipationResponse = z.infer<
   typeof createParticipationResponse
 >;
+
+/**
+ * Request body of POST /api/checkout/products/create. The purchase shape and
+ * currency are enums rather than free strings so the route never has to ask
+ * "is this one of the four we support?" after the fact — and the coherence
+ * rules the shape must satisfy against the product's billing mode stay in the
+ * route, because they need the product row to decide.
+ */
+export const createCheckoutBody = z.object({
+  productId: z.string().min(1, "productId is required"),
+  gamerId: z.string().min(1, "gamerId is required"),
+  // Spelled out rather than derived so the compiler checks it against the
+  // shared union below — adding a shape there fails the build until it is
+  // decided here too.
+  purchaseShape: z.enum([
+    "subscription_monthly",
+    "single_payment",
+    "free",
+    "external",
+  ] as const satisfies readonly PurchaseShape[]),
+  currency: z.enum(SUPPORTED_CURRENCIES),
+});
 
 /** Request body of POST /api/participations/waitlist. */
 export const joinWaitlistBody = z.object({

--- a/src/services/participations/participations.contracts.ts
+++ b/src/services/participations/participations.contracts.ts
@@ -56,6 +56,14 @@ export const joinWaitlistRpcResult = z.object({
 });
 
 /**
+ * Body of POST /api/admin/products/[id]/participations — admin comp-enrollment.
+ * The product comes from the URL path, so the body names only the gamer.
+ */
+export const adminEnrollGamerBody = z.object({
+  gamerId: z.string().min(1, "gamerId is required"),
+});
+
+/**
  * Body of PATCH /api/admin/products/[id]/participations/[participationId] — the
  * admin waitlist status transitions driven by the groups-panel drag UI.
  * `promote` carries the drop target (`groupId` null = unassigned inbox);

--- a/src/services/pin/pin.contracts.ts
+++ b/src/services/pin/pin.contracts.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+/**
+ * The parent PIN as it travels on the wire: exactly four digits. Shared by the
+ * set/change route and the verify route, so the two cannot drift apart.
+ */
+export const pinBody = z.object({
+  pin: z.string().regex(/^\d{4}$/, "must be exactly four digits"),
+});
+
 /** Response of GET /api/auth/pin/status. */
 export const pinStatusResponse = z.object({
   isSet: z.boolean(),

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -82,6 +82,10 @@ or the build fails. Three things about maintaining it:
 - **Warts are recorded, not excused.** A route standing off the shared primitive, a
   handler with no test, a body parsed without a schema — each has a slot in the
   registry. Recording one keeps it countable; hiding it is how it survives.
+- **The untested list is a ratchet, and it is at zero.** The check asserts equality
+  against an empty list rather than being deleted once it emptied, so a handler that
+  ships with no test fails immediately instead of quietly starting a new backlog. Add
+  the test, not an entry.
 - **A recorded exception expires on its own.** The checks fail when a file that claims
   to stand off the primitive starts using it, so fixing the code forces the annotation
   to be deleted in the same change instead of rotting into a rubber stamp.

--- a/tests/helpers/json.ts
+++ b/tests/helpers/json.ts
@@ -8,6 +8,20 @@ import { z } from "zod";
 
 const objectSchema = z.record(z.string(), z.unknown());
 
+/**
+ * Narrow a loosely-typed value (a `vi.fn()` mock-call argument, a console line)
+ * to a string. Same contract as the field readers below: validates at runtime
+ * and throws loudly on a mismatch, so no assertion is needed at the call site.
+ */
+export function asString(value: unknown): string {
+  return z.string().parse(value);
+}
+
+/** Narrow a loosely-typed value to a plain object, for key/shape assertions. */
+export function asObject(value: unknown): Record<string, unknown> {
+  return objectSchema.parse(value);
+}
+
 /** Read a required string field. Throws if absent or not a string. */
 export function getString(value: unknown, key: string): string {
   return z.string().parse(objectSchema.parse(value)[key]);

--- a/tests/integration/api-route-registry.test.ts
+++ b/tests/integration/api-route-registry.test.ts
@@ -234,7 +234,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       POST: {
         posture: ADMIN_ONLY,
-        body: { kind: "json", schema: "inline: { gamerId }" },
+        body: { kind: "json", schema: "adminEnrollGamerBody" },
         test: TESTS.productsParticipations,
       },
     },

--- a/tests/integration/api-route-registry.test.ts
+++ b/tests/integration/api-route-registry.test.ts
@@ -98,7 +98,7 @@ type Posture =
 type WebhookVerifier =
   | "stripe-signature"
   | "meta-hmac-sha256"
-  | "meta-challenge-plain-compare"
+  | "meta-challenge-timing-safe"
   | "discord-ed25519";
 
 /**
@@ -268,7 +268,10 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       POST: {
         posture: ADMIN_ONLY,
-        body: { kind: "json", schema: "inline: requestSchema" },
+        body: {
+          kind: "json",
+          schema: "inline: requestSchema (declared on the primitive)",
+        },
         test: TESTS.sendTestEmail,
       },
     },
@@ -288,7 +291,10 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       POST: {
         posture: ADMIN_ONLY,
-        body: { kind: "json", schema: "inline: requestSchema" },
+        body: {
+          kind: "json",
+          schema: "inline: requestSchema (declared on the primitive)",
+        },
         test: TESTS.whatsappSend,
       },
     },
@@ -319,7 +325,13 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           reason:
             "a password reset is requested by someone who cannot sign in. Always answers 200 regardless of whether the address exists, which is the enumeration defence",
         },
-        body: { kind: "json", schema: "inline: requestSchema" },
+        body: {
+          kind: "json",
+          // Parsed inside the handler rather than through the primitive's body
+          // slot: the slot answers 400 on a schema failure, and this route must
+          // answer 200 whatever happens or the answer itself enumerates.
+          schema: "inline: requestSchema (parsed in-handler)",
+        },
         test: TESTS.forgotPassword,
       },
     },
@@ -674,7 +686,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           reason:
             "anyone holding the room code may join as a guest, and a recognized admin or verified educator is silently elevated to room owner. A public-or-gated binary cannot express it. Ownership is derived only from the server-side session lookup — never from the request body — and every ambiguous outcome falls through to guest",
         },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "inline: instantRoomTokenBody" },
         test: TESTS.voiceInstantToken,
       },
     },
@@ -722,9 +734,9 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
       GET: {
         posture: {
           kind: "webhook",
-          verifier: "meta-challenge-plain-compare",
+          verifier: "meta-challenge-timing-safe",
           reason:
-            "Meta's subscription handshake: it echoes a challenge back when the shared verify token matches. RECORDED WART — the token comparison is a plain equality check rather than a constant-time one, unlike every other secret comparison on this surface. The sweep gives it a timing-safe compare",
+            "Meta's subscription handshake: it echoes a challenge back when the shared verify token matches. The verify token is compared in constant time, like every other secret comparison on this surface — it was a plain equality check until the sweep fixed it",
         },
         body: { kind: "none" },
         test: TESTS.whatsappWebhook,

--- a/tests/integration/api-route-registry.test.ts
+++ b/tests/integration/api-route-registry.test.ts
@@ -149,12 +149,17 @@ const API_DIR = join("src", "app", "api");
 
 const TESTS = {
   adminLocations: "tests/integration/api/admin-locations.test.ts",
+  adminSiteNotes: "tests/integration/api/admin-site-notes.test.ts",
+  billingPortal: "tests/integration/api/billing-portal.test.ts",
   callback: "tests/integration/auth/callback.test.ts",
   checkout: "tests/integration/api/checkout-products-create.test.ts",
+  discordInteractions: "tests/integration/api/discord-interactions.test.ts",
+  familyList: "tests/integration/api/family-list.test.ts",
   feedback: "tests/integration/api/feedback.test.ts",
   forgotPassword: "tests/integration/auth/forgot-password.test.ts",
   gamersCreate: "tests/integration/api/gamers-create.test.ts",
   gamersUpdate: "tests/integration/api/gamers-update.test.ts",
+  geduRegister: "tests/integration/api/gedu-register.test.ts",
   minecraftAccount: "tests/integration/api/minecraft-account.test.ts",
   minecraftJoinCheck: "tests/integration/api/minecraft-join-check.test.ts",
   minecraftVerify: "tests/integration/api/minecraft-verify.test.ts",
@@ -164,12 +169,17 @@ const TESTS = {
   productsParticipations: "tests/integration/api/products-participations.test.ts",
   productsParticipationsDelete:
     "tests/integration/api/products-participations-delete.test.ts",
+  productsParticipationsTransition:
+    "tests/integration/api/products-participations-transition.test.ts",
+  productsUpdate: "tests/integration/api/products-update.test.ts",
   sendTestEmail: "tests/integration/api/send-test-email.test.ts",
+  signout: "tests/integration/auth/signout.test.ts",
   stripeWebhook: "tests/integration/api/stripe-webhook-products.test.ts",
   switchAccount: "tests/integration/auth/switch-account.test.ts",
   userLocale: "tests/integration/api/user-locale.test.ts",
   voiceInstantCreate: "tests/integration/api/voice-instant-create.test.ts",
   voiceInstantEnd: "tests/integration/api/voice-instant-end.test.ts",
+  voiceInstantExists: "tests/integration/api/voice-instant-exists.test.ts",
   voiceInstantToken: "tests/integration/api/voice-instant-token.test.ts",
   voiceToken: "tests/integration/api/voice-token.test.ts",
   waitlist: "tests/integration/api/participations-waitlist.test.ts",
@@ -222,10 +232,10 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
       PATCH: {
         posture: ADMIN_ONLY,
         body: { kind: "json", schema: "waitlistTransitionBody" },
-        // The one untested handler in an otherwise-tested file — the shape the
-        // per-file view of coverage hides, and the reason check 4 is per
-        // handler rather than per file.
-        test: null,
+        // The handler that was untested while its file-mate was covered — the
+        // shape a per-file view of coverage hides, and the reason check 4 is
+        // per handler rather than per file.
+        test: TESTS.productsParticipationsTransition,
       },
     },
   },
@@ -247,7 +257,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
       POST: {
         posture: ADMIN_ONLY,
         body: { kind: "multipart", schema: "updateProductData" },
-        test: null,
+        test: TESTS.productsUpdate,
       },
     },
   },
@@ -282,7 +292,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
       PATCH: {
         posture: ADMIN_ONLY,
         body: { kind: "json", schema: "updateSiteNotesBody" },
-        test: null,
+        test: TESTS.adminSiteNotes,
       },
     },
   },
@@ -418,7 +428,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
             "clearing a session must work even when the session is already unusable, so requiring a valid one would strand exactly the callers who need it. POST-only is the CSRF control: a cross-origin top-level POST carries no SameSite=Lax cookie, so a hostile page cannot force a sign-out. Answers a 303 the browser follows as a full-page GET",
         },
         body: { kind: "none" },
-        test: null,
+        test: TESTS.signout,
       },
     },
   },
@@ -458,7 +468,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
       POST: {
         posture: { kind: "role-gated", roles: ["customer"] },
         body: { kind: "none" },
-        test: null,
+        test: TESTS.billingPortal,
       },
     },
   },
@@ -478,7 +488,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           kind: "raw",
           reason: "the signature is computed over the exact bytes sent",
         },
-        test: null,
+        test: TESTS.discordInteractions,
       },
     },
   },
@@ -496,7 +506,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           allowUnverified: true,
         },
         body: { kind: "none" },
-        test: null,
+        test: TESTS.familyList,
       },
     },
   },
@@ -559,7 +569,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
             "educators self-register, so no session can exist yet. The highest-value public route on the surface: it creates an account, and the account it creates is unverified until an admin approves it",
         },
         body: { kind: "json", schema: "registerGeduBody" },
-        test: null,
+        test: TESTS.geduRegister,
       },
     },
   },
@@ -673,7 +683,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
             "the lobby checks whether a room code resolves before asking for camera and microphone permission, and a guest joining by link has no session. Reveals only that a code exists, which anyone holding the code could learn by joining",
         },
         body: { kind: "none" },
-        test: null,
+        test: TESTS.voiceInstantExists,
       },
     },
   },
@@ -1035,19 +1045,12 @@ describe("check 4 — test linkage", () => {
     ).toBe(true);
   });
 
-  // Untested handlers are recorded rather than excused. This assertion is the
-  // counter: it can only go down, and the sweep ends when it reaches zero.
-  it("records the handlers that still have no test", () => {
-    expect(untested.map((h) => h.label).sort()).toEqual([
-      "GET src/app/api/family/list/route.ts",
-      "GET src/app/api/voice/instant/exists/route.ts",
-      "PATCH src/app/api/admin/products/[id]/participations/[participationId]/route.ts",
-      "PATCH src/app/api/admin/site-notes/route.ts",
-      "POST src/app/api/admin/products/[id]/update/route.ts",
-      "POST src/app/api/auth/signout/route.ts",
-      "POST src/app/api/discord/interactions/route.ts",
-      "POST src/app/api/gedu/register/route.ts",
-      "POST src/app/api/parent/billing-portal/route.ts",
-    ]);
+  // Untested handlers were recorded rather than excused, and the list is now
+  // empty. Keeping the assertion as an equality against `[]` rather than
+  // deleting it is deliberate: it is a ratchet. A new handler that ships with
+  // `test: null` fails here immediately, so the zero cannot quietly become a
+  // one the way the original nine accumulated.
+  it("has no handler left without a test", () => {
+    expect(untested.map((h) => h.label).sort()).toEqual([]);
   });
 });

--- a/tests/integration/api-route-registry.test.ts
+++ b/tests/integration/api-route-registry.test.ts
@@ -363,7 +363,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           roles: ["customer"],
           allowUnverified: true,
         },
-        body: { kind: "json", schema: "inline: { pin, currentPin? }" },
+        body: { kind: "json", schema: "pinBody" },
         test: TESTS.pin,
       },
     },
@@ -391,7 +391,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           roles: ["customer"],
           allowUnverified: true,
         },
-        body: { kind: "json", schema: "inline: { pin }" },
+        body: { kind: "json", schema: "pinBody" },
         test: TESTS.pin,
       },
     },
@@ -420,7 +420,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           roles: ["customer", "gamer"],
           allowUnverified: true,
         },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "inline: switchAccountBody" },
         test: TESTS.switchAccount,
       },
     },
@@ -434,7 +434,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       POST: {
         posture: { kind: "role-gated", roles: ["customer"] },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "createCheckoutBody" },
         test: TESTS.checkout,
       },
     },
@@ -516,7 +516,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       PATCH: {
         posture: { kind: "role-gated", roles: ["customer"] },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "updateGamerBody" },
         test: TESTS.gamersUpdate,
       },
     },
@@ -528,7 +528,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       POST: {
         posture: { kind: "role-gated", roles: ["customer"] },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "createGamerBody" },
         test: TESTS.gamersCreate,
       },
     },
@@ -558,7 +558,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
     handlers: {
       PATCH: {
         posture: { kind: "role-gated", roles: ["gamer", "gedu"] },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "updateMinecraftAccountBody" },
         test: TESTS.minecraftAccount,
       },
     },
@@ -609,8 +609,6 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
   // --- User settings -------------------------------------------------------
 
   "src/app/api/user/locale/route.ts": {
-    offPrimitive:
-      "the one route that re-implements the session check inline — it verifies the token and reads the subject itself instead of calling the shared gate. Recorded as nonconforming from day one; the sweep moves it onto the standard primitive",
     handlers: {
       PATCH: {
         posture: {
@@ -618,7 +616,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           reason:
             "every role sets their own interface language, and the write is scoped to the caller's own row by a column grant plus a self-update policy, so the role is genuinely irrelevant here",
         },
-        body: { kind: "json", schema: null },
+        body: { kind: "json", schema: "setLocaleBody" },
         test: TESTS.userLocale,
       },
     },
@@ -648,7 +646,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           roles: ["admin", "gedu"],
           requireVerifiedGedu: true,
         },
-        body: { kind: "json", schema: "inline: { code }" },
+        body: { kind: "json", schema: "inline: { code } (declared on the primitive)" },
         test: TESTS.voiceInstantEnd,
       },
     },
@@ -691,7 +689,7 @@ const ROUTE_REGISTRY: Record<string, RouteEntry> = {
           kind: "role-gated",
           roles: ["gedu", "gamer", "admin"],
         },
-        body: { kind: "json", schema: "inline: { groupId }" },
+        body: { kind: "json", schema: "inline: { groupId } (declared on the primitive)" },
         test: TESTS.voiceToken,
       },
     },

--- a/tests/integration/api-route-registry.test.ts
+++ b/tests/integration/api-route-registry.test.ts
@@ -104,8 +104,9 @@ type WebhookVerifier =
 /**
  * How the handler takes its request payload. `schema: null` on a `json` entry
  * records a body parsed without a schema — a hand-rolled shape check, or none
- * at all. Those are the sweep's targets; recording them is how they stay
- * countable.
+ * at all. There are none left, and the `null` stays in the type as the slot a
+ * regression would have to occupy: recording one is what makes it countable,
+ * and check 1 asserts the count is still zero.
  */
 type BodyDiscipline =
   | { kind: "json"; schema: string | null }
@@ -883,6 +884,17 @@ describe("check 1 — completeness: the surface and the registry agree", () => {
       expect(handler.posture.reason.trim().length).toBeGreaterThan(0);
     },
   );
+
+  // The second counter the sweep drove to zero, kept as a ratchet for the same
+  // reason as the untested one in check 4: a JSON body parsed by hand is how a
+  // shape rule ends up stated twice and drifting, and the only way one comes
+  // back is if someone writes the `null` in.
+  it("has no JSON handler left without a body schema", () => {
+    const unschemad = REGISTERED_HANDLERS.filter(
+      (h) => h.handler.body.kind === "json" && h.handler.body.schema === null,
+    );
+    expect(unschemad.map((h) => h.label).sort()).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/api/admin-site-notes.test.ts
+++ b/tests/integration/api/admin-site-notes.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+// Site notes are admin-only reference data attached to a location. The route
+// upserts either or both halves (the member-facing address/notes and the
+// staff-only notes) on the USER-bound client, so the admin-only write policies
+// on both tables are the second layer behind the role gate.
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockUpsert = vi.fn();
+const mockFrom = vi.fn(() => ({ upsert: mockUpsert }));
+
+import { PATCH } from "@/app/api/admin/site-notes/route";
+
+const LOCATION_ID = "00000000-0000-0000-0000-0000000000aa";
+
+function patchRequest(body: unknown, rawBody?: string): Request {
+  return new Request("http://localhost:3000/api/admin/site-notes", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: rawBody ?? JSON.stringify(body),
+  });
+}
+
+function mockAdmin() {
+  mockRequireRole.mockResolvedValue({
+    user: { id: "admin-1" },
+    profile: { role: "admin" },
+    supabase: { from: mockFrom },
+  });
+}
+
+function mockUnauthenticated() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  );
+}
+
+function mockNonAdmin() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json(
+      { error: "Only admins can edit site notes" },
+      { status: 403 },
+    ),
+  );
+}
+
+describe("PATCH /api/admin/site-notes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue({ error: null });
+  });
+
+  // -- Auth --
+
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthenticated();
+
+    const response = await PATCH(
+      patchRequest({ location_id: LOCATION_ID, staff: { notes: "x" } }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-admin", async () => {
+    mockNonAdmin();
+
+    const response = await PATCH(
+      patchRequest({ location_id: LOCATION_ID, staff: { notes: "x" } }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  // -- Input --
+
+  it("returns 400 for malformed JSON", async () => {
+    mockAdmin();
+
+    const response = await PATCH(patchRequest(null, "{not-json"));
+
+    expect(response.status).toBe(400);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when neither half is supplied", async () => {
+    // Sending only the half being edited is the point of the shape; sending
+    // neither is a no-op the route refuses rather than silently accepts.
+    mockAdmin();
+
+    const response = await PATCH(patchRequest({ location_id: LOCATION_ID }));
+
+    expect(response.status).toBe(400);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when location_id is missing", async () => {
+    mockAdmin();
+
+    const response = await PATCH(patchRequest({ staff: { notes: "x" } }));
+
+    expect(response.status).toBe(400);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  // -- Happy path --
+
+  it("upserts only the member half when only that half is sent", async () => {
+    mockAdmin();
+
+    const response = await PATCH(
+      patchRequest({
+        location_id: LOCATION_ID,
+        member: { address: "  Kaisaniemenkatu 1  ", notes: "  Ring the bell " },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+    expect(mockFrom).toHaveBeenCalledWith("site_details");
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        location_id: LOCATION_ID,
+        address: "Kaisaniemenkatu 1",
+        notes: "Ring the bell",
+      },
+      { onConflict: "location_id" },
+    );
+  });
+
+  it("upserts both halves when both are sent", async () => {
+    mockAdmin();
+
+    const response = await PATCH(
+      patchRequest({
+        location_id: LOCATION_ID,
+        member: { notes: "Members" },
+        staff: { notes: "Staff" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFrom).toHaveBeenCalledWith("site_details");
+    expect(mockFrom).toHaveBeenCalledWith("site_staff_details");
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("stores a blanked field as null rather than an empty string", async () => {
+    mockAdmin();
+
+    await PATCH(
+      patchRequest({ location_id: LOCATION_ID, staff: { notes: "   " } }),
+    );
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { location_id: LOCATION_ID, notes: null },
+      { onConflict: "location_id" },
+    );
+  });
+
+  // -- Failure --
+
+  it("maps a policy refusal to 403 through the shared error table", async () => {
+    mockAdmin();
+    mockUpsert.mockResolvedValue({
+      error: { code: "42501", message: "permission denied for site_details" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(
+      patchRequest({ location_id: LOCATION_ID, member: { notes: "x" } }),
+    );
+
+    expect(response.status).toBe(403);
+    // The driver's text names the table; the client gets the generic message.
+    expect((await response.json()).error).toBe("Forbidden");
+    spy.mockRestore();
+  });
+
+  it("maps an unknown location to a 400 foreign-key violation", async () => {
+    mockAdmin();
+    mockUpsert.mockResolvedValue({
+      error: { code: "23503", message: "violates foreign key constraint" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(
+      patchRequest({ location_id: LOCATION_ID, member: { notes: "x" } }),
+    );
+
+    expect(response.status).toBe(400);
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/api/billing-portal.test.ts
+++ b/tests/integration/api/billing-portal.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { getString } from "../../helpers/json";
+
+process.env.STRIPE_SECRET_KEY = "sk_test_billing_portal";
+process.env.NEXT_PUBLIC_SITE_URL = "https://test.sogverse.local";
+
+// The billing-portal route hands a parent a Stripe-hosted session URL. Two
+// things make it worth pinning: the customer id it uses must come from the
+// verified session (a portal session for someone else's Stripe customer is a
+// full billing-data leak), and the return URL must be built off the trusted
+// origin rather than the caller's Host header.
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ marker: "admin" }),
+}));
+
+const mockGetOrCreateStripeCustomer = vi.fn();
+vi.mock("@/lib/stripe/customer", () => ({
+  getOrCreateStripeCustomer: (...args: unknown[]) =>
+    mockGetOrCreateStripeCustomer(...args),
+}));
+
+vi.mock("@/lib/stripe/portal-configuration", () => ({
+  getPortalConfigurationId: vi.fn(async () => "bpc_test"),
+}));
+
+const mockGetLocale = vi.fn();
+vi.mock("next-intl/server", () => ({
+  getLocale: () => mockGetLocale(),
+}));
+
+const mockPortalCreate = vi.fn();
+vi.mock("stripe", () => ({
+  default: class {
+    billingPortal = {
+      sessions: { create: (...args: unknown[]) => mockPortalCreate(...args) },
+    };
+  },
+}));
+
+import { POST } from "@/app/api/parent/billing-portal/route";
+
+const CUSTOMER_ID = "11111111-1111-1111-1111-111111111111";
+
+function portalRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost:3000/api/parent/billing-portal", {
+    method: "POST",
+    headers,
+  });
+}
+
+function mockAuthenticatedCustomer(id = CUSTOMER_ID) {
+  mockRequireRole.mockResolvedValue({
+    user: { id },
+    profile: { id, role: "customer" },
+  });
+}
+
+describe("POST /api/parent/billing-portal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetLocale.mockResolvedValue("en");
+    mockGetOrCreateStripeCustomer.mockResolvedValue("cus_test123");
+    mockPortalCreate.mockResolvedValue({
+      url: "https://billing.stripe.com/session/test",
+    });
+  });
+
+  // -- Auth --
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireRole.mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+
+    const response = await POST(portalRequest());
+
+    expect(response.status).toBe(401);
+    expect(mockPortalCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-customer role", async () => {
+    mockRequireRole.mockResolvedValue(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    );
+
+    const response = await POST(portalRequest());
+
+    expect(response.status).toBe(403);
+    expect(mockPortalCreate).not.toHaveBeenCalled();
+  });
+
+  // -- Happy path --
+
+  it("returns the Stripe-hosted portal URL", async () => {
+    mockAuthenticatedCustomer();
+
+    const response = await POST(portalRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      url: "https://billing.stripe.com/session/test",
+    });
+  });
+
+  it("opens the portal for the SESSION's Stripe customer, never a requested one", async () => {
+    mockAuthenticatedCustomer("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+
+    await POST(portalRequest());
+
+    expect(mockGetOrCreateStripeCustomer).toHaveBeenCalledWith(
+      expect.anything(),
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    );
+    expect(mockPortalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_test123" }),
+    );
+  });
+
+  it("builds the return URL off the trusted origin, ignoring a spoofed Host", async () => {
+    mockAuthenticatedCustomer();
+
+    await POST(portalRequest({ host: "evil.example" }));
+
+    const returnUrl = getString(mockPortalCreate.mock.calls[0][0], "return_url");
+    expect(returnUrl).toBe("https://test.sogverse.local/parent#billing");
+  });
+
+  it("falls back to Stripe's own locale detection for a locale Stripe cannot render", async () => {
+    // Klingon is an app locale but not a Stripe one; 'auto' is the documented
+    // escape hatch rather than silently sending the wrong language.
+    mockAuthenticatedCustomer();
+    mockGetLocale.mockResolvedValue("tlh");
+
+    await POST(portalRequest());
+
+    expect(mockPortalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "auto" }),
+    );
+  });
+
+  // -- Failure --
+
+  it("answers 502 when Stripe refuses to create the session", async () => {
+    mockAuthenticatedCustomer();
+    mockPortalCreate.mockRejectedValue(new Error("stripe is down"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(portalRequest());
+
+    expect(response.status).toBe(502);
+    expect((await response.json()).error).toBe("Failed to open billing portal");
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/api/checkout-products-create.test.ts
+++ b/tests/integration/api/checkout-products-create.test.ts
@@ -247,7 +247,7 @@ describe("POST /api/checkout/products/create", () => {
     const res = await POST(createRequest(null, { rawBody: "{not-json" }));
     const data = await res.json();
     expect(res.status).toBe(400);
-    expect(data.error).toBe("Invalid JSON");
+    expect(data.error).toBe("Invalid JSON body");
   });
 
   it.each([
@@ -259,7 +259,7 @@ describe("POST /api/checkout/products/create", () => {
     const res = await POST(createRequest(body));
     const data = await res.json();
     expect(res.status).toBe(400);
-    expect(data.error).toBe("productId, gamerId and purchaseShape are required");
+    expect(data.error).toContain("Required");
   });
 
   it("returns 400 when purchaseShape is not in the allowed set", async () => {
@@ -271,7 +271,7 @@ describe("POST /api/checkout/products/create", () => {
     );
     const data = await res.json();
     expect(res.status).toBe(400);
-    expect(data.error).toContain("Unsupported purchaseShape");
+    expect(data.error).toContain("purchaseShape");
   });
 
   it("returns 400 when currency is not supported", async () => {
@@ -281,7 +281,7 @@ describe("POST /api/checkout/products/create", () => {
     );
     const data = await res.json();
     expect(res.status).toBe(400);
-    expect(data.error).toBe("Unsupported currency");
+    expect(data.error).toContain("currency");
   });
 
   // ── Product lookup / shape × billing_mode × product_type guards ───

--- a/tests/integration/api/discord-interactions.test.ts
+++ b/tests/integration/api/discord-interactions.test.ts
@@ -49,6 +49,15 @@ vi.mock("@/lib/microsoft-graph", () => ({
   resetPassword: (...args: unknown[]) => mockResetPassword(...args),
 }));
 
+// The deferred work PATCHes the answer back to Discord over the network, and
+// it is started eagerly (the platform hook receives an already-running
+// promise). Stub fetch so the suite stays hermetic, and give every downstream
+// mock a resolved value in beforeEach for the same reason: that promise is
+// never awaited, so anything it rejects with surfaces as an unhandled
+// rejection and fails the run even though every assertion passed.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
 import { POST } from "@/app/api/discord/interactions/route";
 
 function interactionRequest(
@@ -71,7 +80,21 @@ describe("POST /api/discord/interactions", () => {
     vi.clearAllMocks();
     deferred.length = 0;
     mockVerifyKey.mockResolvedValue(true);
+    mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+    mockAskGeduGuru.mockResolvedValue("vastaus");
+    mockAskHappinappi.mockResolvedValue("HAPPEE!");
+    mockResetPassword.mockResolvedValue({
+      ok: true,
+      upn: "alice@gamer.sog.gg",
+      password: "Sogverse42",
+      forceChange: false,
+    });
   });
+
+  /** Let the eagerly-started deferred work settle before the test ends. */
+  async function settleDeferred(): Promise<void> {
+    await Promise.all(deferred);
+  }
 
   // -- Authorization: the signature is the whole gate --
 
@@ -181,6 +204,7 @@ describe("POST /api/discord/interactions", () => {
     // The slow work is handed to the platform's post-response hook, so the
     // function stays alive for it after the interaction is acknowledged.
     expect(deferred).toHaveLength(1);
+    await settleDeferred();
   });
 
   it("defers the password-reset command the same way", async () => {
@@ -197,6 +221,7 @@ describe("POST /api/discord/interactions", () => {
     // Two usernames, one Graph call each — dispatched to the deferred path
     // rather than blocking the acknowledgement.
     expect(mockResetPassword).toHaveBeenCalledTimes(2);
+    await settleDeferred();
   });
 
   it("falls back to a harmless PONG when the command carries no argument", async () => {

--- a/tests/integration/api/discord-interactions.test.ts
+++ b/tests/integration/api/discord-interactions.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.DISCORD_PUBLIC_KEY = "test-public-key";
+process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+process.env.DISCORD_APPLICATION_ID = "test-app-id";
+
+// A webhook, so there is no session and no role: the Ed25519 signature over the
+// timestamp and the raw body IS the authorization. That makes two properties
+// the ones worth pinning. First, an unsigned or wrongly-signed request must be
+// refused before the payload is parsed at all — the signature is the only
+// gate, so anything that happens before it runs happens for anybody. Second,
+// every command must answer synchronously and finish its slow work afterwards,
+// because Discord hard-times-out an interaction at three seconds and
+// de-registers an endpoint that fails its handshake.
+
+const mockVerifyKey = vi.fn();
+const deferred: unknown[] = [];
+
+vi.mock("discord-interactions", () => ({
+  verifyKey: (...args: unknown[]) => mockVerifyKey(...args),
+  InteractionType: { PING: 1, APPLICATION_COMMAND: 2 },
+  InteractionResponseType: {
+    PONG: 1,
+    DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE: 5,
+  },
+}));
+
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return {
+    ...actual,
+    // Capture the background work instead of running it, so the tests can
+    // assert that the route deferred rather than awaited.
+    after: (work: unknown) => {
+      deferred.push(work);
+    },
+  };
+});
+
+const mockAskGeduGuru = vi.fn();
+const mockAskHappinappi = vi.fn();
+vi.mock("@/lib/gemini", () => ({
+  askGeduGuru: (...args: unknown[]) => mockAskGeduGuru(...args),
+  askHappinappi: (...args: unknown[]) => mockAskHappinappi(...args),
+}));
+
+const mockResetPassword = vi.fn();
+vi.mock("@/lib/microsoft-graph", () => ({
+  resetPassword: (...args: unknown[]) => mockResetPassword(...args),
+}));
+
+import { POST } from "@/app/api/discord/interactions/route";
+
+function interactionRequest(
+  payload: unknown,
+  { signature = "sig", timestamp = "123", rawBody = "" } = {},
+): Request {
+  return new Request("http://localhost:3000/api/discord/interactions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-signature-ed25519": signature,
+      "x-signature-timestamp": timestamp,
+    },
+    body: rawBody || JSON.stringify(payload),
+  });
+}
+
+describe("POST /api/discord/interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deferred.length = 0;
+    mockVerifyKey.mockResolvedValue(true);
+  });
+
+  // -- Authorization: the signature is the whole gate --
+
+  it("returns 401 when the signature does not verify", async () => {
+    mockVerifyKey.mockResolvedValue(false);
+
+    const response = await POST(interactionRequest({ type: 1 }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Invalid signature" });
+  });
+
+  it("refuses an unsigned request", async () => {
+    mockVerifyKey.mockResolvedValue(false);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/discord/interactions", {
+        method: "POST",
+        body: JSON.stringify({ type: 1 }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("verifies over the exact raw bytes, with the timestamp and the public key", async () => {
+    // The signature covers timestamp + body, so the route must hand the
+    // verifier the untouched text rather than a re-serialized object.
+    const rawBody = '{"type":1,"unknown_field":"kept"}';
+
+    await POST(
+      interactionRequest(null, { rawBody, signature: "sig-1", timestamp: "t-1" }),
+    );
+
+    // The public key is read from the environment at module load, so only the
+    // three request-derived arguments are asserted here.
+    const [body, signature, timestamp] = mockVerifyKey.mock.calls[0];
+    expect(body).toBe(rawBody);
+    expect(signature).toBe("sig-1");
+    expect(timestamp).toBe("t-1");
+  });
+
+  it("does no work at all when verification fails", async () => {
+    mockVerifyKey.mockResolvedValue(false);
+
+    await POST(
+      interactionRequest({
+        type: 2,
+        token: "interaction-token",
+        data: { name: "geduguru", options: [{ value: "kysymys" }] },
+      }),
+    );
+
+    expect(deferred).toHaveLength(0);
+    expect(mockAskGeduGuru).not.toHaveBeenCalled();
+  });
+
+  // -- Payload --
+
+  it("returns 400 for a payload that is not an interaction", async () => {
+    const response = await POST(interactionRequest({ no: "type" }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for an interaction type it does not handle", async () => {
+    const response = await POST(interactionRequest({ type: 99 }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("keeps unknown fields from breaking the webhook", async () => {
+    // Meta and Discord both add fields over time; a strict schema here would
+    // turn a harmless addition into a de-registered endpoint.
+    const response = await POST(
+      interactionRequest({ type: 1, brand_new_field: { nested: true } }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ type: 1 });
+  });
+
+  // -- Handshake --
+
+  it("answers a PING with a PONG", async () => {
+    const response = await POST(interactionRequest({ type: 1 }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ type: 1 });
+  });
+
+  // -- Commands --
+
+  it("defers every command rather than answering inline", async () => {
+    const response = await POST(
+      interactionRequest({
+        type: 2,
+        token: "interaction-token",
+        data: { name: "geduguru", options: [{ value: "Mikä on SOG?" }] },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    // 5 = DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE. Discord times out at 3s, so the
+    // AI/Graph call must never run before this response is returned.
+    expect(await response.json()).toEqual({ type: 5 });
+    // The slow work is handed to the platform's post-response hook, so the
+    // function stays alive for it after the interaction is acknowledged.
+    expect(deferred).toHaveLength(1);
+  });
+
+  it("defers the password-reset command the same way", async () => {
+    const response = await POST(
+      interactionRequest({
+        type: 2,
+        token: "interaction-token",
+        data: { name: "reset-password", options: [{ value: "alice bob" }] },
+      }),
+    );
+
+    expect(await response.json()).toEqual({ type: 5 });
+    expect(deferred).toHaveLength(1);
+    // Two usernames, one Graph call each — dispatched to the deferred path
+    // rather than blocking the acknowledgement.
+    expect(mockResetPassword).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a harmless PONG when the command carries no argument", async () => {
+    const response = await POST(
+      interactionRequest({
+        type: 2,
+        token: "interaction-token",
+        data: { name: "geduguru" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ type: 1 });
+    expect(deferred).toHaveLength(0);
+  });
+
+  it("falls back to a PONG for a non-string option value", async () => {
+    const response = await POST(
+      interactionRequest({
+        type: 2,
+        token: "interaction-token",
+        data: { name: "geduguru", options: [{ value: { nested: true } }] },
+      }),
+    );
+
+    expect(await response.json()).toEqual({ type: 1 });
+    expect(deferred).toHaveLength(0);
+  });
+
+  it("falls back to a PONG when there is no interaction token to reply to", async () => {
+    const response = await POST(
+      interactionRequest({
+        type: 2,
+        data: { name: "geduguru", options: [{ value: "kysymys" }] },
+      }),
+    );
+
+    expect(await response.json()).toEqual({ type: 1 });
+    expect(deferred).toHaveLength(0);
+  });
+});

--- a/tests/integration/api/family-list.test.ts
+++ b/tests/integration/api/family-list.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+// The family-list route is one of the few that legitimately reads past the
+// caller's own row-level view: a gamer must be able to see their siblings, and
+// RLS restricts them to their own parent link. The service-role read is
+// therefore the point, and what this file pins is the boundary around it — the
+// role gate, the PIN-gate exemption the profile chooser depends on, and the
+// fact that identity is taken from the verified session rather than the request.
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockAdminClient = { marker: "admin" };
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => mockAdminClient,
+}));
+
+const mockResolveFamily = vi.fn();
+vi.mock("@/services/family/family.server", () => ({
+  resolveFamilyWithAdmin: (...args: unknown[]) => mockResolveFamily(...args),
+}));
+
+import { GET } from "@/app/api/family/list/route";
+
+const CUSTOMER_ID = "11111111-1111-1111-1111-111111111111";
+const GAMER_ID = "22222222-2222-2222-2222-222222222222";
+
+const FAMILY = [
+  { id: CUSTOMER_ID, role: "customer", first_name: "Pat" },
+  { id: GAMER_ID, role: "gamer", first_name: "Robin" },
+];
+
+function listRequest(): Request {
+  return new Request("http://localhost:3000/api/family/list");
+}
+
+function mockAuthenticatedAs(role: "customer" | "gamer", id: string) {
+  mockRequireRole.mockResolvedValue({
+    user: { id },
+    profile: { id, role },
+  });
+}
+
+function mockUnauthenticated() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  );
+}
+
+function mockForbidden() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+  );
+}
+
+describe("GET /api/family/list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveFamily.mockResolvedValue(FAMILY);
+  });
+
+  // -- Auth --
+
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthenticated();
+
+    const response = await GET(listRequest());
+
+    expect(response.status).toBe(401);
+    expect(mockResolveFamily).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a role outside the family unit (admin, gedu)", async () => {
+    mockForbidden();
+
+    const response = await GET(listRequest());
+
+    expect(response.status).toBe(403);
+    expect(mockResolveFamily).not.toHaveBeenCalled();
+  });
+
+  it("gates to customer and gamer, and exempts the parent-PIN lock", async () => {
+    // allowUnverified is load-bearing: the profile chooser and the lock gate
+    // both need this list while the customer session is still locked, so the
+    // parent can hand the device to a child without entering the PIN first.
+    mockAuthenticatedAs("customer", CUSTOMER_ID);
+
+    await GET(listRequest());
+
+    expect(mockRequireRole).toHaveBeenCalledWith(
+      ["customer", "gamer"],
+      expect.objectContaining({ allowUnverified: true }),
+    );
+  });
+
+  // -- Happy path --
+
+  it("returns the resolved family for a parent", async () => {
+    mockAuthenticatedAs("customer", CUSTOMER_ID);
+
+    const response = await GET(listRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ family: FAMILY });
+  });
+
+  it("resolves against the session's identity, never a request parameter", async () => {
+    // A gamer reading siblings is the case the service-role client exists for,
+    // so the id it is handed has to be the gate-verified one.
+    mockAuthenticatedAs("gamer", GAMER_ID);
+
+    await GET(
+      new Request("http://localhost:3000/api/family/list?userId=someone-else"),
+    );
+
+    expect(mockResolveFamily).toHaveBeenCalledWith(
+      mockAdminClient,
+      GAMER_ID,
+      "gamer",
+    );
+  });
+
+  // -- Failure --
+
+  it("answers a generic 500 when the resolver fails", async () => {
+    mockAuthenticatedAs("customer", CUSTOMER_ID);
+    mockResolveFamily.mockRejectedValue(new Error("pg: connection reset"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await GET(listRequest());
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).error).toBe("Internal server error");
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/api/feedback.test.ts
+++ b/tests/integration/api/feedback.test.ts
@@ -318,7 +318,10 @@ describe("POST /api/feedback", () => {
     });
   });
 
-  it("returns 500 and sends no mail when the RPC errors", async () => {
+  it("returns 400 and sends no mail when the RPC refuses the message", async () => {
+    // The RPC re-checks the same length bounds the body schema enforces, so its
+    // check violation is genuinely bad input. The route used to fold every RPC
+    // failure into a 500; the shared table separates the two.
     mockAuthenticatedAs("customer");
     setupHappyPath();
     mockRpc.mockResolvedValue({
@@ -328,7 +331,22 @@ describe("POST /api/feedback", () => {
 
     const response = await POST(createRequest(validBody));
 
+    expect(response.status).toBe(400);
+    expect(mockSendTransactionalEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic 500 and sends no mail when the RPC fails unexpectedly", async () => {
+    mockAuthenticatedAs("customer");
+    setupHappyPath();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: "XX000", message: "connection reset" },
+    });
+
+    const response = await POST(createRequest(validBody));
+
     expect(response.status).toBe(500);
+    expect((await response.json()).error).toBe("Internal server error");
     expect(mockSendTransactionalEmail).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/api/gamers-create.test.ts
+++ b/tests/integration/api/gamers-create.test.ts
@@ -124,7 +124,7 @@ describe("POST /api/gamers/create — DOB validation", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toContain("Date of birth is required");
+    expect(data.error).toContain("dateOfBirth");
   });
 
   it("should return 400 when dateOfBirth is in the future", async () => {
@@ -297,7 +297,7 @@ describe("POST /api/gamers/create — v1 minimal body (auto-generated credential
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toContain("Gender");
+    expect(data.error).toContain("gender");
   });
 
   it("accepts a missing/null gender (no longer required)", async () => {
@@ -313,8 +313,11 @@ describe("POST /api/gamers/create — v1 minimal body (auto-generated credential
     );
 
     // 400 from createUser's mock-stop, not from a gender validation error.
+    // The provider's own message is logged rather than forwarded now, so the
+    // body is this route's own copy — what matters here is that no gender
+    // issue was raised on the way.
     const data = await response.json();
-    expect(data.error).toBe("mock-stop");
+    expect(data.error).not.toContain("gender");
     expect(response.status).toBe(400);
   });
 });

--- a/tests/integration/api/gamers-update.test.ts
+++ b/tests/integration/api/gamers-update.test.ts
@@ -47,6 +47,10 @@ function mockForbiddenRole() {
 
 const mockSupabaseFrom = vi.fn();
 
+// Real gamer ids are auth-user uuids, and the route validates the path
+// segment as one — so the fixtures are uuids too.
+const GAMER_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+
 function mockAuthenticated(userId = "customer-123") {
   mockRequireRole.mockResolvedValue({
     user: { id: userId },
@@ -132,7 +136,7 @@ function mockProfileFetch(profile: Record<string, unknown>) {
 function mockAdminSuccess(
   targetRole = "gamer",
   updatedProfile: Record<string, unknown> = {
-    id: "gamer-1",
+    id: GAMER_ID,
     first_name: "Updated Name",
     role: "gamer",
   },
@@ -170,7 +174,7 @@ describe("PATCH /api/gamers/[id]", () => {
   it("should return 401 when unauthenticated", async () => {
     mockUnauthenticated();
 
-    const [req, ctx] = createRequest("gamer-1", { firstName: "New Name" });
+    const [req, ctx] = createRequest(GAMER_ID, { firstName: "New Name" });
     const response = await PATCH(req, ctx);
     expect(response.status).toBe(401);
   });
@@ -178,7 +182,7 @@ describe("PATCH /api/gamers/[id]", () => {
   it("should enforce customer role and return 403 for non-customers", async () => {
     mockForbiddenRole();
 
-    const [req, ctx] = createRequest("gamer-1", { firstName: "New Name" });
+    const [req, ctx] = createRequest(GAMER_ID, { firstName: "New Name" });
     const response = await PATCH(req, ctx);
     expect(response.status).toBe(403);
     expect(mockRequireRole).toHaveBeenCalledWith("customer", expect.any(Object));
@@ -189,7 +193,7 @@ describe("PATCH /api/gamers/[id]", () => {
   it("should return 400 when body is empty", async () => {
     mockAuthenticated();
 
-    const [req, ctx] = createRequest("gamer-1", {});
+    const [req, ctx] = createRequest(GAMER_ID, {});
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
@@ -201,7 +205,7 @@ describe("PATCH /api/gamers/[id]", () => {
   it("should return 400 when firstName is too short", async () => {
     mockAuthenticated();
 
-    const [req, ctx] = createRequest("gamer-1", { firstName: "A" });
+    const [req, ctx] = createRequest(GAMER_ID, { firstName: "A" });
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
@@ -212,7 +216,7 @@ describe("PATCH /api/gamers/[id]", () => {
   it("should return 400 when password is too short", async () => {
     mockAuthenticated();
 
-    const [req, ctx] = createRequest("gamer-1", { password: "12345" });
+    const [req, ctx] = createRequest(GAMER_ID, { password: "12345" });
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
@@ -226,7 +230,7 @@ describe("PATCH /api/gamers/[id]", () => {
     mockAuthenticated("customer-123");
     mockParentGamerLookup(false);
 
-    const [req, ctx] = createRequest("gamer-1", { firstName: "New Name" });
+    const [req, ctx] = createRequest(GAMER_ID, { firstName: "New Name" });
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
@@ -239,7 +243,10 @@ describe("PATCH /api/gamers/[id]", () => {
     mockParentGamerLookup(true);
     mockAdminSuccess("admin"); // target is admin, not gamer
 
-    const [req, ctx] = createRequest("admin-1", { firstName: "New Name" });
+    const [req, ctx] = createRequest(
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1",
+      { firstName: "New Name" },
+    );
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
@@ -253,19 +260,19 @@ describe("PATCH /api/gamers/[id]", () => {
     mockAuthenticated("customer-123");
     mockParentGamerLookup(true);
     mockAdminSuccess("gamer", {
-      id: "gamer-1",
+      id: GAMER_ID,
       first_name: "New Name",
       role: "gamer",
     });
 
-    const [req, ctx] = createRequest("gamer-1", { firstName: "New Name" });
+    const [req, ctx] = createRequest(GAMER_ID, { firstName: "New Name" });
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
     expect(response.status).toBe(200);
     expect(data.gamer.first_name).toBe("New Name");
     expect(mockAdminAuthAdmin.updateUserById).toHaveBeenCalledWith(
-      "gamer-1",
+      GAMER_ID,
       { user_metadata: { first_name: "New Name", display_name: "New Name" } },
     );
   });
@@ -277,7 +284,7 @@ describe("PATCH /api/gamers/[id]", () => {
     // For password-only, admin calls: role check → final fetch (no profile update)
     const roleCheck = mockTargetProfile("gamer");
     const fetch = mockProfileFetch({
-      id: "gamer-1",
+      id: GAMER_ID,
       first_name: "Existing",
       role: "gamer",
     });
@@ -294,14 +301,14 @@ describe("PATCH /api/gamers/[id]", () => {
       error: null,
     });
 
-    const [req, ctx] = createRequest("gamer-1", { password: "newpass123" });
+    const [req, ctx] = createRequest(GAMER_ID, { password: "newpass123" });
     const response = await PATCH(req, ctx);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.gamer.id).toBe("gamer-1");
+    expect(data.gamer.id).toBe(GAMER_ID);
     expect(mockAdminAuthAdmin.updateUserById).toHaveBeenCalledWith(
-      "gamer-1",
+      GAMER_ID,
       { password: "newpass123" },
     );
   });
@@ -310,12 +317,12 @@ describe("PATCH /api/gamers/[id]", () => {
     mockAuthenticated("customer-123");
     mockParentGamerLookup(true);
     mockAdminSuccess("gamer", {
-      id: "gamer-1",
+      id: GAMER_ID,
       first_name: "New Name",
       role: "gamer",
     });
 
-    const [req, ctx] = createRequest("gamer-1", {
+    const [req, ctx] = createRequest(GAMER_ID, {
       firstName: "New Name",
       password: "newpass123",
     });
@@ -344,7 +351,7 @@ describe("PATCH /api/gamers/[id]", () => {
       upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
     };
     const fetch = mockProfileFetch({
-      id: "gamer-1",
+      id: GAMER_ID,
       first_name: "Existing",
       role: "gamer",
     });
@@ -357,7 +364,7 @@ describe("PATCH /api/gamers/[id]", () => {
       return fetch;
     });
 
-    const [req, ctx] = createRequest("gamer-1", {
+    const [req, ctx] = createRequest(GAMER_ID, {
       minecraftUsername: "notch",
     });
     const response = await PATCH(req, ctx);
@@ -366,7 +373,7 @@ describe("PATCH /api/gamers/[id]", () => {
     expect(mockLookupMinecraftUser).toHaveBeenCalledWith("notch");
     expect(mcUpsert.upsert).toHaveBeenCalledWith(
       {
-        user_id: "gamer-1",
+        user_id: GAMER_ID,
         minecraft_username: "notch",
         minecraft_uuid: "069a79f4-44e9-4726-a5be-fca90e38aaf5",
       },
@@ -383,7 +390,7 @@ describe("PATCH /api/gamers/[id]", () => {
       upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
     };
     const fetch = mockProfileFetch({
-      id: "gamer-1",
+      id: GAMER_ID,
       first_name: "Existing",
       role: "gamer",
     });
@@ -396,7 +403,7 @@ describe("PATCH /api/gamers/[id]", () => {
       return fetch;
     });
 
-    const [req, ctx] = createRequest("gamer-1", {
+    const [req, ctx] = createRequest(GAMER_ID, {
       minecraftUsername: null,
     });
     const response = await PATCH(req, ctx);
@@ -409,7 +416,7 @@ describe("PATCH /api/gamers/[id]", () => {
   it("should return 400 for invalid minecraft username format", async () => {
     mockAuthenticated("customer-123");
 
-    const [req, ctx] = createRequest("gamer-1", {
+    const [req, ctx] = createRequest(GAMER_ID, {
       minecraftUsername: "ab",
     });
     const response = await PATCH(req, ctx);

--- a/tests/integration/api/gedu-register.test.ts
+++ b/tests/integration/api/gedu-register.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The highest-value public route on the surface: it creates an account, with no
+// session in play, from a body a stranger controls. There is no wrong-role case
+// — there is no role — so what this file covers instead is the shape of that
+// power: the account it creates is never privileged, the auth user is created
+// only after every rejectable precondition has been checked, a failed promotion
+// leaves no orphaned auth user behind, and no database text reaches the caller.
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockCreateUser = vi.fn();
+const mockDeleteUser = vi.fn();
+const mockRpc = vi.fn();
+const mockMinecraftLookupRow = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    auth: {
+      admin: {
+        createUser: (...args: unknown[]) => mockCreateUser(...args),
+        deleteUser: (...args: unknown[]) => mockDeleteUser(...args),
+      },
+    },
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: () => mockMinecraftLookupRow() }) }),
+    }),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  }),
+}));
+
+const mockLookupMinecraftUser = vi.fn();
+vi.mock("@/lib/mojang", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/mojang")>();
+  return {
+    ...actual,
+    lookupMinecraftUser: (...args: unknown[]) => mockLookupMinecraftUser(...args),
+  };
+});
+
+import { POST } from "@/app/api/gedu/register/route";
+import { asObject, getString } from "../../helpers/json";
+
+const NEW_USER_ID = "99999999-9999-4999-8999-999999999999";
+
+const validBody = {
+  email: "teacher@example.test",
+  password: "a-long-enough-password",
+  firstName: "Aino",
+  lastName: "Virtanen",
+  // The route strips a leading + and requires bare digits; it does not strip
+  // separators, so the form sends the compact form.
+  phone: "+358401234567",
+  spokenLanguages: ["fi"],
+  locale: "fi",
+  locationIds: [],
+};
+
+function registerRequest(body: unknown, rawBody?: string): Request {
+  return new Request("http://localhost:3000/api/gedu/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: rawBody ?? JSON.stringify(body),
+  });
+}
+
+describe("POST /api/gedu/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMinecraftLookupRow.mockResolvedValue({ data: null, error: null });
+    mockLookupMinecraftUser.mockResolvedValue({ uuid: "mc-uuid-1" });
+    mockCreateUser.mockResolvedValue({
+      data: { user: { id: NEW_USER_ID } },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({ error: null });
+    mockDeleteUser.mockResolvedValue({ error: null });
+  });
+
+  // -- Public posture --
+
+  it("registers with no session and never consults the role gate", async () => {
+    const response = await POST(registerRequest(validBody));
+
+    expect(response.status).toBe(200);
+    expect(mockRequireRole).not.toHaveBeenCalled();
+  });
+
+  // -- Input --
+
+  it("returns 400 for malformed JSON", async () => {
+    const response = await POST(registerRequest(null, "{not-json"));
+
+    expect(response.status).toBe(400);
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a body that fails the contract schema", async () => {
+    const response = await POST(
+      registerRequest({ ...validBody, email: "not-an-email" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("email");
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a password below the contract minimum", async () => {
+    const response = await POST(
+      registerRequest({ ...validBody, password: "short" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unusable phone number, before creating anything", async () => {
+    const response = await POST(
+      registerRequest({ ...validBody, phone: "12" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe("Invalid phone number");
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed Minecraft username, before creating anything", async () => {
+    const response = await POST(
+      registerRequest({ ...validBody, minecraftUsername: "no spaces allowed" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+
+  // -- Happy path --
+
+  it("creates the auth user and promotes it, returning only the new id", async () => {
+    const response = await POST(registerRequest(validBody));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ userId: NEW_USER_ID });
+    expect(mockRpc).toHaveBeenCalledWith(
+      "register_gedu",
+      expect.objectContaining({ p_user_id: NEW_USER_ID, p_first_name: "Aino" }),
+    );
+  });
+
+  it("normalizes the phone to the digits the profile CHECK accepts", async () => {
+    await POST(registerRequest(validBody));
+
+    expect(getString(mockRpc.mock.calls[0][1], "p_phone")).toMatch(
+      /^\d{7,15}$/,
+    );
+  });
+
+  it("never asks for a role — the account is created unverified by the RPC", async () => {
+    // Self-registration must not be able to name its own privileges, so no
+    // role, verification flag or admin field is passed from the request.
+    await POST(
+      registerRequest({ ...validBody, role: "admin", isVerified: true }),
+    );
+
+    const args = asObject(mockRpc.mock.calls[0][1]);
+    expect(Object.keys(args)).not.toContain("p_role");
+    expect(JSON.stringify(args)).not.toContain("admin");
+  });
+
+  // -- Minecraft conflict --
+
+  it("returns 409 for an already-linked Minecraft account, without creating the user", async () => {
+    // Checked before createUser because createUser burns the email
+    // irreversibly — the registrant can retry with a different Minecraft name.
+    mockMinecraftLookupRow.mockResolvedValue({
+      data: { user_id: "someone-else" },
+      error: null,
+    });
+
+    const response = await POST(
+      registerRequest({ ...validBody, minecraftUsername: "Notch" }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 and deletes the auth user when the RPC loses the Minecraft race", async () => {
+    mockRpc.mockResolvedValue({
+      error: { code: "23505", message: "duplicate key minecraft_uuid" },
+    });
+
+    const response = await POST(
+      registerRequest({ ...validBody, minecraftUsername: "Notch" }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockDeleteUser).toHaveBeenCalledWith(NEW_USER_ID);
+  });
+
+  // -- Failure --
+
+  it("answers 400 without echoing the auth provider's message when signup is refused", async () => {
+    mockCreateUser.mockResolvedValue({
+      data: null,
+      error: { message: "A user with this email address has already been registered" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(registerRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).not.toContain("already been registered");
+    spy.mockRestore();
+  });
+
+  it("answers 500 without echoing database text, and deletes the orphaned auth user", async () => {
+    mockRpc.mockResolvedValue({
+      error: {
+        code: "23514",
+        message: 'new row for relation "profiles" violates check constraint "profiles_phone_check"',
+      },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(registerRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).not.toContain("check constraint");
+    expect(mockDeleteUser).toHaveBeenCalledWith(NEW_USER_ID);
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/api/minecraft-verify.test.ts
+++ b/tests/integration/api/minecraft-verify.test.ts
@@ -47,7 +47,7 @@ describe("GET /api/minecraft/verify", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toContain("Invalid username");
+    expect(data.error).toContain("username");
   });
 
   it("should return 400 for invalid username format", async () => {

--- a/tests/integration/api/products-groups-apply.test.ts
+++ b/tests/integration/api/products-groups-apply.test.ts
@@ -143,7 +143,10 @@ describe("POST /api/admin/products/[id]/groups/apply", () => {
     expect(body.error).toBe("Product not found");
   });
 
-  it("maps other RPC errors to HTTP 400", async () => {
+  it("maps a unique violation to HTTP 409 through the shared error table", async () => {
+    // This route used to answer 400 for every code except P0002. On the shared
+    // table a duplicate is a conflict, which is what every other route on the
+    // surface already answered for the same code.
     mockAuthenticatedAdmin();
     mockRpc.mockResolvedValue({
       data: null,
@@ -154,8 +157,21 @@ describe("POST /api/admin/products/[id]/groups/apply", () => {
     });
 
     const response = await POST(createRequest(emptyBatch), { params });
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(409);
     const body = await response.json();
     expect(body.error).toContain("duplicate key");
+  });
+
+  it("maps an unrecognized database code to a logged 500 rather than a 400", async () => {
+    // An error nobody anticipated is a server error; reporting it to the admin
+    // as their bad request hid it.
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: "boom", code: "XX000" },
+    });
+
+    const response = await POST(createRequest(emptyBatch), { params });
+    expect(response.status).toBe(500);
   });
 });

--- a/tests/integration/api/products-participations-delete.test.ts
+++ b/tests/integration/api/products-participations-delete.test.ts
@@ -105,8 +105,10 @@ describe("DELETE /api/admin/products/[id]/participations/[participationId]", () 
     rpcFails("P0002", "participation is not on product");
     const response = await DELETE(createRequest(), { params });
     expect(response.status).toBe(404);
+    // The status carries the meaning; the body is the shared table's generic
+    // message, because the RPC's own text names rows the admin never asked for.
     const error = getString(await response.json(), "error");
-    expect(error).toContain("not found on this product");
+    expect(error).toBe("Not found");
   });
 
   it("rejects consumer_club products (removal goes through Stripe, not here)", async () => {
@@ -130,11 +132,15 @@ describe("DELETE /api/admin/products/[id]/participations/[participationId]", () 
     expect(error).toContain("live Stripe subscription");
   });
 
-  it("returns 400 for any other RPC error", async () => {
+  it("returns a logged 500 for an unrecognized RPC error code", async () => {
+    // Used to be a 400 carrying the raw message. A code the shared table does
+    // not recognize is not the admin's mistake, so it is a server error.
     mockAuthenticatedAdmin();
     rpcFails("XX000", "boom");
     const response = await DELETE(createRequest(), { params });
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(500);
+    const error = getString(await response.json(), "error");
+    expect(error).toBe("Internal server error");
   });
 
   it("returns 500 when the RPC result does not match its contract", async () => {

--- a/tests/integration/api/products-participations-transition.test.ts
+++ b/tests/integration/api/products-participations-transition.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { PATCH } from "@/app/api/admin/products/[id]/participations/[participationId]/route";
+import { asString } from "../../helpers/json";
+
+// The admin waitlist promote/demote handler, driven by the groups-panel drag
+// UI. Its sibling DELETE handler is covered next door; this file is the reason
+// test linkage is per handler rather than per file — the two live in one route
+// file and only one of them used to be exercised.
+//
+// The rules themselves live in the RPCs and are covered against a real database
+// in tests/db/. What this file covers is the handler's own job: the role gate,
+// the IDOR guard that ties the participation to THIS product, the consumer-club
+// refusal, and the mapping from SQLSTATE to HTTP status.
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockRpc = vi.fn();
+const mockParticipationRead = vi.fn();
+const mockProductRead = vi.fn();
+
+/** `participations` and `products` are read through the same client stub. */
+function tableStub(table: string) {
+  const read = table === "participations" ? mockParticipationRead : mockProductRead;
+  return {
+    select: () => ({ eq: () => ({ maybeSingle: () => read() }) }),
+  };
+}
+
+const PRODUCT_ID = "11111111-1111-1111-1111-111111111111";
+const PARTICIPATION_ID = "44444444-4444-4444-4444-444444444444";
+const GROUP_ID = "55555555-5555-5555-5555-555555555555";
+
+const params = Promise.resolve({
+  id: PRODUCT_ID,
+  participationId: PARTICIPATION_ID,
+});
+
+function patchRequest(body: unknown, rawBody?: string): Request {
+  return new Request(
+    `http://localhost/api/admin/products/x/participations/y`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: rawBody ?? JSON.stringify(body),
+    },
+  );
+}
+
+function mockAuthenticatedAdmin() {
+  mockRequireRole.mockResolvedValue({
+    user: { id: "admin-user-id" },
+    profile: { role: "admin" },
+    supabase: { rpc: mockRpc, from: (table: string) => tableStub(table) },
+  });
+}
+
+function mockUnauthenticated() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  );
+}
+
+function mockNonAdmin() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json(
+      { error: "Only admins can change waitlist status" },
+      { status: 403 },
+    ),
+  );
+}
+
+const promote = { action: "promote", groupId: GROUP_ID };
+const demote = { action: "demote" };
+
+describe("PATCH /api/admin/products/[id]/participations/[participationId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParticipationRead.mockResolvedValue({
+      data: { id: PARTICIPATION_ID, product_id: PRODUCT_ID },
+      error: null,
+    });
+    mockProductRead.mockResolvedValue({
+      data: { product_type: "camp" },
+      error: null,
+    });
+    mockRpc.mockResolvedValue({
+      data: {
+        kind: "promoted",
+        participation_id: PARTICIPATION_ID,
+        product_id: PRODUCT_ID,
+        group_id: GROUP_ID,
+      },
+      error: null,
+    });
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+  });
+
+  // -- Auth --
+
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthenticated();
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(401);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-admin", async () => {
+    mockNonAdmin();
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(403);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  // -- Input --
+
+  it("returns 400 for malformed JSON", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await PATCH(patchRequest(null, "{not-json"), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an action outside the promote/demote pair", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await PATCH(patchRequest({ action: "delete" }), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when promote omits its drop target", async () => {
+    // `groupId: null` means the unassigned inbox and is valid; omitting the key
+    // entirely is not, because the drag UI always knows where it dropped.
+    mockAuthenticatedAdmin();
+
+    const response = await PATCH(patchRequest({ action: "promote" }), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed participation id in the path", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await PATCH(patchRequest(promote), {
+      params: Promise.resolve({ id: PRODUCT_ID, participationId: "nope" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  // -- IDOR guard --
+
+  it("returns 404 when the participation belongs to a different product", async () => {
+    // Without this, a participationId from another product could be transitioned
+    // through this URL — the whole reason the guard exists.
+    mockAuthenticatedAdmin();
+    mockParticipationRead.mockResolvedValue({
+      data: {
+        id: PARTICIPATION_ID,
+        product_id: "99999999-9999-4999-8999-999999999999",
+      },
+      error: null,
+    });
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(404);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the participation does not exist", async () => {
+    mockAuthenticatedAdmin();
+    mockParticipationRead.mockResolvedValue({ data: null, error: null });
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(404);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the product does not exist", async () => {
+    mockAuthenticatedAdmin();
+    mockProductRead.mockResolvedValue({ data: null, error: null });
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(404);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  // -- Consumer-club gate --
+
+  it("refuses a consumer club, where promote/demote would break billing", async () => {
+    // Promotion would mean an unbilled active seat; demotion would strand a
+    // paying subscriber on the waitlist. Symmetric with the add/remove gate.
+    mockAuthenticatedAdmin();
+    mockProductRead.mockResolvedValue({
+      data: { product_type: "consumer_club" },
+      error: null,
+    });
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("consumer clubs");
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  // -- Happy paths --
+
+  it("promotes into the named group", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(mockRpc).toHaveBeenCalledWith("promote_from_waitlist", {
+      p_participation_id: PARTICIPATION_ID,
+      p_group_id: GROUP_ID,
+    });
+  });
+
+  it("promotes into the unassigned inbox when groupId is null", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: {
+        kind: "promoted",
+        participation_id: PARTICIPATION_ID,
+        product_id: PRODUCT_ID,
+        group_id: null,
+      },
+      error: null,
+    });
+
+    const response = await PATCH(
+      patchRequest({ action: "promote", groupId: null }),
+      { params },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledWith("promote_from_waitlist", {
+      p_participation_id: PARTICIPATION_ID,
+      p_group_id: undefined,
+    });
+  });
+
+  it("demotes an active gamer to the back of the waitlist", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: {
+        kind: "demoted",
+        participation_id: PARTICIPATION_ID,
+        product_id: PRODUCT_ID,
+      },
+      error: null,
+    });
+
+    const response = await PATCH(patchRequest(demote), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledWith("demote_to_waitlist", {
+      p_participation_id: PARTICIPATION_ID,
+    });
+  });
+
+  it("treats the RPC's noop as success, letting the panel refetch reconcile", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: { kind: "noop", status: "active" },
+      error: null,
+    });
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("writes an audit line naming the admin, the product and the action", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: {
+        kind: "demoted",
+        participation_id: PARTICIPATION_ID,
+        product_id: PRODUCT_ID,
+      },
+      error: null,
+    });
+
+    await PATCH(patchRequest(demote), { params });
+
+    const line = asString(vi.mocked(console.info).mock.calls[0][0]);
+    expect(JSON.parse(line)).toMatchObject({
+      event: "admin_waitlist_transition",
+      action: "demote",
+      admin_id: "admin-user-id",
+      product_id: PRODUCT_ID,
+      participation_id: PARTICIPATION_ID,
+    });
+  });
+
+  // -- Error mapping --
+
+  it("maps the RPC's no_data_found to 404", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: "P0002", message: "Participation not found" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe("Not found");
+    spy.mockRestore();
+  });
+
+  it("maps a check violation to 400 through the shared error table", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: "23514", message: "only an active participation can be moved" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(patchRequest(demote), { params });
+
+    expect(response.status).toBe(400);
+    spy.mockRestore();
+  });
+
+  it("maps an unrecognized code to a logged, generic 500", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: "XX000", message: "connection reset" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).error).toBe("Internal server error");
+    spy.mockRestore();
+  });
+
+  it("answers 500 without echoing database text when the IDOR read fails", async () => {
+    mockAuthenticatedAdmin();
+    mockParticipationRead.mockResolvedValue({
+      data: null,
+      error: { code: "XX000", message: "permission denied for table participations" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(patchRequest(promote), { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).not.toContain("permission denied");
+    expect(mockRpc).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("returns 500 when the RPC result does not match its contract", async () => {
+    mockAuthenticatedAdmin();
+    mockRpc.mockResolvedValue({ data: { kind: "who-knows" }, error: null });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await PATCH(patchRequest(promote), { params });
+
+    expect(response.status).toBe(500);
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/api/products-update.test.ts
+++ b/tests/integration/api/products-update.test.ts
@@ -1,0 +1,442 @@
+// @vitest-environment node
+//
+// Node environment so Request, FormData, and File are all undici/Node natives
+// from one realm: jsdom's FormData isn't serializable by undici's Request, and
+// files parsed out of a real multipart body would fail the route's
+// `instanceof File` check against jsdom's File. See the sibling create test.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { POST } from "@/app/api/admin/products/[id]/update/route";
+import { asString } from "../../helpers/json";
+
+// The update route is the create route's mirror with one extra hazard: it moves
+// blobs in a bucket the caller has no rights to, around an RPC that can fail.
+// So beyond auth and body validation, what this file pins is the storage
+// choreography — upload BEFORE the RPC so the new path commits atomically with
+// the rest of the update, delete the new blob if the RPC then fails, and delete
+// the superseded blob only once the RPC has succeeded.
+
+// --- Mocks ---
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+const mockUserRpc = vi.fn();
+
+const mockAdminUpload = vi.fn();
+const mockAdminRemove = vi.fn();
+const mockProductRead = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    storage: {
+      from: vi.fn(() => ({ upload: mockAdminUpload, remove: mockAdminRemove })),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: () => mockProductRead() })),
+      })),
+    })),
+  })),
+}));
+
+// --- Helpers ---
+
+const PRODUCT_ID = "11111111-1111-1111-1111-111111111111";
+const params = Promise.resolve({ id: PRODUCT_ID });
+
+function mockUnauthenticated() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  );
+}
+
+function mockAuthenticatedAdmin() {
+  mockRequireRole.mockResolvedValue({
+    user: { id: "admin-user-id" },
+    profile: { role: "admin" },
+    supabase: { rpc: mockUserRpc },
+  });
+}
+
+function mockAuthenticatedNonAdmin() {
+  mockRequireRole.mockResolvedValue(
+    NextResponse.json(
+      { error: "Only admins can update products" },
+      { status: 403 },
+    ),
+  );
+}
+
+// The full UpdateProductInput shape the admin form sends; the contract schema
+// requires every field, with explicit nulls for the absent ones.
+const validBody = {
+  billing_mode: "paid",
+  translations: [
+    { locale: "en", name: "X", short_description: "Y", long_description: null },
+  ],
+  topic: "minecraft_java",
+  min_age: 7,
+  max_age: 12,
+  spoken_language_code: "en",
+  padlet_url: null,
+  location_id: null,
+  is_remote: true,
+  signup_threshold: null,
+  start_date: null,
+  end_date: null,
+  timezone: "Europe/Helsinki",
+  seat_count: null,
+  waitlist_enabled: false,
+  registration_opens_at: "2026-01-01T00:00:00Z",
+  is_visible: true,
+  refund_policy_days: null,
+  schedule_slots: [{ weekday: 1, start_time: "16:00", duration_minutes: 90 }],
+  prices: [],
+  holiday_calendar_ids: [],
+  primary_gedu_fee_cents: null,
+  assistant_gedu_fee_cents: null,
+  municipality_fee_cents: null,
+};
+
+function updateRequest(
+  opts: {
+    data?: unknown;
+    rawData?: string;
+    file?: File | null;
+    clearImage?: boolean;
+    plainBody?: boolean;
+  } = {},
+): Request {
+  if (opts.plainBody) {
+    return new Request(`http://localhost/api/admin/products/x/update`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not a form",
+    });
+  }
+
+  const fd = new FormData();
+  if (opts.rawData !== undefined) {
+    fd.append("data", opts.rawData);
+  } else if ("data" in opts) {
+    if (opts.data !== undefined) fd.append("data", JSON.stringify(opts.data));
+  } else {
+    fd.append("data", JSON.stringify(validBody));
+  }
+
+  const file = "file" in opts ? opts.file : null;
+  if (file) fd.append("file", file);
+  if (opts.clearImage) fd.append("clear_image", "true");
+
+  return new Request(`http://localhost/api/admin/products/x/update`, {
+    method: "POST",
+    body: fd,
+  });
+}
+
+function jpeg(name = "new.jpg"): File {
+  return new File(["bytes"], name, { type: "image/jpeg" });
+}
+
+// --- Tests ---
+
+describe("POST /api/admin/products/[id]/update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProductRead.mockResolvedValue({
+      data: { image_path: null },
+      error: null,
+    });
+    mockUserRpc.mockResolvedValue({ data: PRODUCT_ID, error: null });
+    mockAdminUpload.mockResolvedValue({ error: null });
+    mockAdminRemove.mockResolvedValue({ error: null });
+  });
+
+  // -- Auth --
+
+  it("returns 401 when not authenticated", async () => {
+    mockUnauthenticated();
+
+    const response = await POST(updateRequest(), { params });
+
+    expect(response.status).toBe(401);
+    expect(mockUserRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-admin", async () => {
+    mockAuthenticatedNonAdmin();
+
+    const response = await POST(updateRequest(), { params });
+
+    expect(response.status).toBe(403);
+    expect(mockUserRpc).not.toHaveBeenCalled();
+  });
+
+  // -- Input --
+
+  it("returns 400 for a non-multipart request", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await POST(updateRequest({ plainBody: true }), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockUserRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the data field is missing", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await POST(updateRequest({ data: undefined }), { params });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing 'data' field" });
+  });
+
+  it("returns 400 when the data field is not valid JSON", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await POST(updateRequest({ rawData: "{nope" }), { params });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "'data' field must be valid JSON",
+    });
+  });
+
+  it("returns 400 when the data field fails the contract schema", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await POST(
+      updateRequest({ data: { ...validBody, min_age: "seven" } }),
+      { params },
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockUserRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed product id in the path", async () => {
+    // The path segment is validated at the boundary, so a junk id becomes a
+    // plain 400 rather than an unmapped driver error further in.
+    mockAuthenticatedAdmin();
+
+    const response = await POST(updateRequest(), {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mockUserRpc).not.toHaveBeenCalled();
+  });
+
+  it("returns 413 for an oversized image", async () => {
+    mockAuthenticatedAdmin();
+    const big = new File([new Uint8Array(6 * 1024 * 1024)], "big.jpg", {
+      type: "image/jpeg",
+    });
+
+    const response = await POST(updateRequest({ file: big }), { params });
+
+    expect(response.status).toBe(413);
+    expect(mockAdminUpload).not.toHaveBeenCalled();
+  });
+
+  it("returns 415 for an unsupported image type", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await POST(
+      updateRequest({ file: new File(["x"], "notes.txt", { type: "text/plain" }) }),
+      { params },
+    );
+
+    expect(response.status).toBe(415);
+    expect(mockAdminUpload).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the product does not exist", async () => {
+    mockAuthenticatedAdmin();
+    mockProductRead.mockResolvedValue({ data: null, error: null });
+
+    const response = await POST(updateRequest(), { params });
+
+    expect(response.status).toBe(404);
+    expect(mockUserRpc).not.toHaveBeenCalled();
+  });
+
+  // -- Happy path --
+
+  it("updates without touching storage when no image is sent", async () => {
+    mockAuthenticatedAdmin();
+
+    const response = await POST(updateRequest(), { params });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ product_id: PRODUCT_ID });
+    expect(mockAdminUpload).not.toHaveBeenCalled();
+    expect(mockAdminRemove).not.toHaveBeenCalled();
+  });
+
+  it("calls the RPC on the user client, with the id from the path", async () => {
+    // SECURITY INVOKER: the RPC's role lookup needs auth.uid() populated, so it
+    // must run on the caller's client and not on the admin one used for storage.
+    mockAuthenticatedAdmin();
+
+    await POST(updateRequest(), { params });
+
+    expect(mockUserRpc).toHaveBeenCalledWith(
+      "update_product",
+      expect.objectContaining({ p_id: PRODUCT_ID }),
+    );
+  });
+
+  it("uploads the new blob BEFORE the RPC, and commits its server-derived path", async () => {
+    // The path never comes from the client: it is derived from the uploaded
+    // blob, so a caller cannot point a product row at an arbitrary object.
+    mockAuthenticatedAdmin();
+    const order: string[] = [];
+    mockAdminUpload.mockImplementation(async () => {
+      order.push("upload");
+      return { error: null };
+    });
+    mockUserRpc.mockImplementation(async () => {
+      order.push("rpc");
+      return { data: PRODUCT_ID, error: null };
+    });
+
+    await POST(updateRequest({ file: jpeg() }), { params });
+
+    expect(order).toEqual(["upload", "rpc"]);
+    const uploadedPath = asString(mockAdminUpload.mock.calls[0][0]);
+    expect(uploadedPath).toMatch(/^[0-9a-f-]+\.jpg$/);
+    expect(mockUserRpc).toHaveBeenCalledWith(
+      "update_product",
+      expect.objectContaining({ p_image_path: uploadedPath }),
+    );
+  });
+
+  it("normalizes a .jpeg upload to a .jpg path", async () => {
+    mockAuthenticatedAdmin();
+
+    await POST(updateRequest({ file: jpeg("photo.jpeg") }), { params });
+
+    expect(mockAdminUpload.mock.calls[0][0]).toMatch(/\.jpg$/);
+  });
+
+  it("deletes the superseded blob after a successful replace", async () => {
+    mockAuthenticatedAdmin();
+    mockProductRead.mockResolvedValue({
+      data: { image_path: "old-path.png" },
+      error: null,
+    });
+
+    const response = await POST(updateRequest({ file: jpeg() }), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockAdminRemove).toHaveBeenCalledWith(["old-path.png"]);
+  });
+
+  it("clears the image and deletes the old blob when asked to", async () => {
+    mockAuthenticatedAdmin();
+    mockProductRead.mockResolvedValue({
+      data: { image_path: "old-path.png" },
+      error: null,
+    });
+
+    const response = await POST(updateRequest({ clearImage: true }), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockUserRpc).toHaveBeenCalledWith(
+      "update_product",
+      expect.objectContaining({ p_image_path: undefined }),
+    );
+    expect(mockAdminRemove).toHaveBeenCalledWith(["old-path.png"]);
+  });
+
+  // -- Failure --
+
+  it("deletes the freshly uploaded blob when the RPC then fails", async () => {
+    // Otherwise a failed update leaves an unreferenced object in the bucket.
+    mockAuthenticatedAdmin();
+    mockUserRpc.mockResolvedValue({
+      data: null,
+      error: { code: "23503", message: "violates foreign key constraint" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(updateRequest({ file: jpeg() }), { params });
+
+    expect(response.status).toBe(400);
+    const uploadedPath = asString(mockAdminUpload.mock.calls[0][0]);
+    expect(mockAdminRemove).toHaveBeenCalledWith([uploadedPath]);
+    spy.mockRestore();
+  });
+
+  it("gives a written explanation for the two native codes the RPC can raise", async () => {
+    mockAuthenticatedAdmin();
+    mockUserRpc.mockResolvedValue({
+      data: null,
+      error: { code: "23503", message: "violates foreign key constraint" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(updateRequest(), { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("no longer available");
+    expect(data.error).not.toContain("foreign key");
+    spy.mockRestore();
+  });
+
+  it("passes the RPC's own refusal through, which the product form shows verbatim", async () => {
+    mockAuthenticatedAdmin();
+    mockUserRpc.mockResolvedValue({
+      data: null,
+      error: { code: "P0001", message: "At least one translation is required" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(updateRequest(), { params });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toBe(
+      "At least one translation is required",
+    );
+    spy.mockRestore();
+  });
+
+  it("answers 500 without echoing storage internals when the upload fails", async () => {
+    mockAuthenticatedAdmin();
+    mockAdminUpload.mockResolvedValue({
+      error: { message: "bucket product-images: signature expired" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(updateRequest({ file: jpeg() }), { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).not.toContain("signature expired");
+    expect(mockUserRpc).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("answers 500 without echoing database text when the existence read fails", async () => {
+    mockAuthenticatedAdmin();
+    mockProductRead.mockResolvedValue({
+      data: null,
+      error: { code: "42501", message: "permission denied for table products" },
+    });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await POST(updateRequest(), { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).not.toContain("permission denied");
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/api/send-test-email.test.ts
+++ b/tests/integration/api/send-test-email.test.ts
@@ -242,7 +242,9 @@ describe("POST /api/admin/send-test-email", () => {
 
   // -- Error handling --
 
-  it("should return 500 when Brevo API fails", async () => {
+  it("should return a generic 500 when the email provider fails", async () => {
+    // The provider's own message used to be returned to the client. It is now
+    // logged and answered generically — this route never opted into disclosure.
     mockAuthenticatedWithRole("admin");
     mockSendTransactionalEmail.mockRejectedValue(new Error("Brevo API error: 500 Internal Server Error"));
 
@@ -250,7 +252,7 @@ describe("POST /api/admin/send-test-email", () => {
     const data = await response.json();
 
     expect(response.status).toBe(500);
-    expect(data.error).toBe("Brevo API error: 500 Internal Server Error");
+    expect(data.error).toBe("Internal server error");
   });
 
   // -- Template mode --

--- a/tests/integration/api/user-locale.test.ts
+++ b/tests/integration/api/user-locale.test.ts
@@ -77,6 +77,8 @@ describe("PATCH /api/user/locale", () => {
 
   // -- Validation --
 
+  // The hand-rolled `isSupportedLocale` check is now a body schema, so the 400
+  // names the offending field the way every other schema-validated route does.
   it("should return 400 for unsupported locale", async () => {
     mockAuthenticated();
 
@@ -84,7 +86,8 @@ describe("PATCH /api/user/locale", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe("Invalid locale");
+    expect(data.error).toContain("locale");
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it("should return 400 for missing locale", async () => {
@@ -94,7 +97,8 @@ describe("PATCH /api/user/locale", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe("Invalid locale");
+    expect(data.error).toContain("locale");
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   // -- Happy path --
@@ -139,7 +143,9 @@ describe("PATCH /api/user/locale", () => {
     const data = await response.json();
 
     expect(response.status).toBe(500);
-    expect(data.error).toBe("Failed to update locale");
+    // The driver's message goes to the log, not to the client — this route
+    // never opted into disclosure.
+    expect(data.error).toBe("Internal server error");
   });
 
   it("should return 403 when the database refuses the write", async () => {

--- a/tests/integration/api/voice-instant-create.test.ts
+++ b/tests/integration/api/voice-instant-create.test.ts
@@ -4,6 +4,14 @@ import { POST } from "@/app/api/voice/instant/create/route";
 import { DailyApiError } from "@/lib/daily";
 import { VOICE_CONFIG } from "@/lib/constants/voice";
 
+/** The route takes no body; the handler still receives the request Next.js
+ * hands it, so the tests pass one. */
+function createRequest(): Request {
+  return new Request("http://localhost:3000/api/voice/instant/create", {
+    method: "POST",
+  });
+}
+
 const mockRequireRole = vi.fn();
 vi.mock("@/lib/auth", () => ({
   requireRole: (...args: unknown[]) => mockRequireRole(...args),
@@ -36,7 +44,7 @@ describe("POST /api/voice/instant/create", () => {
     mockRequireRole.mockResolvedValue(
       NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
     );
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(401);
   });
 
@@ -44,13 +52,13 @@ describe("POST /api/voice/instant/create", () => {
     mockRequireRole.mockResolvedValue(
       NextResponse.json({ error: "Forbidden" }, { status: 403 }),
     );
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(403);
   });
 
   it("returns a 4-character code on success", async () => {
     authenticated("admin");
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.code).toMatch(/^[A-HJ-NP-Z2-9]{4}$/);
@@ -59,7 +67,7 @@ describe("POST /api/voice/instant/create", () => {
   it("creates a Daily room with an 8-hour exp", async () => {
     authenticated("admin");
     const before = Math.round(Date.now() / 1000);
-    await POST();
+    await POST(createRequest());
     const after = Math.round(Date.now() / 1000);
 
     expect(mockCreateDailyRoom).toHaveBeenCalledTimes(1);
@@ -83,7 +91,7 @@ describe("POST /api/voice/instant/create", () => {
       .mockRejectedValueOnce(new DailyApiError(400, "a room named X already exists"))
       .mockResolvedValueOnce({ name: "ok" });
 
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(200);
     expect(mockCreateDailyRoom).toHaveBeenCalledTimes(2);
   });
@@ -94,7 +102,7 @@ describe("POST /api/voice/instant/create", () => {
       .mockRejectedValueOnce(new DailyApiError(409, "Conflict"))
       .mockResolvedValueOnce({ name: "ok" });
 
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(200);
     expect(mockCreateDailyRoom).toHaveBeenCalledTimes(2);
   });
@@ -105,7 +113,7 @@ describe("POST /api/voice/instant/create", () => {
       new DailyApiError(400, "a room named X already exists"),
     );
 
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(503);
     expect(mockCreateDailyRoom).toHaveBeenCalledTimes(
       VOICE_CONFIG.INSTANT_ROOM_CREATE_MAX_RETRIES,
@@ -118,7 +126,7 @@ describe("POST /api/voice/instant/create", () => {
       new DailyApiError(500, "Daily down"),
     );
 
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(500);
     expect(mockCreateDailyRoom).toHaveBeenCalledTimes(1);
   });
@@ -131,7 +139,7 @@ describe("POST /api/voice/instant/create", () => {
       new DailyApiError(400, "invalid token format"),
     );
 
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(500);
     expect(mockCreateDailyRoom).toHaveBeenCalledTimes(1);
   });
@@ -141,7 +149,7 @@ describe("POST /api/voice/instant/create", () => {
     // we wired the right role list, not requireRole's internals.
     expect(mockRequireRole).not.toHaveBeenCalled();
     authenticated("admin");
-    await POST();
+    await POST(createRequest());
     expect(mockRequireRole).toHaveBeenLastCalledWith(
       ["admin", "gedu"],
       expect.any(Object),
@@ -153,7 +161,7 @@ describe("POST /api/voice/instant/create", () => {
     // tests/unit/lib/auth.test.ts); here we pin that the route opts into that
     // gate via `requireVerifiedGedu`, so the boundary can't be lost in a refactor.
     authenticated("admin");
-    await POST();
+    await POST(createRequest());
     expect(mockRequireRole).toHaveBeenLastCalledWith(
       ["admin", "gedu"],
       expect.objectContaining({ requireVerifiedGedu: true }),
@@ -167,7 +175,7 @@ describe("POST /api/voice/instant/create", () => {
         { status: 403 },
       ),
     );
-    const response = await POST();
+    const response = await POST(createRequest());
     expect(response.status).toBe(403);
     expect((await response.json()).code).toBe("GEDU_UNVERIFIED");
     expect(mockCreateDailyRoom).not.toHaveBeenCalled();

--- a/tests/integration/api/voice-instant-exists.test.ts
+++ b/tests/integration/api/voice-instant-exists.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// A deliberately public route: the lobby checks whether a room code resolves
+// before asking the browser for camera and microphone permission, and a guest
+// joining by link has no session. It reveals only that a code exists — which
+// anyone holding the code could learn by simply joining — and nothing else.
+// There is no wrong-role case to test, because there is no role.
+
+const mockGetDailyRoom = vi.fn();
+vi.mock("@/lib/daily", () => ({
+  getDailyRoom: (...args: unknown[]) => mockGetDailyRoom(...args),
+}));
+
+const mockRequireRole = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+import { GET } from "@/app/api/voice/instant/exists/route";
+
+function existsRequest(query: string): Request {
+  return new Request(
+    `http://localhost:3000/api/voice/instant/exists${query}`,
+  );
+}
+
+describe("GET /api/voice/instant/exists", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDailyRoom.mockResolvedValue({ name: "K7P2" });
+  });
+
+  // -- Public posture --
+
+  it("answers with no session and never consults the role gate", async () => {
+    const response = await GET(existsRequest("?code=K7P2"));
+
+    expect(response.status).toBe(204);
+    expect(mockRequireRole).not.toHaveBeenCalled();
+  });
+
+  // -- Input --
+
+  it("returns 400 when no code is given", async () => {
+    const response = await GET(existsRequest(""));
+
+    expect(response.status).toBe(400);
+    expect(mockGetDailyRoom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed code, before any Daily call", async () => {
+    // Validating the code shape first is what stops a malformed value from
+    // becoming a path-traversal request against Daily's API.
+    const response = await GET(existsRequest("?code=../../admin"));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid room code" });
+    expect(mockGetDailyRoom).not.toHaveBeenCalled();
+  });
+
+  // -- Happy path --
+
+  it("answers 204 with no body when the room exists", async () => {
+    const response = await GET(existsRequest("?code=k7p2"));
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+    expect(mockGetDailyRoom).toHaveBeenCalledWith("K7P2");
+  });
+
+  it("answers 404 with the entered code echoed back when the room does not exist", async () => {
+    // The echo lets the lobby show the user what they typed, so a typo is
+    // obvious. A never-minted code, an ended room and an expired one all
+    // collapse to this one answer on purpose.
+    mockGetDailyRoom.mockResolvedValue(null);
+
+    const response = await GET(existsRequest("?code=K7P2"));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "room_not_found",
+      code: "K7P2",
+    });
+  });
+});

--- a/tests/integration/auth/pin.test.ts
+++ b/tests/integration/auth/pin.test.ts
@@ -73,6 +73,11 @@ function request(path: string, body: unknown): Request {
   });
 }
 
+/** A GET has no body; the handler still receives the request Next.js hands it. */
+function getRequest(path: string): Request {
+  return new Request(`http://localhost:3000${path}`);
+}
+
 function authCustomer(overrides: { email?: string | null } = {}) {
   mockRequireRole.mockResolvedValue({
     user: { id: "u1", email: "p@test.local" },
@@ -187,7 +192,7 @@ describe("GET /api/auth/pin/status", () => {
     setRpc({ pin_is_set: { data: false, error: null } });
     mockCookieGet.mockReturnValue(undefined);
 
-    await statusGet();
+    await statusGet(getRequest("/api/auth/pin/status"));
     expect(mockRequireRole).toHaveBeenCalledWith("customer", { allowUnverified: true });
   });
 
@@ -197,7 +202,7 @@ describe("GET /api/auth/pin/status", () => {
     // A valid token for this (user, session) is the proof of an unlocked session.
     mockCookieGet.mockReturnValue({ value: await pinTokenFor("u1", "s1") });
 
-    const res = await statusGet();
+    const res = await statusGet(getRequest("/api/auth/pin/status"));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ isSet: true, unlocked: true });
   });
@@ -207,7 +212,7 @@ describe("GET /api/auth/pin/status", () => {
     setRpc({ pin_is_set: { data: true, error: null } });
     mockCookieGet.mockReturnValue(undefined);
 
-    const res = await statusGet();
+    const res = await statusGet(getRequest("/api/auth/pin/status"));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ isSet: true, unlocked: false });
   });
@@ -219,7 +224,7 @@ describe("GET /api/auth/pin/status", () => {
     // account switch / re-login relies on this binding).
     mockCookieGet.mockReturnValue({ value: await pinTokenFor("u1", "other-session") });
 
-    const res = await statusGet();
+    const res = await statusGet(getRequest("/api/auth/pin/status"));
     expect(await res.json()).toMatchObject({ unlocked: false });
   });
 
@@ -228,7 +233,7 @@ describe("GET /api/auth/pin/status", () => {
     setRpc({ pin_is_set: { data: false, error: null } });
     mockCookieGet.mockReturnValue(undefined);
 
-    const res = await statusGet();
+    const res = await statusGet(getRequest("/api/auth/pin/status"));
     expect(await res.json()).toEqual({ isSet: false, unlocked: false });
   });
 
@@ -238,7 +243,7 @@ describe("GET /api/auth/pin/status", () => {
     // Silence the route's console.error for the expected failure path.
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const res = await statusGet();
+    const res = await statusGet(getRequest("/api/auth/pin/status"));
     expect(res.status).toBe(500);
     spy.mockRestore();
   });

--- a/tests/integration/auth/signout.test.ts
+++ b/tests/integration/auth/signout.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The sign-out route is deliberately session-mutating-public: clearing a session
+// must work even when the session is already unusable, so requiring a valid one
+// would strand exactly the callers who need it. What this file pins is that the
+// route really does all three parts of a sign-out — drop the Supabase session,
+// drop the parent-PIN unlock cookie, and hand back a redirect the browser
+// follows as a full-page GET — because a partial sign-out leaves the browser's
+// in-memory Supabase client believing it is still signed in.
+
+const mockSignOut = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ auth: { signOut: mockSignOut } }),
+}));
+
+const mockCookieDelete = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ delete: mockCookieDelete })),
+}));
+
+import { POST } from "@/app/api/auth/signout/route";
+import { PIN_COOKIE_NAME } from "@/lib/pin-session";
+
+function signoutRequest(url = "http://localhost:3000/api/auth/signout") {
+  return new Request(url, { method: "POST" });
+}
+
+describe("POST /api/auth/signout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  it("is reachable with no session at all", async () => {
+    const response = await POST(signoutRequest());
+
+    expect(response.status).toBe(303);
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+
+  it("clears the Supabase session server-side", async () => {
+    await POST(signoutRequest());
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the parent-PIN unlock cookie so the next session starts locked", async () => {
+    await POST(signoutRequest());
+
+    expect(mockCookieDelete).toHaveBeenCalledWith(PIN_COOKIE_NAME);
+  });
+
+  it("answers a 303 to the site root, which the browser follows as a GET", async () => {
+    // 303 specifically: it is what turns the POST into a full-page GET, and the
+    // full-page load is what rebuilds the browser's Supabase client. A soft
+    // navigation would leave a stale client thinking the user is signed in.
+    const response = await POST(signoutRequest());
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("http://localhost:3000/");
+  });
+
+  it("redirects within the request's own origin", async () => {
+    const response = await POST(
+      signoutRequest("https://app.example.test/api/auth/signout"),
+    );
+
+    expect(response.headers.get("location")).toBe("https://app.example.test/");
+  });
+});

--- a/tests/integration/auth/switch-account.test.ts
+++ b/tests/integration/auth/switch-account.test.ts
@@ -187,7 +187,9 @@ describe("POST /api/auth/switch-account", () => {
       const response = await POST(createRequest({}));
       const data = await response.json();
       expect(response.status).toBe(400);
-      expect(data.error).toBe("userId is required");
+      // The hand-rolled presence check is now a body schema, so the message is
+      // the shared "<field>: <issue>" shape every other route already uses.
+      expect(data.error).toContain("userId");
     });
 
     it("returns 400 when userId is the caller itself", async () => {
@@ -403,7 +405,9 @@ describe("POST /api/auth/switch-account", () => {
       const response = await POST(createRequest({ userId: GAMER_A1 }));
       const data = await response.json();
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Gamer account is not properly configured");
+      // A misconfigured account is our problem, not a fact the caller needs
+      // spelled out — the detail is logged and the client gets the generic 500.
+      expect(data.error).toBe("Internal server error");
       expect(mockSignOut).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Phase 2 of the HTTP route boundary refactor (`docs/route-boundary-architecture.md` §5). Stacked on #78 — base is `refactor/route-boundary-phase1`.

Phase 1 built the primitive, the posture registry and its four spine checks, and converted one exemplar. This is the sweep: everything that can go through the primitive does, the recorded warts are fixed, the missing tests are written, and the counters the design set up are at zero.

## Batches

**A — admin role-gated JSON routes** (`97d5bee`). Eight handlers: the two locations writes, group change-set apply, comp-enrollment, both participation handlers on the `[participationId]` route, site notes, the test-email harness, the WhatsApp send route. Each gains a params schema, so a dynamic segment is validated rather than trusted.

**B — the remaining gated surface, plus the locale fix** (`e078f6e`). Fourteen handlers: the four parent-PIN routes, family list, feedback, billing portal, checkout, switch-account, both gamer routes, the Minecraft account and verify routes, both instant-voice mod routes, the room existence check, the group voice token route.

**C — multipart, public routes, the webhook fix** (`79e1053`). Both multipart product routes, educator self-registration, forgot-password; the last schema-less body; the timing-safe compare.

**Tests** (`ffd6769`). The nine untested handlers.

**Docs** (`62ec899`). Status flipped to built; the second counter pinned.

## End state

- **31 of 39 route files on the primitive.** The eight that are not are the postures it deliberately does not cover — two session-mutating redirect flows, the signed-token PIN reset, the api-key server-to-server check, the optional-auth room token, three webhook verifiers. Each is a reasoned carve-out in the registry.
- **Zero unclassified handlers, zero schema-less JSON bodies, zero untested handlers, zero unreasoned carve-outs.** The last two are assertions against an empty list rather than assertions that got deleted once they emptied — kept as ratchets, so a regression fails CI instead of quietly starting a new backlog.
- **No route's posture changed.** The one apparent exception is not one: the route that hand-rolled its session check now *declares* the any-authenticated posture, which is what its code always did.

## Error-map decisions

Three patterns recurred, each resolved deliberately and noted inline at the route:

- **An unrecognized database code is a logged 500**, not a 400. Several routes had a catch-all `else 400` that reported every unanticipated failure to the caller as their own mistake and hid it.
- **`no_data_found` split cleanly.** A route whose subject is named in the URL path answers 404 (a missing one is a missing resource): locations update, group apply, comp-enrollment, both participation handlers. A route whose subject arrives in the body answers 400 by override (the caller's input names something that does not exist): checkout, matching the Phase 1 waitlist exemplar.
- **A status the shared table has no default for stays explicit with its reason**: 502 for an upstream Stripe failure, 503 for an exhausted retry loop, 500 by override for a broken money-path invariant on the un-enroll route.

Two normalizations change observable status codes, both deliberate: a unique violation on the group-apply route is now 409 rather than 400 (matching every other route on the surface), and the feedback RPC's check violation is now 400 rather than 500 — it re-checks the same length bounds the body schema enforces, so it really is bad input.

## Disclosure decisions

Every remaining forward opts in by name with a reason; the rest answer a generic message for the status and log the real one.

**Kept (5):** the waitlist join (Phase 1), checkout, group apply, product create, product update. All five carry RPC messages that *are* the user-facing explanation and are rendered verbatim by the UI. On each, the handler is written so nothing raw can escape past the opt-in.

**Closed (11 handlers):** locations create/update, comp-enrollment, both participation handlers, site notes, test email, WhatsApp send, switch-account, both gamer routes, the Minecraft account route, the locale route, educator registration. The last is the one that mattered most — the promotion RPC's message used to reach an *unauthenticated* caller on a 500.

Curated copy survived only where it tells the caller something the status alone does not (already enrolled, live Stripe subscription, consumer-club refusals, Minecraft account taken). Where it merely restated the status, the shared generic replaced it.

## Schemas added

- **Body: 7** (every schema-less JSON body). `pinBody`, `createCheckoutBody`, `createGamerBody`, `updateGamerBody`, `updateMinecraftAccountBody`, `setLocaleBody`, `switchAccountBody` — plus `adminEnrollGamerBody` and `instantRoomTokenBody` lifted out of routes. Two new contract files (gamers, minecraft); the rest joined existing ones.
- **Query: 2.** The Mojang lookup and the room existence check, both of which read the query string by hand.
- **Params: 6.** Every route with a dynamic segment.

The instant-room token schema is also a small security win in its own right: it drops undeclared fields, so `role`, `owner` and `userId` in the body are now unreadable rather than merely unread.

## Recorded fixes

- **The locale route** moves onto the primitive with the any-authenticated posture. The spine's `offPrimitive` exception expired by itself exactly as designed — the check fails a file that carries the excuse while using the gate, so deleting the annotation was forced by the same change.
- **The WhatsApp webhook GET challenge** gains a timing-safe compare, extracted so it and the POST handler's HMAC check share one helper. The registry's verifier name changed with it, so the annotation cannot outlive the fix.
- **Incidental raw-message forwards close** (above).

## Tests

Nine new files, one per previously-untested handler. Where a route's real risk is not its role gate, the file goes after that risk: sign-out pins all three parts of a sign-out; family list pins that the service-role read is scoped to the verified identity and never to a request parameter; billing portal pins the session-derived Stripe customer and the trusted-origin return URL; educator registration pins that no privilege can be named in the request and that a failed promotion deletes the auth user again; Discord pins that nothing happens before the signature check and that every command defers; product update pins the storage choreography around a fallible RPC; the waitlist PATCH pins the IDOR guard that ties a participation to the product in the URL.

Existing assertions updated where a deliberate decision above changed a message or a status — each traceable to a decision, not a test bent to fit.

## Doc-home recommendation

Phase 1 deferred where this architecture should permanently live. **Recommendation: leave it in `docs/`.** The system has three homes in the tree (the primitive, the routes, the registry) and no single directory a route author works in would auto-load a doc covering all three. What belongs colocated is the operating rule — and that already is: `tests/CLAUDE.md` carries how to register a route and what a reason has to say, which is what someone adding a route needs at the moment they need it. This doc is the design record behind that rule, read deliberately rather than incidentally. Moving it would trade a doc a human opens on purpose for one that auto-loads in one of three places and is wrong about the other two.

## Notes

- Local: type-check clean, lint clean (zero errors, zero warnings, no new suppressions), 1313 unit + integration tests pass.
- No database involvement — no migrations, no schema or generated-types changes.
- One finding worth a look: a route whose payload is an RPC's `Json` result cannot use the response-schema slot without a cast, because the generated type is `Json` and the slot's type is the contract shape. Those routes narrow the result in the handler instead (the shape the Phase 1 exemplar already used), and the slot is used where the route assembles the payload itself. Recorded in the doc rather than worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
